### PR TITLE
Fixes #51 upstream

### DIFF
--- a/roles/ipaclient/library/ipadiscovery.py
+++ b/roles/ipaclient/library/ipadiscovery.py
@@ -274,11 +274,11 @@ def main():
 
     if options.ntp_servers and options.no_ntp:
         module.fail_json(
-            "--ntp-server cannot be used together with --no-ntp")
+            msg="--ntp-server cannot be used together with --no-ntp")
 
     if options.ntp_pool and options.no_ntp:
         module.fail_json(
-            "--ntp-pool cannot be used together with --no-ntp")
+            msg="--ntp-pool cannot be used together with --no-ntp")
 
     #if options.no_nisdomain and options.nisdomain:
     #    module.fail_json(

--- a/roles/ipaserver/library/ipaserver_test.py
+++ b/roles/ipaserver/library/ipaserver_test.py
@@ -261,7 +261,7 @@ def main():
         try:
             check_zone_overlap(options.domain_name, False)
         except ValueError as e:
-            ansible_module.fail_json(str(e))
+            ansible_module.fail_json(msg=str(e))
 
     # dm_password
     with redirect_stdout(ansible_log):


### PR DESCRIPTION
Fixes the error

```
# ...
File \"/tmp/ansible_ipaserver_test_payload_Ifhk4f/__main__.py\", line 264, in main\r\nTypeError: fail_json() takes exactly 1 argument (2 given)
# ...
```