### PR TITLE
Adds tuned ansible.cfg

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,0 +1,18 @@
+# config file for ansible -- http://ansible.com/
+# ==============================================
+#
+# Tuned config file for running ansible-freeipa playbooks.
+
+[defaults]
+# Set the log_path
+#log_path = ~/ansible-freeipa.log
+retry_files_enabled = False
+nocows = True
+callback_whitelist = profile_tasks
+# Set the path for library & modules folder
+library      = plugins/modules
+module_utils = plugins/module_utils
+
+[inventory]
+# fail more helpfully when the inventory file does not parse (Ansible 2.4+)
+unparsed_is_failed=true


### PR DESCRIPTION
Based on the [OpenShift one](https://github.com/openshift/openshift-ansible/blob/master/ansible.cfg).

Adds tuned ansible.cfg for two reasons:

1. Tuned ssh connectivity and fact gathering. Will make playbooks execution faster.
2 .Set the right library and modules folder to be able to run additional playbooks, such as the topology ones.