### PR TITLE
Add debian support for ipaclient

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Supported Distributions
 * RHEL/CentOS 7.4+
 * Fedora 26+
 * Ubuntu
+* Debian 10+ (ipaclient only, no server or replica!)
 
 Requirements
 ------------

--- a/roles/ipaclient/vars/Debian.yml
+++ b/roles/ipaclient/vars/Debian.yml
@@ -1,0 +1,2 @@
+# vars/Debian.yml
+ipaclient_packages: [ "freeipa-client" ]


### PR DESCRIPTION
Added correct freeipa-client package for debian. Tried to do this already in #98 but messed it up.