### PR TITLE
Allow execution of API commands that do not require parameters.

### DIFF
--- a/plugins/module_utils/ansible_freeipa_module.py
+++ b/plugins/module_utils/ansible_freeipa_module.py
@@ -151,6 +151,13 @@ def api_command(module, command, name, args):
     return api.Command[command](name, **args)
 
 
+def api_command_no_name(module, command, args):
+    """
+    Call ipa.Command without a name.
+    """
+    return api.Command[command](**args)
+
+
 def api_check_param(command, name):
     """
     Return if param exists in command param list


### PR DESCRIPTION
There are some commands in the IPA API that do not require arguments, and current implementation does not allow these commands to be executed.

This patch provides a utility function to allow this behavior, that is required by the vaultcontainer module.