### PR TITLE
ipauser, ipahost: Return random password

### DIFF
--- a/README-host.md
+++ b/README-host.md
@@ -101,6 +101,11 @@ Example playbook to initiate the generation of a random password to be used in b
       description: Example host
       ip_address: 192.168.0.123
       random: yes
+    register: ipahost
+
+  - name: Print generated random password
+    debug:
+      var: ipahost.host.randompassword
 ```
 
 
@@ -165,6 +170,21 @@ Variable | Description | Required
 `update_dns` | Update DNS entries. | no
 `update_password` |  Set password for a host in present state only on creation or always. It can be one of `always` or `on_create` and defaults to `always`. | no
 `state` | The state to ensure. It can be one of `present`, `absent` or `disabled`, default: `present`. | yes
+
+
+Return Values
+=============
+
+ipahost
+-------
+
+There are only return values if one or more random passwords have been generated.
+
+Variable | Description | Returned When
+-------- | ----------- | -------------
+`host` | Host dict with random password. (dict) <br>Options: | If random is yes and host did not exist or update_password is yes
+&nbsp; | `randompassword` - The generated random password | If only one host is handled by the module
+&nbsp; | `name` - The host name of the host that got a new random password. (dict) <br> Options: <br> &nbsp; `randompassword` - The generated random password | If several hosts are handled by the module
 
 
 Authors

--- a/README-user.md
+++ b/README-user.md
@@ -142,6 +142,64 @@ And ensure the presence of the users with this example playbook:
       users: "{{ users }}"
 ```
 
+Ensure user pinky is present with a generated random password and print the random password:
+
+```yaml
+---
+- name: Playbook to handle users
+  hosts: ipaserver
+  become: true
+
+  tasks:
+  # Ensure user pinky is present with a random password
+  - ipauser:
+      ipaadmin_password: MyPassword123
+      name: brain
+      first: brain
+      last: Acme
+      random: yes
+    register: ipauser
+
+  - name: Print generated random password
+    debug:
+      var: ipauser.user.randompassword
+```
+
+Ensure users pinky and brain are present with a generated random password and print the random passwords:
+
+```yaml
+---
+- name: Playbook to handle users
+  hosts: ipaserver
+  become: true
+
+  tasks:
+  # Ensure users pinky and brain are present with random password
+  - ipauser:
+      ipaadmin_password: MyPassword123
+      users:
+      - name: pinky
+        first: pinky
+        last: Acme
+        uid: 10001
+        gid: 100
+        phone: "+555123457"
+        email: pinky@acme.com
+        passwordexpiration: "2023-01-19 23:59:59"
+        password: "no-brain"
+      - name: brain
+        first: brain
+        last: Acme
+    register: ipauser
+
+  - name: Print generated random password of pinky
+    debug:
+      var: ipauser.user.pinky.randompassword
+
+  - name: Print generated random password of brain
+    debug:
+      var: ipauser.user.brain.randompassword
+```
 
 Example playbook to delete a user, but preserve it:
 
@@ -364,6 +422,22 @@ Variable | Description | Required
 &nbsp; | `subject` - Subject of the certificate | no
 `noprivate` | Do not create user private group. (bool) | no
 `nomembers` | Suppress processing of membership attributes. (bool) | no
+
+
+
+Return Values
+=============
+
+ipauser
+-------
+
+There are only return values if one or more random passwords have been generated.
+
+Variable | Description | Returned When
+-------- | ----------- | -------------
+`host` | Host dict with random password. (dict) <br>Options: | If random is yes and user did not exist or update_password is yes
+&nbsp; | `randompassword` - The generated random password | If only one user is handled by the module
+&nbsp; | `name` - The user name of the user that got a new random password. (dict) <br> Options: <br> &nbsp; `randompassword` - The generated random password | If several users are handled by the module
 
 
 Authors

--- a/playbooks/host/ensure_host_with_randompassword.yml
+++ b/playbooks/host/ensure_host_with_randompassword.yml
@@ -1,0 +1,18 @@
+---
+- name: Ensure host with random password
+  hosts: ipaserver
+  become: true
+
+  tasks:
+  - name: Host "{{ 'host1.' + ipaserver_domain }}" present with random password
+    ipahost:
+      ipaadmin_password: MyPassword123
+      name: "{{ 'host1.' + ipaserver_domain }}"
+      random: yes
+      force: yes
+      update_password: on_create
+    register: ipahost
+
+  - name: Print generated random password
+    debug:
+      var: ipahost.host.randompassword

--- a/playbooks/user/ensure_user_with_randompassword.yml
+++ b/playbooks/user/ensure_user_with_randompassword.yml
@@ -1,0 +1,19 @@
+---
+- name: Ensure user with random password
+  hosts: ipaserver
+  become: true
+
+  tasks:
+  - name: User user1 present with random password
+    ipauser:
+      ipaadmin_password: MyPassword123
+      name: user1
+      first: first1
+      last: last1
+      random: yes
+      update_password: on_create
+    register: ipauser
+
+  - name: Print generated random password
+    debug:
+      var: ipauser.user.randompassword

--- a/playbooks/user/ensure_users_with_randompasswords.yml
+++ b/playbooks/user/ensure_users_with_randompasswords.yml
@@ -1,0 +1,28 @@
+---
+- name: Tests
+  hosts: ipaserver
+  become: true
+
+  tasks:
+  - name: Users user1 and user1 present with random password
+    ipauser:
+      ipaadmin_password: MyPassword123
+      users:
+      - name: user1
+        first: first1
+        last: last1
+        random: yes
+      - name: user2
+        first: first2
+        last: last2
+        random: yes
+      update_password: on_create
+    register: ipauser
+
+  - name: Print generated random password for user1
+    debug:
+      var: ipauser.user.user1.randompassword
+
+  - name: Print generated random password for user2
+    debug:
+      var: ipauser.user.user2.randompassword

--- a/tests/host/test_host_random.yml
+++ b/tests/host/test_host_random.yml
@@ -1,0 +1,41 @@
+---
+- name: Test ipahost random password generation
+  hosts: ipaserver
+  become: true
+
+  tasks:
+  - name: Get Domain from server name
+    set_fact:
+      ipaserver_domain: "{{ groups.ipaserver[0].split('.')[1:] | join ('.') }}"
+    when: ipaserver_domain is not defined
+
+  - name: Test hosts absent
+    ipahost:
+      ipaadmin_password: MyPassword123
+      name:
+      - "{{ 'host1.' + ipaserver_domain }}"
+      - "{{ 'host2.' + ipaserver_domain }}"
+      update_dns: yes
+      state: absent
+
+  - name: Host "{{ 'host1.' + ipaserver_domain }}" present with random password
+    ipahost:
+      ipaadmin_password: MyPassword123
+      name: "{{ 'host1.' + ipaserver_domain }}"
+      random: yes
+      force: yes
+      update_password: on_create
+    register: ipahost
+    failed_when: not ipahost.changed or
+                 ipahost.host.randompassword is not defined
+
+  - name: Print generated random password
+    debug:
+      var: ipahost.host.randompassword
+
+  - name: Host "{{ 'host1.' + ipaserver_domain }}" absent
+    ipahost:
+      ipaadmin_password: MyPassword123
+      name:
+      - "{{ 'host1.' + ipaserver_domain }}"
+      state: absent

--- a/tests/user/test_user_random.yml
+++ b/tests/user/test_user_random.yml
@@ -1,0 +1,70 @@
+---
+- name: Test ipauser random password generation
+  hosts: ipaserver
+  become: true
+
+  tasks:
+  - name: Users user1 and user2 absent
+    ipauser:
+      ipaadmin_password: MyPassword123
+      name:
+      - user1
+      - user2
+      state: absent
+
+  - name: User user1 present with random password
+    ipauser:
+      ipaadmin_password: MyPassword123
+      name: user1
+      first: first1
+      last: last1
+      random: yes
+      update_password: on_create
+    register: ipauser
+    failed_when: not ipauser.changed or
+                 ipauser.user.randompassword is not defined
+
+  - name: Print generated random password
+    debug:
+      var: ipauser.user.randompassword
+
+  - name: User user1 absent
+    ipauser:
+      ipaadmin_password: MyPassword123
+      name:
+      - user1
+      state: absent
+
+  - name: Users user1 and user1 present with random password
+    ipauser:
+      ipaadmin_password: MyPassword123
+      users:
+      - name: user1
+        first: first1
+        last: last1
+        random: yes
+      - name: user2
+        first: first2
+        last: last2
+        random: yes
+      update_password: on_create
+    register: ipauser
+    failed_when: not ipauser.changed or
+                 ipauser.user.user1.randompassword is not defined or
+                 ipauser.user.user2.randompassword is not defined
+
+  - name: Print generated random password for user1
+    debug:
+      var: ipauser.user.user1.randompassword
+
+  - name: Print generated random password for user2
+    debug:
+      var: ipauser.user.user2.randompassword
+
+  - name: Users user1 and user2 absent
+    ipauser:
+      ipaadmin_password: MyPassword123
+      name:
+      - user1
+      - user2
+      state: absent


### PR DESCRIPTION
ipauser: Return generated random password

The random password is only returned if random is yes and user did not exist or update_password is yes.

ipahost: Return generated random password

The random password is only returned if random is yes and the host did not exist or update_password is yes.

Fixes issue #134 (ipahost does not return the random password)