### PR TITLE
New hbacsvc (HBAC Service) management module

### DIFF
--- a/README-hbacsvc.md
+++ b/README-hbacsvc.md
@@ -1,0 +1,109 @@
+HBACsvc module
+==============
+
+Description
+-----------
+
+The hbacsvc (HBAC Service) module allows to ensure presence and absence of HBAC Services.
+
+
+Features
+--------
+* HBACsvc management
+
+
+Supported FreeIPA Versions
+--------------------------
+
+FreeIPA versions 4.4.0 and up are supported by the ipahbacsvc module.
+
+
+Requirements
+------------
+
+**Controller**
+* Ansible version: 2.8+
+
+**Node**
+* Supported FreeIPA version (see above)
+
+
+Usage
+=====
+
+Example inventory file
+
+```ini
+[ipaserver]
+ipaserver.test.local
+```
+
+
+Example playbook to make sure HBAC Service for http is present
+
+```yaml
+---
+- name: Playbook to handle HBAC Services
+  hosts: ipaserver
+  become: true
+
+  tasks:
+  # Ensure HBAC Service for http is present
+  - ipahbacsvc:
+      ipaadmin_password: MyPassword123
+      name: http
+      description: Web service
+```
+
+Example playbook to make sure HBAC Service for tftp is present
+
+```yaml
+---
+- name: Playbook to handle HBAC Services
+  hosts: ipaserver
+  become: true
+
+  tasks:
+  # Ensure HBAC Service for tftp is present
+  - ipahbacsvc:
+      ipaadmin_password: MyPassword123
+      name: tftp
+      description: TFTPWeb service
+```
+
+Example playbook to make sure HBAC Services for http and tftp are absent
+
+```yaml
+---
+- name: Playbook to handle HBAC Services
+  hosts: ipaserver
+  become: true
+
+  tasks:
+  # Ensure HBAC Service for http and tftp are absent
+  - ipahbacsvc:
+      ipaadmin_password: MyPassword123
+      name: http,tftp
+      state: absent
+```
+
+
+Variables
+=========
+
+ipahbacsvc
+----------
+
+Variable | Description | Required
+-------- | ----------- | --------
+`ipaadmin_principal` | The admin principal is a string and defaults to `admin` | no
+`ipaadmin_password` | The admin password is a string and is required if there is no admin ticket available on the node | no
+`name` \| `cn` \| `service` | The list of hbacsvc name strings. | no
+`description` | The hbacsvc description string. | no
+`state` | The state to ensure. It can be one of `present` or `absent`, default: `present`. | no
+
+
+Authors
+=======
+
+Thomas Woerner

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Features
 * One-time-password (OTP) support for client installation
 * Repair mode for clients
 * Modules for group management
+* Modules for hbacsvc management
 * Modules for host management
 * Modules for hostgroup management
 * Modules for pwpolicy management
@@ -392,6 +393,7 @@ Modules in plugin/modules
 =========================
 
 * [ipagroup](README-group.md)
+* [ipahbacsvc](README-hbacsvc.md)
 * [ipahost](README-host.md)
 * [ipahostgroup](README-hostgroup.md)
 * [ipapwpolicy](README-pwpolicy.md)

--- a/playbooks/hbacsvc/ensure-hbacsvc-absent.yml
+++ b/playbooks/hbacsvc/ensure-hbacsvc-absent.yml
@@ -1,0 +1,12 @@
+---
+- name: Tests
+  hosts: ipaserver
+  become: true
+  gather_facts: false
+
+  tasks:
+  - name: Ensure HBAC Services for http and tftp are absent
+    ipahbacsvc:
+      ipaadmin_password: MyPassword123
+      name: http,tftp
+      state: absent

--- a/playbooks/hbacsvc/ensure-hbacsvc-present.yml
+++ b/playbooks/hbacsvc/ensure-hbacsvc-present.yml
@@ -1,0 +1,18 @@
+---
+- name: Tests
+  hosts: ipaserver
+  become: true
+  gather_facts: false
+
+  tasks:
+  - name: Ensure HBAC Service for http is present
+    ipahbacsvc:
+      ipaadmin_password: MyPassword123
+      name: http
+      description: Web service
+
+  - name: Ensure HBAC Service for tftp is present
+    ipahbacsvc:
+      ipaadmin_password: MyPassword123
+      name: tftp
+      description: TFTP service

--- a/plugins/modules/ipahbacsvc.py
+++ b/plugins/modules/ipahbacsvc.py
@@ -1,0 +1,220 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Authors:
+#   Thomas Woerner <twoerner@redhat.com>
+#
+# Copyright (C) 2019 Red Hat
+# see file 'COPYING' for use and warranty information
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+ANSIBLE_METADATA = {
+    "metadata_version": "1.0",
+    "supported_by": "community",
+    "status": ["preview"],
+}
+
+DOCUMENTATION = """
+---
+module: ipahbacsvc
+short description: Manage FreeIPA HBAC Services
+description: Manage FreeIPA HBAC Services
+options:
+  ipaadmin_principal:
+    description: The admin principal
+    default: admin
+  ipaadmin_password:
+    description: The admin password
+    required: false
+  name:
+    description: The group name
+    required: false
+    aliases: ["cn", "service"]
+  description:
+    description: The HBAC Service description
+    required: false
+  state:
+    description: State to ensure
+    default: present
+    choices: ["present", "absent"]
+author:
+    - Thomas Woerner
+"""
+
+EXAMPLES = """
+# Ensure HBAC Service for http is present
+- ipahbacsvc:
+    ipaadmin_password: MyPassword123
+    name: http
+    description: Web service
+
+# Ensure HBAC Service for tftp is absent
+- ipahbacsvc:
+    ipaadmin_password: MyPassword123
+    name: tftp
+    state: absent
+"""
+
+RETURN = """
+"""
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils._text import to_text
+from ansible.module_utils.ansible_freeipa_module import temp_kinit, \
+    temp_kdestroy, valid_creds, api_connect, api_command, compare_args_ipa
+
+
+def find_hbacsvc(module, name):
+    _args = {
+        "all": True,
+        "cn": to_text(name),
+    }
+
+    _result = api_command(module, "hbacsvc_find", to_text(name), _args)
+
+    if len(_result["result"]) > 1:
+        module.fail_json(
+            msg="There is more than one hbacsvc '%s'" % (name))
+    elif len(_result["result"]) == 1:
+        return _result["result"][0]
+    else:
+        return None
+
+
+def gen_args(description):
+    _args = {}
+    if description is not None:
+        _args["description"] = to_text(description)
+
+    return _args
+
+
+def main():
+    ansible_module = AnsibleModule(
+        argument_spec=dict(
+            # general
+            ipaadmin_principal=dict(type="str", default="admin"),
+            ipaadmin_password=dict(type="str", required=False, no_log=True),
+
+            name=dict(type="list", aliases=["cn", "service"], default=None,
+                      required=True),
+            # present
+
+            description=dict(type="str", default=None),
+
+            # state
+            state=dict(type="str", default="present",
+                       choices=["present", "absent"]),
+        ),
+        supports_check_mode=True,
+    )
+
+    ansible_module._ansible_debug = True
+
+    # Get parameters
+
+    # general
+    ipaadmin_principal = ansible_module.params.get("ipaadmin_principal")
+    ipaadmin_password = ansible_module.params.get("ipaadmin_password")
+    names = ansible_module.params.get("name")
+
+    # present
+    description = ansible_module.params.get("description")
+
+    # state
+    state = ansible_module.params.get("state")
+
+    # Check parameters
+
+    if state == "present":
+        if len(names) != 1:
+            ansible_module.fail_json(
+                msg="Only one hbacsvc can be set at a time.")
+
+    if state == "absent":
+        if len(names) < 1:
+            ansible_module.fail_json(
+                msg="No name given.")
+        invalid = ["description"]
+        for x in invalid:
+            if vars()[x] is not None:
+                ansible_module.fail_json(
+                    msg="Argument '%s' can not be used with state '%s'" %
+                    (x, state))
+
+    # Init
+
+    changed = False
+    exit_args = {}
+    ccache_dir = None
+    ccache_name = None
+    try:
+        if not valid_creds(ansible_module, ipaadmin_principal):
+            ccache_dir, ccache_name = temp_kinit(ipaadmin_principal,
+                                                 ipaadmin_password)
+        api_connect()
+
+        commands = []
+
+        for name in names:
+            # Try to find hbacsvc
+            res_find = find_hbacsvc(ansible_module, name)
+
+            # Create command
+            if state == "present":
+                # Generate args
+                args = gen_args(description)
+
+                # Found the hbacsvc
+                if res_find is not None:
+                    # For all settings is args, check if there are
+                    # different settings in the find result.
+                    # If yes: modify
+                    if not compare_args_ipa(ansible_module, args,
+                                            res_find):
+                        commands.append([name, "hbacsvc_mod", args])
+                else:
+                    commands.append([name, "hbacsvc_add", args])
+
+            elif state == "absent":
+                if res_find is not None:
+                    commands.append([name, "hbacsvc_del", {}])
+
+            else:
+                ansible_module.fail_json(msg="Unkown state '%s'" % state)
+
+        # Execute commands
+
+        for name, command, args in commands:
+            try:
+                api_command(ansible_module, command, to_text(name), args)
+                changed = True
+            except Exception as e:
+                ansible_module.fail_json(msg="%s: %s: %s" % (command, name,
+                                                             str(e)))
+
+    except Exception as e:
+        ansible_module.fail_json(msg=str(e))
+
+    finally:
+        temp_kdestroy(ccache_dir, ccache_name)
+
+    # Done
+
+    ansible_module.exit_json(changed=changed, **exit_args)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/hbacsvc/test_hbacsvc.yml
+++ b/tests/hbacsvc/test_hbacsvc.yml
@@ -1,0 +1,58 @@
+---
+- name: Tests
+  hosts: ipaserver
+  become: true
+  gather_facts: false
+
+  tasks:
+  - name: Ensure HBAC Service for http is absent
+    ipahbacsvc:
+      ipaadmin_password: MyPassword123
+      name: http,tftp
+      state: absent
+
+  - name: Ensure HBAC Service for http is present
+    ipahbacsvc:
+      ipaadmin_password: MyPassword123
+      name: http
+    register: result
+    failed_when: not result.changed
+
+  - name: Ensure HBAC Service for http is present again
+    ipahbacsvc:
+      ipaadmin_password: MyPassword123
+      name: http
+    register: result
+    failed_when: result.changed
+
+  - name: Ensure HBAC Service for tftp is present
+    ipahbacsvc:
+      ipaadmin_password: MyPassword123
+      name: tftp
+      description: TFTP service
+    register: result
+    failed_when: not result.changed
+
+  - name: Ensure HBAC Service for tftp is present again
+    ipahbacsvc:
+      ipaadmin_password: MyPassword123
+      name: tftp
+      description: TFTP service
+    register: result
+    failed_when: result.changed
+
+  - name: Ensure HBAC Services for http and tftp are absent
+    ipahbacsvc:
+      ipaadmin_password: MyPassword123
+      name: http,tftp
+      state: absent
+    register: result
+    failed_when: not result.changed
+
+  - name: Ensure HBAC Services for http and tftp are absent again
+    ipahbacsvc:
+      ipaadmin_password: MyPassword123
+      name: http,tftp
+      state: absent
+    register: result
+    failed_when: result.changed


### PR DESCRIPTION
There is a new hbacsvc (HBAC Service) management module placed in the plugins
folder:

  plugins/modules/ipahbacsvc.py

The hbacsvc module allows to ensure presence and absence of HBAC Services.

Here is the documentation for the module:

  README-hbacsvc.md

New example playbooks have been added:

  playbooks/hbacsvc/ensure-hbacsvc-absent.yml
  playbooks/hbacsvc/ensure-hbacsvc-present.yml

New tests added for pwpolicy:

  tests/hbacsvc/test_hbacsvc.yml