### PR TITLE
Fix otp + force-join usecase

### DIFF
--- a/roles/ipaclient/tasks/install.yml
+++ b/roles/ipaclient/tasks/install.yml
@@ -45,7 +45,7 @@
   - name: Install - Disable One-Time Password for client with working krb5.keytab
     set_fact:
       ipaclient_use_otp: "no"
-    when: ipaclient_use_otp | bool and ipatest.krb5_keytab_ok
+    when: ipaclient_use_otp | bool and ipatest.krb5_keytab_ok and not ipaclient_force_join | bool
 
 
   # The following block is executed when using OTP to enroll IPA client


### PR DESCRIPTION
When the client already has a working keytab, use_otp is disabled. This creates
an issue when ipaclient_force_join is set, because the join module is called
with ipaadmin_principal and ipaadmin_password, but these variables may be
undefined if ipaadmin_keytab is used instead.
We should not disable OTP when force-join is specified.