### PR TITLE
Fixed wrong path to CheckedIPAddress class

### DIFF
--- a/roles/ipareplica/library/ipareplica_test.py
+++ b/roles/ipareplica/library/ipareplica_test.py
@@ -294,7 +294,7 @@ def main():
     if installer.ip_addresses is not None:
         for value in installer.ip_addresses:
             try:
-                CheckedIPAddress(value)
+                ipautil.CheckedIPAddress(value)
             except Exception as e:
                 ansible_module.fail_json(msg="invalid IP address {0}: {1}".format(
                     value, e))


### PR DESCRIPTION
This is the fix for the following when `ipareplica_ip_addresses` is defined:
```
TASK [ipareplica : Install - Replica installation test] ******************************************************************************************************************************************************************************************************************************************************
fatal: [hhh]: FAILED! => {"changed": false, "msg": "invalid IP address <IP>: global name 'CheckedIPAddress' is not defined"}
```
