### PR TITLE
ipaserver_test: Do not use zone_overlap_check for domain name validation

### DIFF
--- a/roles/ipaserver/library/ipaserver_test.py
+++ b/roles/ipaserver/library/ipaserver_test.py
@@ -719,12 +719,7 @@ def main():
                 msg="File %s does not exist." % options.dirsrv_config_file)
 
     # domain_name
-    if options.setup_dns and not options.allow_zone_overlap and \
-       options.domain_name is not None:
-        try:
-            check_zone_overlap(options.domain_name, False)
-        except ValueError as e:
-            ansible_module.fail_json(msg=str(e))
+    # Validation is done later on in ipaserver_prepare dns.install_check
 
     # dm_password
     with redirect_stdout(ansible_log):


### PR DESCRIPTION
The use of zone_overlay_check for the domain name validation is not good
for a repeated execution of the server deployment where setup_dns is
enabled. The zone overlay check will fail with "DNS zone X already exists
in DNS". zone_overlay_check is later on used in dns.install_check so it is
not needed to do it here also.

Fixes issues #164 (domain option validator should not call zone overlap..)