### PR TITLE
ipatopologysegment: Fail if given entry can not be found for reinitia…

### DIFF
--- a/plugins/modules/ipatopologysegment.py
+++ b/plugins/modules/ipatopologysegment.py
@@ -311,6 +311,18 @@ def main():
 
                     commands.append(["topologysegment_reinitialize", args,
                                      suffix])
+                else:
+                    params = []
+                    if name is not None:
+                        params.append("name=%s" % name)
+                    if left is not None:
+                        params.append("left=%s" % left)
+                    if right is not None:
+                        params.append("right=%s" % right)
+                    ansible_module.fail_json(
+                        msg="No entry '%s' for suffix '%s'" %
+                        (",".join(params), suffix))
+
             else:
                 ansible_module.fail_json(msg="Unkown state '%s'" % state)
 


### PR DESCRIPTION
…lized

Currently it is ignored if the entry for reinitialized can not be found if
the name or left and right are not correct. Now there is a failure in this
case.

Fixes: #107 (Reinitialize are failed to find the node in ipatopology ..)