### PR TITLE
ipaclient: Fix misspelled sssd options

### DIFF
--- a/roles/ipaclient/defaults/main.yml
+++ b/roles/ipaclient/defaults/main.yml
@@ -19,11 +19,11 @@ ipaclient_force_ntpd: no
 ipaclient_no_nisdomain: no
 ipaclient_configure_firefox: no
 ipaclient_all_ip_addresses: no
-ipassd_fixed_primary: no
-ipassd_permit: no
-ipassd_enable_dns_updates: no
-ipassd_no_krb5_offline_passwords: no
-ipassd_preserve_sssd: no
+ipasssd_fixed_primary: no
+ipasssd_permit: no
+ipasssd_enable_dns_updates: no
+ipasssd_no_krb5_offline_passwords: no
+ipasssd_preserve_sssd: no
 ipaclient_request_cert: no
 
 ### packages ###

--- a/roles/ipaclient/tasks/install.yml
+++ b/roles/ipaclient/tasks/install.yml
@@ -51,7 +51,8 @@
     all_ip_addresses: "{{ ipaclient_all_ip_addresses }}"
     on_master: "{{ ipaclient_on_master }}"
     ### sssd ###
-    enable_dns_updates: "{{ ipassd_enable_dns_updates }}"
+    enable_dns_updates: "{{ ipassd_enable_dns_updates
+                            | default(ipasssd_enable_dns_updates) }}"
   register: result_ipaclient_test
 
 - block:
@@ -259,11 +260,16 @@
         no_sshd: "{{ ipaclient_no_sshd }}"
         no_sudo: "{{ ipaclient_no_sudo }}"
         all_ip_addresses: "{{ ipaclient_all_ip_addresses }}"
-        fixed_primary: "{{ ipassd_fixed_primary }}"
-        permit: "{{ ipassd_permit }}"
-        enable_dns_updates: "{{ ipassd_enable_dns_updates }}"
-        preserve_sssd: "{{ ipassd_preserve_sssd }}"
-        no_krb5_offline_passwords: "{{ ipassd_no_krb5_offline_passwords }}"
+        fixed_primary: "{{ ipassd_fixed_primary
+                           | default(ipasssd_fixed_primary) }}"
+        permit: "{{ ipassd_permit | default(ipasssd_permit) }}"
+        enable_dns_updates: "{{ ipassd_enable_dns_updates
+                                | default(ipasssd_enable_dns_updates) }}"
+        preserve_sssd: "{{ ipassd_preserve_sssd
+                           | default(ipasssd_preserve_sssd) }}"
+        no_krb5_offline_passwords:
+          "{{ ipassd_no_krb5_offline_passwords
+              | default(ipasssd_no_krb5_offline_passwords) }}"
 
     - name: Install - Configure krb5 for IPA realm
       ipaclient_setup_krb5:
@@ -310,17 +316,22 @@
         ca_enabled: "{{ result_ipaclient_api.ca_enabled }}"
         on_master: "{{ ipaclient_on_master }}"
         dnsok: "{{ result_ipaclient_test.dnsok }}"
-        enable_dns_updates: "{{ ipassd_enable_dns_updates }}"
+        enable_dns_updates: "{{ ipassd_enable_dns_updates
+                                | default(ipasssd_enable_dns_updates) }}"
         all_ip_addresses: "{{ ipaclient_all_ip_addresses }}"
         ip_addresses: "{{ ipaclient_ip_addresses | default(omit) }}"
         request_cert: "{{ ipaclient_request_cert }}"
-        preserve_sssd: "{{ ipassd_preserve_sssd }}"
+        preserve_sssd: "{{ ipassd_preserve_sssd
+                           | default(ipasssd_preserve_sssd) }}"
         no_ssh: "{{ ipaclient_no_ssh }}"
         no_sshd: "{{ ipaclient_no_sshd }}"
         no_sudo: "{{ ipaclient_no_sudo }}"
-        fixed_primary: "{{ ipassd_fixed_primary }}"
-        permit: "{{ ipassd_permit }}"
-        no_krb5_offline_passwords: "{{ ipassd_no_krb5_offline_passwords }}"
+        fixed_primary: "{{ ipassd_fixed_primary
+                           | default(ipasssd_fixed_primary) }}"
+        permit: "{{ ipassd_permit | default(ipasssd_permit) }}"
+        no_krb5_offline_passwords:
+          "{{ ipassd_no_krb5_offline_passwords
+              | default(ipasssd_no_krb5_offline_passwords) }}"
         no_dns_sshfp: "{{ ipaclient_no_dns_sshfp }}"
 
     - name: Install - Configure SSH and SSHD

--- a/utils/ansible-ipa-client-install
+++ b/utils/ansible-ipa-client-install
@@ -339,15 +339,15 @@ def main(options, args):
             f.write("ipaclient_kinit_attempts=%d\n" % options.kinit_attempts)
         # sssd
         if options.fixed_primary:
-            f.write("ipassd_fixed_primary=yes\n")
+            f.write("ipasssd_fixed_primary=yes\n")
         if options.permit:
-            f.write("ipassd_permit=yes\n")
+            f.write("ipasssd_permit=yes\n")
         if options.enable_dns_updates:
-            f.write("ipassd_enable_dns_updates=yes\n")
+            f.write("ipasssd_enable_dns_updates=yes\n")
         if options.no_krb5_offline_passwords:
-            f.write("ipassd_no_krb5_offline_passwords=yes\n")
+            f.write("ipasssd_no_krb5_offline_passwords=yes\n")
         if options.preserve_sssd:
-            f.write("ipassd_preserve_sssd=yes\n")
+            f.write("ipasssd_preserve_sssd=yes\n")
         # automount
         if options.automount_location:
             f.write("ipaclient_automount_location=%s\n" %


### PR DESCRIPTION
The sssd options in the ipaclient role missed a 's' in the role. The readme
of the role used the proper names with 3 's'. The names in the role have
been fixed and if the old setting are used, they will be used in the first
place.

Also utils/ansible-ipa-client-install has been adaped to use the proper
option names now.

This fixes issue #145 (The ipaclient role misspells sssd)