### PR TITLE
ipauser: Allow reset of userauthtype, do not depend on first,last for…

### DIFF
--- a/README-user.md
+++ b/README-user.md
@@ -408,7 +408,7 @@ Variable | Description | Required
 `manager` | List of manager user names. | no
 `carlicense` | List of car licenses. | no
 `sshpubkey` \| `ipasshpubkey` | List of SSH public keys. | no
-`userauthtype` | List of supported user authentication types. Choices: `password`, `radius` and `otp` | no
+`userauthtype` | List of supported user authentication types. Choices: `password`, `radius`, `otp` and ``. Use empty string to reset userauthtype to the initial value. | no
 `userclass` | User category. (semantics placed on this attribute are for local interpretation). | no
 `radius` | RADIUS proxy configuration  | no
 `radiususer` | RADIUS proxy username | no


### PR DESCRIPTION
… mod

It was not possible to reset the userauthtype. The empty string has been
added to userauthtype for this.

Also ipauser will only depend on given first and last name if the user
does not exist yet. For the update operation these parameters are not
needed anymore.