### PR TITLE
Fix errors when ipaservers variable is not set

### DIFF
--- a/roles/ipaclient/library/ipaclient_test.py
+++ b/roles/ipaclient/library/ipaclient_test.py
@@ -306,8 +306,9 @@ def main():
 
     # Get domain from first server if domain is not set, but if there are
     # servers
-    if options.domain_name is None and len(options.servers) > 0:
-        options.domain_name = options.servers[0][options.servers[0].find(".")+1:]
+    if options.domain_name is None and options.servers is not None:
+        if len(options.servers) > 0:
+            options.domain_name = options.servers[0][options.servers[0].find(".")+1:]
 
     try:
         self = options
@@ -324,7 +325,8 @@ def main():
 
         ### ServiceInstallInterface ###
 
-        validate_domain_name(options.domain_name)
+        if options.domain_name:
+            validate_domain_name(options.domain_name)
 
         if options.realm_name:
             argspec = inspect.getargspec(validate_domain_name)


### PR DESCRIPTION
When using ipaclient to join an IDM domain without having an ipaservers variable defined then the `TASK [ipaclient : Install - IPA client test]` fails with the below backtrace.

```
Traceback (most recent call last):
  File \"/root/.ansible/tmp/ansible-tmp-1557337129.19-136008642669454/AnsiballZ_ipaclient_test.py\", line 113, in <module>
    _ansiballz_main()
  File \"/root/.ansible/tmp/ansible-tmp-1557337129.19-136008642669454/AnsiballZ_ipaclient_test.py\", line 105, in _ansiballz_main
    invoke_module(zipped_mod, temp_path, ANSIBALLZ_PARAMS)
  File \"/root/.ansible/tmp/ansible-tmp-1557337129.19-136008642669454/AnsiballZ_ipaclient_test.py\", line 48, in invoke_module
    imp.load_module('__main__', mod, module, MOD_DESC)
  File \"/tmp/ansible_ipaclient_test_payload_hgIJdW/__main__.py\", line 892, in <module>
  File \"/tmp/ansible_ipaclient_test_payload_hgIJdW/__main__.py\", line 309, in main
TypeError: object of type 'NoneType' has no len()
```

After the test on line 309 is fixed the validate_domain_name fails because options.domain_name is not set, so the additional change to only validate the domain_name if one has been defined.