### PR TITLE
ipauser: Add info about version limitation of passwordexpiration

### DIFF
--- a/README-user.md
+++ b/README-user.md
@@ -332,7 +332,7 @@ Variable | Description | Required
 `email` | List of email address strings. | no
 `principal` \| `principalnam` \| `krbprincipalname` | The kerberos principal sptring. | no
 `principalexpiration` \| `krbprincipalexpiration` | The kerberos principal expiration date. Possible formats: `YYYYMMddHHmmssZ`, `YYYY-MM-ddTHH:mm:ssZ`, `YYYY-MM-ddTHH:mmZ`, `YYYY-MM-ddZ`, `YYYY-MM-dd HH:mm:ssZ` or `YYYY-MM-dd HH:mmZ`. The trailing 'Z' can be skipped. | no
-`passwordexpiration` \| `krbpasswordexpiration` | The kerberos password expiration date. Possible formats: `YYYYMMddHHmmssZ`, `YYYY-MM-ddTHH:mm:ssZ`, `YYYY-MM-ddTHH:mmZ`, `YYYY-MM-ddZ`, `YYYY-MM-dd HH:mm:ssZ` or `YYYY-MM-dd HH:mmZ`. The trailing 'Z' can be skipped. | no
+`passwordexpiration` \| `krbpasswordexpiration` | The kerberos password expiration date. Possible formats: `YYYYMMddHHmmssZ`, `YYYY-MM-ddTHH:mm:ssZ`, `YYYY-MM-ddTHH:mmZ`, `YYYY-MM-ddZ`, `YYYY-MM-dd HH:mm:ssZ` or `YYYY-MM-dd HH:mmZ`. The trailing 'Z' can be skipped. Only usable with IPA versions 4.7 and up. | no
 `password` | The user password string. | no
 `random` | Generate a random user password | no
 `uid` \| `uidnumber` | The UID integer. | no

--- a/plugins/modules/ipauser.py
+++ b/plugins/modules/ipauser.py
@@ -92,6 +92,7 @@ options:
         - (possible formats: YYYYMMddHHmmssZ, YYYY-MM-ddTHH:mm:ssZ,
         - YYYY-MM-ddTHH:mmZ, YYYY-MM-ddZ, YYYY-MM-dd HH:mm:ssZ,
         - YYYY-MM-dd HH:mmZ) The trailing 'Z' can be skipped.
+        - Only usable with IPA versions 4.7 and up.
         required: false
         aliases: ["krbpasswordexpiration"]
       password:
@@ -247,6 +248,7 @@ options:
     - (possible formats: YYYYMMddHHmmssZ, YYYY-MM-ddTHH:mm:ssZ,
     - YYYY-MM-ddTHH:mmZ, YYYY-MM-ddZ, YYYY-MM-dd HH:mm:ssZ,
     - YYYY-MM-dd HH:mmZ) The trailing 'Z' can be skipped.
+    - Only usable with IPA versions 4.7 and up.
     required: false
     aliases: ["krbpasswordexpiration"]
   password:


### PR DESCRIPTION
The information about the version limitation of the passwordexpiration
parameter has been missing. The parameter is only usable for IPA versions
4.7 and up.