### PR TITLE
New hostgroup management module

### DIFF
--- a/README-hostgroup.md
+++ b/README-hostgroup.md
@@ -1,0 +1,147 @@
+Hostgroup module
+================
+
+Description
+-----------
+
+The hostgroup module allows to ensure presence and absence of hostgroups and members of hostgroups.
+
+The hostgroup module is as compatible as possible to the Ansible upstream `ipa_hostgroup` module, but addtionally offers to make sure that hosts are present or absent in a hostgroup.
+
+
+Features
+--------
+* Hostgroup management
+
+
+Supported FreeIPA Versions
+--------------------------
+
+FreeIPA versions 4.4.0 and up are supported by the ipahostgroup module.
+
+
+Requirements
+------------
+
+**Controller**
+* Ansible version: 2.8+
+
+**Node**
+* Supported FreeIPA version (see above)
+
+
+Usage
+=====
+
+Example inventory file
+
+```ini
+[ipaserver]
+ipaserver.test.local
+```
+
+
+Example playbook to make sure hostgroup databases exists:
+
+```yaml
+---
+- name: Playbook to handle hostgroups
+  hosts: ipaserver
+  become: true
+
+  tasks:
+  # Ensure host-group databases is present
+  - ipahostgroup:
+      ipaadmin_password: MyPassword123
+      name: databases
+      host:
+      - db.example.com
+      hostgroup:
+      - mysql-server
+      - oracle-server
+```
+
+Example playbook to make sure that hosts and hostgroups are present in existing databases hostgroup:
+
+```yaml
+---
+- name: Playbook to handle hostgroups
+  hosts: ipaserver
+  become: true
+
+  tasks:
+  # Ensure hosts and hostgroups are present in existing databases hostgroup
+  - ipahostgroup:
+      ipaadmin_password: MyPassword123
+      name: databases
+      host:
+      - db.example.com
+      hostgroup:
+      - mysql-server
+      - oracle-server
+      action: member
+```
+`action` controls if a the hostgroup or member will be handled. To add or remove members, set `action` to `member`.
+
+Example playbook to make sure hosts and hostgroups are absent in databases hostgroup:
+
+```yaml
+---
+- name: Playbook to handle hostgroups
+  hosts: ipaserver
+  become: true
+
+  tasks:
+  # Ensure hosts and hostgroups are absent in databases hostgroup
+  - ipahostgroup:
+      ipaadmin_password: MyPassword123
+      name: databases
+      host:
+      - db.example.com
+      hostgroup:
+      - mysql-server
+      - oracle-server
+      action: member
+      state: absent
+```
+
+Example playbook to make sure host-group databases is absent:
+
+```yaml
+---
+- name: Playbook to handle hostgroups
+  hosts: ipaserver
+  become: true
+
+  tasks:
+  # Ensure host-group databases is absent
+  - ipahostgroup:
+      ipaadmin_password: MyPassword123
+      name: databases
+      state: absent
+```
+
+
+Variables
+=========
+
+ipahostgroup
+-------
+
+Variable | Description | Required
+-------- | ----------- | --------
+`ipaadmin_principal` | The admin principal is a string and defaults to `admin` | no
+`ipaadmin_password` | The admin password is a string and is required if there is no admin ticket available on the node | no
+`name` \| `cn` | The list of hostgroup name strings. | no
+`description` | The hostgroup description string. | no
+`nomembers` | Suppress processing of membership attributes. (bool) | no
+`host` | List of host name strings assigned to this hostgroup. | no
+`hostgroup` | List of hostgroup name strings assigned to this hostgroup. | no
+`action` | Work on hostgroup or member level. It can be on of `member` or `hostgroup` and defaults to `hostgroup`. | no
+`state` | The state to ensure. It can be one of `present` or `absent`, default: `present`. | no
+
+
+Authors
+=======
+
+Thomas Woerner

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Features
 * Repair mode for clients
 * Modules for group management
 * Modules for host management
+* Modules for hostgroup management
 * Modules for topology management
 * Modules for user management
 
@@ -389,6 +390,7 @@ Modules in plugin/modules
 
 * [ipagroup](README-group.md)
 * [ipahost](README-host.md)
+* [ipahostgroup](README-hostgroup.md)
 * [ipatopologysegment](README-topology.md)
 * [ipatopologysuffix](README-topology.md)
 * [ipauser](README-user.md)

--- a/playbooks/hostgroup/ensure-hostgroup-is-absent.yml
+++ b/playbooks/hostgroup/ensure-hostgroup-is-absent.yml
@@ -1,0 +1,11 @@
+---
+- name: Playbook to handle hostgroups
+  hosts: ipaserver
+  become: true
+
+  tasks:
+  # Ensure host-group databases is present
+  - ipahostgroup:
+      ipaadmin_password: MyPassword123
+      name: databases
+      state: absent

--- a/playbooks/hostgroup/ensure-hostgroup-is-present.yml
+++ b/playbooks/hostgroup/ensure-hostgroup-is-present.yml
@@ -1,0 +1,15 @@
+---
+- name: Playbook to handle hostgroups
+  hosts: ipaserver
+  become: true
+
+  tasks:
+  # Ensure host-group databases is present
+  - ipahostgroup:
+      ipaadmin_password: MyPassword123
+      name: databases
+      host:
+      - db.example.com
+      hostgroup:
+      - mysql-server
+      - oracle-server

--- a/playbooks/hostgroup/ensure-hosts-and-hostgroups-are-absent-in-hostgroup.yml
+++ b/playbooks/hostgroup/ensure-hosts-and-hostgroups-are-absent-in-hostgroup.yml
@@ -1,0 +1,17 @@
+---
+- name: Playbook to handle hostgroups
+  hosts: ipaserver
+  become: true
+
+  tasks:
+  # Ensure hosts and hostgroups are present in existing databases hostgroup
+  - ipahostgroup:
+      ipaadmin_password: MyPassword123
+      name: databases
+      host:
+      - db.example.com
+      hostgroup:
+      - mysql-server
+      - oracle-server
+      action: member
+      state: absent

--- a/playbooks/hostgroup/ensure-hosts-and-hostgroups-are-present-in-hostgroup.yml
+++ b/playbooks/hostgroup/ensure-hosts-and-hostgroups-are-present-in-hostgroup.yml
@@ -1,0 +1,16 @@
+---
+- name: Playbook to handle hostgroups
+  hosts: ipaserver
+  become: true
+
+  tasks:
+  # Ensure hosts and hostgroups are present in existing databases hostgroup
+  - ipahostgroup:
+      ipaadmin_password: MyPassword123
+      name: databases
+      host:
+      - db.example.com
+      hostgroup:
+      - mysql-server
+      - oracle-server
+      action: member

--- a/plugins/modules/ipahostgroup.py
+++ b/plugins/modules/ipahostgroup.py
@@ -1,0 +1,363 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Authors:
+#   Thomas Woerner <twoerner@redhat.com>
+#
+# Copyright (C) 2019 Red Hat
+# see file 'COPYING' for use and warranty information
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+ANSIBLE_METADATA = {
+    "metadata_version": "1.0",
+    "supported_by": "community",
+    "status": ["preview"],
+}
+
+
+DOCUMENTATION = """
+---
+module: ipahostgroup
+short description: Manage FreeIPA hostgroups
+description: Manage FreeIPA hostgroups
+options:
+  ipaadmin_principal:
+    description: The admin principal
+    default: admin
+  ipaadmin_password:
+    description: The admin password
+    required: false
+  name:
+    description: The hostgroup name
+    required: false
+    aliases: ["cn"]
+  description:
+    description: The hostgroup description
+    required: false
+  nomembers:
+    description: Suppress processing of membership attributes
+    required: false
+    type: bool
+  host:
+    description: List of host names assigned to this hostgroup.
+    required: false
+    type: list
+  hostgroup:
+    description: List of hostgroup names assigned to this hostgroup.
+    required: false
+    type: list
+  action:
+    description: Work on hostgroup or member level
+    default: hostgroup
+    choices: ["member", "hostgroup"]
+  state:
+    description: State to ensure
+    default: present
+    choices: ["present", "absent"]
+author:
+    - Thomas Woerner
+"""
+
+EXAMPLES = """
+# Ensure host-group databases is present
+- ipahostgroup:
+    ipaadmin_password: MyPassword123
+    name: databases
+    host:
+    - db.example.com
+    hostgroup:
+    - mysql-server
+    - oracle-server
+
+# Ensure hosts and hostgroups are present in existing databases hostgroup
+- ipahostgroup:
+    ipaadmin_password: MyPassword123
+    name: databases
+    host:
+    - db.example.com
+    hostgroup:
+    - mysql-server
+    - oracle-server
+    action: member
+
+# Ensure hosts and hostgroups are absent in databases hostgroup
+- ipahostgroup:
+    ipaadmin_password: MyPassword123
+    name: databases
+    host:
+    - db.example.com
+    hostgroup:
+    - mysql-server
+    - oracle-server
+    action: member
+    state: absent
+
+# Ensure host-group databases is absent
+- ipahostgroup:
+    ipaadmin_password: MyPassword123
+    name: databases
+    state: absent
+"""
+
+RETURN = """
+"""
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils._text import to_text
+from ansible.module_utils.ansible_freeipa_module import temp_kinit, \
+    temp_kdestroy, valid_creds, api_connect, api_command, compare_args_ipa
+
+
+def find_hostgroup(module, name):
+    _args = {
+        "all": True,
+        "cn": to_text(name),
+    }
+
+    _result = api_command(module, "hostgroup_find", to_text(name), _args)
+
+    if len(_result["result"]) > 1:
+        module.fail_json(
+            msg="There is more than one hostgroup '%s'" % (name))
+    elif len(_result["result"]) == 1:
+        return _result["result"][0]
+    else:
+        return None
+
+
+def gen_args(description, nomembers):
+    _args = {}
+    if description is not None:
+        _args["description"] = description
+    if nomembers is not None:
+        _args["nomembers"] = nomembers
+
+    return _args
+
+
+def gen_member_args(host, hostgroup):
+    _args = {}
+    if host is not None:
+        _args["member_host"] = host
+    if hostgroup is not None:
+        _args["member_hostgroup"] = hostgroup
+
+    return _args
+
+
+def main():
+    ansible_module = AnsibleModule(
+        argument_spec=dict(
+            # general
+            ipaadmin_principal=dict(type="str", default="admin"),
+            ipaadmin_password=dict(type="str", required=False, no_log=True),
+
+            name=dict(type="list", aliases=["cn"], default=None,
+                      required=True),
+            # present
+            description=dict(type="str", default=None),
+            nomembers=dict(required=False, type='bool', default=None),
+            host=dict(required=False, type='list', default=None),
+            hostgroup=dict(required=False, type='list', default=None),
+            action=dict(type="str", default="hostgroup",
+                        choices=["member", "hostgroup"]),
+            # state
+            state=dict(type="str", default="present",
+                       choices=["present", "absent"]),
+        ),
+        supports_check_mode=True,
+    )
+
+    ansible_module._ansible_debug = True
+
+    # Get parameters
+
+    # general
+    ipaadmin_principal = ansible_module.params.get("ipaadmin_principal")
+    ipaadmin_password = ansible_module.params.get("ipaadmin_password")
+    names = ansible_module.params.get("name")
+
+    # present
+    description = ansible_module.params.get("description")
+    nomembers = ansible_module.params.get("nomembers")
+    host = ansible_module.params.get("host")
+    hostgroup = ansible_module.params.get("hostgroup")
+    action = ansible_module.params.get("action")
+    # state
+    state = ansible_module.params.get("state")
+
+    # Check parameters
+
+    if state == "present":
+        if len(names) != 1:
+            ansible_module.fail_json(
+                msg="Only one hostgroup can be added at a time.")
+        if action == "member":
+            invalid = ["description", "nomembers"]
+            for x in invalid:
+                if vars()[x] is not None:
+                    ansible_module.fail_json(
+                        msg="Argument '%s' can not be used with action "
+                        "'%s'" % (x, action))
+
+    if state == "absent":
+        if len(names) < 1:
+            ansible_module.fail_json(
+                msg="No name given.")
+        invalid = ["description", "nomembers"]
+        if action == "hostgroup":
+            invalid.extend(["host", "hostgroup"])
+        for x in invalid:
+            if vars()[x] is not None:
+                ansible_module.fail_json(
+                    msg="Argument '%s' can not be used with state '%s'" %
+                    (x, state))
+
+    # Init
+
+    changed = False
+    exit_args = {}
+    ccache_dir = None
+    ccache_name = None
+    try:
+        if not valid_creds(ansible_module, ipaadmin_principal):
+            ccache_dir, ccache_name = temp_kinit(ipaadmin_principal,
+                                                 ipaadmin_password)
+        api_connect()
+
+        commands = []
+
+        for name in names:
+            # Make sure hostgroup exists
+            res_find = find_hostgroup(ansible_module, name)
+
+            # Create command
+            if state == "present":
+                # Generate args
+                args = gen_args(description, nomembers)
+
+                if action == "hostgroup":
+                    # Found the hostgroup
+                    if res_find is not None:
+                        # For all settings is args, check if there are
+                        # different settings in the find result.
+                        # If yes: modify
+                        if not compare_args_ipa(ansible_module, args,
+                                                res_find):
+                            commands.append([name, "hostgroup_mod", args])
+                    else:
+                        commands.append([name, "hostgroup_add", args])
+                        # Set res_find to empty dict for next step
+                        res_find = {}
+
+                    member_args = gen_member_args(host, hostgroup)
+                    if not compare_args_ipa(ansible_module, member_args,
+                                            res_find):
+                        # Generate addition and removal lists
+                        host_add = list(
+                            set(host or []) -
+                            set(res_find.get("member_host", [])))
+                        host_del = list(
+                            set(res_find.get("member_host", [])) -
+                            set(host or []))
+                        hostgroup_add = list(
+                            set(hostgroup or []) -
+                            set(res_find.get("member_hostgroup", [])))
+                        hostgroup_del = list(
+                            set(res_find.get("member_hostgroup", [])) -
+                            set(hostgroup or []))
+
+                        # Add members
+                        if len(host_add) > 0 or len(hostgroup_add) > 0:
+                            commands.append([name, "hostgroup_add_member",
+                                             {
+                                                 "host": host_add,
+                                                 "hostgroup": hostgroup_add,
+                                             }])
+                        # Remove members
+                        if len(host_del) > 0 or len(hostgroup_del) > 0:
+                            commands.append([name, "hostgroup_remove_member",
+                                             {
+                                                 "host": host_del,
+                                                 "hostgroup": hostgroup_del,
+                                             }])
+                elif action == "member":
+                    if res_find is None:
+                        ansible_module.fail_json(
+                            msg="No hostgroup '%s'" % name)
+
+                    # Ensure members are present
+                    commands.append([name, "hostgroup_add_member",
+                                     {
+                                         "host": host,
+                                         "hostgroup": hostgroup,
+                                     }])
+            elif state == "absent":
+                if action == "hostgroup":
+                    if res_find is not None:
+                        commands.append([name, "hostgroup_del", {}])
+
+                elif action == "member":
+                    if res_find is None:
+                        ansible_module.fail_json(
+                            msg="No hostgroup '%s'" % name)
+
+                    # Ensure members are absent
+                    commands.append([name, "hostgroup_remove_member",
+                                     {
+                                         "host": host,
+                                         "hostgroup": hostgroup,
+                                     }])
+            else:
+                ansible_module.fail_json(msg="Unkown state '%s'" % state)
+
+        # Execute commands
+        for name, command, args in commands:
+            try:
+                result = api_command(ansible_module, command, to_text(name),
+                                     args)
+                if "completed" in result and result["completed"] > 0:
+                    changed = True
+            except Exception as e:
+                ansible_module.fail_json(msg="%s: %s: %s" % (command, name,
+                                                             str(e)))
+            # Get all errors
+            # All "already a member" and "not a member" failures in the
+            # result are ignored. All others are reported.
+            errors = []
+            if "failed" in result and "member" in result["failed"]:
+                failed = result["failed"]["member"]
+                for member_type in failed:
+                    for member, failure in failed[member_type]:
+                        if "already a member" not in failure \
+                           and "not a member" not in failure:
+                            errors.append("%s: %s %s: %s" % (
+                                command, member_type, member, failure))
+            if len(errors) > 0:
+                ansible_module.fail_json(msg=", ".join(errors))
+
+    except Exception as e:
+        ansible_module.fail_json(msg=str(e))
+
+    finally:
+        temp_kdestroy(ccache_dir, ccache_name)
+
+    # Done
+
+    ansible_module.exit_json(changed=changed, **exit_args)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
There is a new hostgroup management module placed in the plugins folder:

  plugins/modules/ipahostgroup.py

The hostgroup module allows to add, remove and disable hosts.

The hostgroup module is as compatible as possible to the Ansible upstream
ipa_hostgroup module, but addtionally offers to ensure member presence and
absence.

Here is the documentation for the module:

  README-hostgroup.md

New example playbooks have been added:

  playbooks/hostgroup/ensure-hostgroup-is-absent.yml
  playbooks/hostgroup/ensure-hostgroup-is-present.yml
  playbooks/hostgroup/ensure-hosts-and-hostgroups-are-absent-in-hostgroup.yml
  playbooks/hostgroup/ensure-hosts-and-hostgroups-are-present-in-hostgroup.yml