### PR TITLE
server install force and allow_zone_overlap fixes

### DIFF
--- a/roles/ipaserver/library/ipaserver_prepare.py
+++ b/roles/ipaserver/library/ipaserver_prepare.py
@@ -33,7 +33,7 @@ ANSIBLE_METADATA = {
 DOCUMENTATION = '''
 ---
 module: ipaserver_prepare
-short description: 
+short description:
 description:
 options:
   dm_password:
@@ -81,6 +81,7 @@ def main():
     ansible_module = AnsibleModule(
         argument_spec = dict(
             ### basic ###
+            force=dict(required=False, type='bool', default=False),
             dm_password=dict(required=True, no_log=True),
             password=dict(required=True, no_log=True),
             ip_addresses=dict(required=False, type='list', default=[]),
@@ -130,6 +131,7 @@ def main():
 
     # set values ####################################################
 
+    options.force = ansible_module.params.get('force')
     options.dm_password = ansible_module.params.get('dm_password')
     options.admin_password = ansible_module.params.get('password')
     options.ip_addresses = ansible_module_get_parsed_ip_addresses(
@@ -155,7 +157,7 @@ def main():
     options.subject_base = ansible_module.params.get('subject_base')
     options.ca_subject = ansible_module.params.get('ca_subject')
     ### dns ###
-    options.allow_zone_overlap= ansible_module.params.get('allow_zone_overlap')
+    options.allow_zone_overlap = ansible_module.params.get('allow_zone_overlap')
     options.reverse_zones = ansible_module.params.get('reverse_zones')
     options.no_reverse = ansible_module.params.get('no_reverse')
     options.auto_reverse = ansible_module.params.get('auto_reverse')

--- a/roles/ipaserver/library/ipaserver_test.py
+++ b/roles/ipaserver/library/ipaserver_test.py
@@ -31,7 +31,7 @@ ANSIBLE_METADATA = {
 DOCUMENTATION = '''
 ---
 module: ipaserver_test
-short description: 
+short description:
 description:
 options:
 author:
@@ -56,6 +56,7 @@ def main():
     ansible_module = AnsibleModule(
         argument_spec = dict(
             ### basic ###
+            force=dict(required=False, type='bool', default=False),
             dm_password=dict(required=True, no_log=True),
             password=dict(required=True, no_log=True),
             master_password=dict(required=False, no_log=True),
@@ -128,6 +129,7 @@ def main():
     # set values ############################################################
 
     ### basic ###
+    options.force = ansible_module.params.get('force')
     options.dm_password = ansible_module.params.get('dm_password')
     options.admin_password = ansible_module.params.get('password')
     options.master_password = ansible_module.params.get('master_password')
@@ -174,7 +176,7 @@ def main():
     options.ca_subject = ansible_module.params.get('ca_subject')
     # ca_signing_algorithm
     ### dns ###
-    options.allow_zone_overlap= ansible_module.params.get('allow_zone_overlap')
+    options.allow_zone_overlap = ansible_module.params.get('allow_zone_overlap')
     options.reverse_zones = ansible_module.params.get('reverse_zones')
     options.no_reverse = ansible_module.params.get('no_reverse')
     options.auto_reverse = ansible_module.params.get('auto_reverse')

--- a/roles/ipaserver/tasks/install.yml
+++ b/roles/ipaserver/tasks/install.yml
@@ -130,6 +130,7 @@
       subject_base: "{{ result_ipaserver_test.subject_base }}"
       ca_subject: "{{ result_ipaserver_test.ca_subject }}"
       ### dns ###
+      allow_zone_overlap: "{{ ipaserver_allow_zone_overlap }}"
       reverse_zones: "{{ result_ipaserver_test.reverse_zones }}"
       no_reverse: "{{ ipaserver_no_reverse }}"
       auto_reverse: "{{ ipaserver_auto_reverse }}"


### PR DESCRIPTION
force and allow_zone_overlap options were missing from a couple places.

Signed-off-by: Scott Poore <spoore@redhat.com>