### PR TITLE
Fixes #17 Improve how tasks manage package installation

### DIFF
--- a/roles/ipaclient/tasks/install.yml
+++ b/roles/ipaclient/tasks/install.yml
@@ -3,9 +3,8 @@
 
 - name: Install - Ensure that IPA client packages are installed
   package:
-    name: "{{ item }}"
+    name: "{{ ipaclient_packages }}"
     state: present
-  with_items: "{{ ipaclient_packages }}"
   when: ipaclient_install_packages | bool
 
 #- name: Install - Include Python2/3 import test

--- a/roles/ipaclient/tasks/uninstall.yml
+++ b/roles/ipaclient/tasks/uninstall.yml
@@ -14,8 +14,7 @@
   failed_when: uninstall.rc != 0 and uninstall.rc != 2
   changed_when: uninstall.rc == 0
 
-# - name: Remove IPA client package
-#   package:
-#     name: "{{ item }}"
-#     state: absent
-#   with_items: "{{ ipaclient_packages }}"
+#- name: Remove IPA client package
+#  package:
+#    name: "{{ ipaclient_packages }}"
+#    state: absent

--- a/roles/ipareplica/tasks/install.yml
+++ b/roles/ipareplica/tasks/install.yml
@@ -5,22 +5,19 @@
 
   - name: Install - Ensure IPA replica packages are installed
     package:
-      name: "{{ item }}"
+      name: "{{ ipareplica_packages }}"
       state: present
-    with_items: "{{ ipareplica_packages }}"
 
   - name: Install - Ensure IPA replica packages for dns are installed
     package:
-      name: "{{ item }}"
+      name: "{{ ipareplica_packages_dns }}"
       state: present
-    with_items: "{{ ipareplica_packages_dns }}"
     when: ipareplica_setup_dns | bool
 
   - name: Install - Ensure IPA replica packages for adtrust are installed
     package:
-      name: "{{ item }}"
+      name: "{{ ipareplica_packages_adtrust }}"
       state: present
-    with_items: "{{ ipareplica_packages_adtrust }}"
     when: ipareplica_setup_adtrust | bool
 
   when: ipareplica_install_packages | bool

--- a/roles/ipareplica/tasks/uninstall.yml
+++ b/roles/ipareplica/tasks/uninstall.yml
@@ -34,8 +34,7 @@
 #  failed_when: False
 #  delegate_to: "{{ groups.ipaserver[0] | default(fail) }}"
 
-# - name: Remove IPA replica packages
-#   package:
-#     name: "{{ item }}"
-#     state: absent
-#   with_items: "{{ ipareplica_packages }}"
+#- name: Remove IPA replica packages
+#  package:
+#    name: "{{ ipareplica_packages }}"
+#    state: absent

--- a/roles/ipaserver/tasks/install.yml
+++ b/roles/ipaserver/tasks/install.yml
@@ -4,22 +4,19 @@
 - block:
   - name: Install - Ensure that IPA server packages are installed
     package:
-      name: "{{ item }}"
+      name: "{{ ipaserver_packages }}"
       state: present
-    with_items: "{{ ipaserver_packages }}"
 
   - name: Install - Ensure that IPA server packages for dns are installed
     package:
-      name: "{{ item }}"
+      name: "{{ ipaserver_packages_dns }}"
       state: present
-    with_items: "{{ ipaserver_packages_dns }}"
     when: ipaserver_setup_dns | bool
 
   - name: Install - Ensure that IPA server packages for adtrust are installed
     package:
-      name: "{{ item }}"
+      name: "{{ ipaserver_packages_adtrust }}"
       state: present
-    with_items: "{{ ipaserver_packages_adtrust }}"
     when: ipaserver_setup_adtrust | bool
 
   when: ipaserver_install_packages | bool

--- a/roles/ipaserver/tasks/uninstall.yml
+++ b/roles/ipaserver/tasks/uninstall.yml
@@ -17,8 +17,7 @@
   failed_when: uninstall.rc != 0 and uninstall.rc != 1
   changed_when: uninstall.rc == 0
 
-# - name: Remove IPA server packages
-#   package:
-#     name: "{{ item }}"
-#     state: absent
-#   with_items: "{{ ipaserver_packages }}"
+#- name: Remove IPA server packages
+#  package:
+#    name: "{{ ipaserver_packages }}"
+#    state: absent


### PR DESCRIPTION
The use of squash_actions to invoke a package module, such as “yum”, to only invoke the module once is deprecated, and will be removed in Ansible 2.11. Instead of relying on implicit squashing, tasks should instead supply the list directly to the name, pkg or package parameter of the module.

[Reference to the upstream documentation.](https://docs.ansible.com/ansible/latest/porting_guides/porting_guide_2.7.html#using-a-loop-on-a-package-module-via-squash-actions)

The ipa-krb5 and ipa-sssd modules include *_packages variables in both defaults/ and vars/, additionally, the list of packages in ipa-sssd differs from one to the other.
Unify list of packages into vars/