### PR TITLE
Check variable are defined before use

### DIFF
--- a/roles/ipaclient/tasks/install.yml
+++ b/roles/ipaclient/tasks/install.yml
@@ -167,7 +167,7 @@
         msg: "The ca.crt file is missing, please enable allow_repair to fix this."
       when: not ipatest.ca_crt_exists
     - meta: end_play
-    when: not ipaclient_on_master | bool and not ipajoin.changed and not ipaclient_allow_repair | bool and (ipatest.krb5_keytab_ok or (ipajoin.already_joined is defined and ipajoin.already_joined))
+    when: not ipaclient_on_master | bool and ipajoin is defined and not ipajoin.changed and not ipaclient_allow_repair | bool and (ipatest.krb5_keytab_ok or (ipajoin.already_joined is defined and ipajoin.already_joined))
 
   - name: Install - Configure IPA default.conf
     include_role:

--- a/roles/ipaclient/tasks/python_2_3_test.yml
+++ b/roles/ipaclient/tasks/python_2_3_test.yml
@@ -2,15 +2,18 @@
   - name: Verify Python3 import
     script: py3test.py
     register: py3test
+    check_mode: False
     failed_when: False
     changed_when: False
 
   - name: Set python interpreter to 3
     set_fact:
       ansible_python_interpreter: "/usr/bin/python3"
+    check_mode: False
     when: py3test.rc == 0
 
   - name: Set python interpreter to 2
     set_fact:
       ansible_python_interpreter: "/usr/bin/python2"
+    check_mode: False
     when: py3test.failed or py3test.rc != 0

--- a/roles/ipareplica/tasks/python_2_3_test.yml
+++ b/roles/ipareplica/tasks/python_2_3_test.yml
@@ -2,19 +2,23 @@
   - name: Verify Python3 import
     script: py3test.py
     register: py3test
+    check_mode: False
     failed_when: False
     changed_when: False
 
   - name: Set python interpreter to 3
     set_fact:
       ansible_python_interpreter: "/usr/bin/python3"
+    check_mode: False
     when: py3test.rc == 0
 
   - name: Fail for IPA 4.5.90
     fail: msg="You need to install python2 bindings for ipa server usage"
+    check_mode: False
     when: py3test.rc != 0 and "not usable with python3" in py3test.stdout
 
   - name: Set python interpreter to 2
     set_fact:
       ansible_python_interpreter: "/usr/bin/python2"
+    check_mode: False
     when: py3test.failed or py3test.rc != 0

--- a/roles/ipaserver/tasks/install.yml
+++ b/roles/ipaserver/tasks/install.yml
@@ -94,7 +94,7 @@
   register: result_ipaserver_test
 
 - meta: end_play
-  when: not result_ipaserver_test.changed and (result_ipaserver_test.client_already_configured is defined or result_ipaserver_test.server_already_configured is defined)
+  when: result_ipaserver_test is defined and not result_ipaserver_test.changed and (result_ipaserver_test.client_already_configured is defined or result_ipaserver_test.server_already_configured is defined)
 
 - block:
 

--- a/roles/ipaserver/tasks/python_2_3_test.yml
+++ b/roles/ipaserver/tasks/python_2_3_test.yml
@@ -2,19 +2,23 @@
   - name: Verify Python3 import
     script: py3test.py
     register: py3test
+    check_mode: False
     failed_when: False
     changed_when: False
 
   - name: Set python interpreter to 3
     set_fact:
       ansible_python_interpreter: "/usr/bin/python3"
+    check_mode: False
     when: py3test.rc == 0
 
   - name: Fail for IPA 4.5.90
     fail: msg="You need to install python2 bindings for ipa server usage"
+    check_mode: False
     when: py3test.rc != 0 and "not usable with python3" in py3test.stdout
 
   - name: Set python interpreter to 2
     set_fact:
       ansible_python_interpreter: "/usr/bin/python2"
+    check_mode: False
     when: py3test.failed or py3test.rc != 0


### PR DESCRIPTION
If tags are used, Ansible will skip the tasks that define these variables, but will still try to evaluate the conditionals that make use of the variables, leading to an error.