### PR TITLE
ansible_freeipa_module: Better support for KRB5CCNAME environment variable

### DIFF
--- a/plugins/module_utils/ansible_freeipa_module.py
+++ b/plugins/module_utils/ansible_freeipa_module.py
@@ -50,10 +50,12 @@ def valid_creds(module, principal):
     Get valid credintials matching the princial, try GSSAPI first
     """
     if "KRB5CCNAME" in os.environ:
-        module.debug('KRB5CCNAME set to %s' %
-                     os.environ.get('KRB5CCNAME', None))
+        ccache = os.environ["KRB5CCNAME"]
+        module.debug('KRB5CCNAME set to %s' % ccache)
+
         try:
-            cred = gssapi.creds.Credentials()
+            cred = gssapi.Credentials(usage='initiate',
+                                      store={'ccache': ccache})
         except gssapi.raw.misc.GSSError as e:
             module.fail_json(msg='Failed to find default ccache: %s' % e)
         else:


### PR DESCRIPTION
The use of gssapi.creds.Credentials is not good if krb5 ticket forwarding
is used. It will fail. gssapi.Credentials with usage and store is the proper
way to do this.