### PR TITLE
Use no_host_dns option when setup_dns is enabled

### DIFF
--- a/roles/ipaserver/library/ipaserver_prepare.py
+++ b/roles/ipaserver/library/ipaserver_prepare.py
@@ -226,7 +226,7 @@ def main():
         with redirect_stdout(ansible_log):
             kra.install_check(api, None, options)
 
-    if options.setup_dns:
+    if options.setup_dns and not options.no_host_dns:
         with redirect_stdout(ansible_log):
             dns.install_check(False, api, False, options, options.host_name)
         ip_addresses = dns.ip_addresses


### PR DESCRIPTION
No DNS server in network
You want install FreeIPA to have DNS server (setup_dns=true)
You must ignore DNS check (no_host_dns=true)