### PR TITLE
ensure firewalld is running prior to invoking firewall-cmd

### DIFF
--- a/roles/ipareplica/tasks/install.yml
+++ b/roles/ipareplica/tasks/install.yml
@@ -97,6 +97,11 @@
   #  #  {{ "--no-sshd" if ipaclient_no_sshd | bool else "" }}
   #  when: not result_ipareplica_test.client_enrolled
 
+  - name: Install - Ensure firewalld is running
+    service:
+      name: firewalld
+      state: started
+
   - name: Install - Configure firewalld
     command: >
       firewall-cmd

--- a/roles/ipaserver/tasks/install.yml
+++ b/roles/ipaserver/tasks/install.yml
@@ -366,6 +366,11 @@
       state: absent
     when: result_ipaserver_enable_ipa.changed
 
+  - name: Install - Ensure firewalld is running
+    service:
+      name: firewalld
+      state: started
+
   - name: Install - Configure firewalld
     command: >
       firewall-cmd


### PR DESCRIPTION
The playbook fails if the firewall-cmd command is invoked when firewalld is not yet running.