### PR TITLE
ipa[server,replica,client]: Add support for CentOS-8

### DIFF
--- a/roles/ipaclient/vars/CentOS-8.yml
+++ b/roles/ipaclient/vars/CentOS-8.yml
@@ -1,0 +1,1 @@
+RedHat-8.yml

--- a/roles/ipareplica/vars/CentOS-8.yml
+++ b/roles/ipareplica/vars/CentOS-8.yml
@@ -1,0 +1,1 @@
+RedHat-8.yml

--- a/roles/ipaserver/vars/CentOS-8.yml
+++ b/roles/ipaserver/vars/CentOS-8.yml
@@ -1,0 +1,1 @@
+RedHat-8.yml


### PR DESCRIPTION
The files for RHEL-8 (RedHat-8.yml) have simply been linked to CentOS-8.yml
for the ipaserver, ipareplica and ipaclient roles.

Fixes issue #121 (roles/*/vars needs CentOS-8.yml files)