### PR TITLE
ipagroup: Fix changed flag, new test cases

### DIFF
--- a/plugins/modules/ipagroup.py
+++ b/plugins/modules/ipagroup.py
@@ -378,7 +378,10 @@ def main():
             try:
                 result = api_command(ansible_module, command, to_text(name),
                                      args)
-                if "completed" in result and result["completed"] > 0:
+                if "completed" in result:
+                    if result["completed"] > 0:
+                        changed = True
+                else:
                     changed = True
             except Exception as e:
                 ansible_module.fail_json(msg="%s: %s: %s" % (command, name,

--- a/tests/group/test_group.yml
+++ b/tests/group/test_group.yml
@@ -1,0 +1,175 @@
+---
+- name: Tests
+  hosts: ipaserver
+  become: true
+  gather_facts: false
+
+  tasks:
+  - name: Ensure users user1, user2 and user3 are absent
+    ipauser:
+      ipaadmin_password: MyPassword123
+      name: user1,user2,user3
+      state: absent
+
+  - name: Ensure group group3, group2 and group1 are absent
+    ipagroup:
+      ipaadmin_password: MyPassword123
+      name: group3,group2,group1
+      state: absent
+
+  - name: Ensure users user1..user3 are present
+    ipauser:
+      ipaadmin_password: MyPassword123
+      users:
+      - name: user1
+        first: user1
+        last: Last
+      - name: user2
+        first: user2
+        last: Last
+      - name: user3
+        first: user3
+        last: Last
+    register: result
+    failed_when: not result.changed
+
+  - name: Ensure group1 is present
+    ipagroup:
+      ipaadmin_password: MyPassword123
+      name: group1
+    register: result
+    failed_when: not result.changed
+
+  - name: Ensure group1 is present again
+    ipagroup:
+      ipaadmin_password: MyPassword123
+      name: group1
+    register: result
+    failed_when: result.changed
+
+  - name: Ensure group2 is present
+    ipagroup:
+      ipaadmin_password: MyPassword123
+      name: group2
+    register: result
+    failed_when: not result.changed
+
+  - name: Ensure group2 is present again
+    ipagroup:
+      ipaadmin_password: MyPassword123
+      name: group2
+    register: result
+    failed_when: result.changed
+
+  - name: Ensure group3 is present
+    ipagroup:
+      ipaadmin_password: MyPassword123
+      name: group3
+    register: result
+    failed_when: not result.changed
+
+  - name: Ensure group3 is present again
+    ipagroup:
+      ipaadmin_password: MyPassword123
+      name: group3
+    register: result
+    failed_when: result.changed
+
+  - name: Ensure groups group2 and group3 are present in group group1
+    ipagroup:
+      ipaadmin_password: MyPassword123
+      name: group1
+      group:
+      - group2
+      - group3
+      action: member
+    register: result
+    failed_when: not result.changed
+
+  - name: Ensure groups group2 and group3 are present in group group1 again
+    ipagroup:
+      ipaadmin_password: MyPassword123
+      name: group1
+      group:
+      - group2
+      - group3
+      action: member
+    register: result
+    failed_when: result.changed
+
+  - name: Ensure group3 ia present in group group1
+    ipagroup:
+      ipaadmin_password: MyPassword123
+      name: group1
+      group:
+      - group3
+      action: member
+    register: result
+    failed_when: result.changed
+
+  - name: Ensure users user1, user2 and user3 are present in group group1
+    ipagroup:
+      ipaadmin_password: MyPassword123
+      name: group1
+      user:
+      - user1
+      - user2
+      - user3
+      action: member
+    register: result
+    failed_when: not result.changed
+
+  - name: Ensure users user1, user2 and user3 are present in group group1 again
+    ipagroup:
+      ipaadmin_password: MyPassword123
+      name: group1
+      user:
+      - user1
+      - user2
+      - user3
+      action: member
+    register: result
+    failed_when: result.changed
+
+  #- ipagroup:
+  #    ipaadmin_password: MyPassword123
+  #    name: group1
+  #    user:
+  #    - user7
+  #    action: member
+
+  - name: Ensure user user7 is absent in group group1
+    ipagroup:
+      ipaadmin_password: MyPassword123
+      name: group1
+      user:
+      - user7
+      action: member
+      state: absent
+    register: result
+    failed_when: result.changed
+
+  - name: Ensure group group4 is absent
+    ipagroup:
+      ipaadmin_password: MyPassword123
+      name: group4
+      state: absent
+    register: result
+    failed_when: result.changed
+
+  - name: Ensure group group3, group2 and group1 are absent
+    ipagroup:
+      ipaadmin_password: MyPassword123
+      name: group3,group2,group1
+      state: absent
+    register: result
+    failed_when: not result.changed
+
+  - name: Ensure users user1, user2 and user3 are absent
+    ipauser:
+      ipaadmin_password: MyPassword123
+      name: user1,user2,user3
+      state: absent
+    register: result
+    failed_when: not result.changed
+


### PR DESCRIPTION
The changed flag returned by ipagroup calls have not been correct. This
change fixes this. Addtitionally new test cases have been added to make
sure that the changed flag is correct.