### PR TITLE
Lowered Version for Setup CA | Tested on CentOS 7.5

### DIFF
--- a/roles/ipaserver/library/ipaserver_setup_ca.py
+++ b/roles/ipaserver/library/ipaserver_setup_ca.py
@@ -188,7 +188,7 @@ def main():
     # setup CA ##############################################################
 
     with redirect_stdout(ansible_log):
-        if NUM_VERSION >= 40604:
+        if NUM_VERSION >= 40504:
             custodia = custodiainstance.get_custodia_instance(
                 options, custodiainstance.CustodiaModes.MASTER_PEER)
             custodia.create_instance()
@@ -200,7 +200,7 @@ def main():
                               if n in options.__dict__}
                 write_cache(cache_vars)
 
-            if NUM_VERSION >= 40604:
+            if NUM_VERSION >= 40504:
                 ca.install_step_0(False, None, options, custodia=custodia)
             else:
                 ca.install_step_0(False, None, options)
@@ -225,7 +225,7 @@ def main():
 
         if options.setup_ca:
             with redirect_stdout(ansible_log):
-                if NUM_VERSION >= 40604:
+                if NUM_VERSION >= 40504:
                     ca.install_step_1(False, None, options, custodia=custodia)
                 else:
                     ca.install_step_1(False, None, options)


### PR DESCRIPTION
I have lowered the version here to 4.5.04 (current on CentOS 7.5)
Otherwise the execution fails on CentOS 7.5