### PR TITLE
Fix for typeError on line 875

### DIFF
--- a/roles/ipaclient/library/ipaclient_test.py
+++ b/roles/ipaclient/library/ipaclient_test.py
@@ -872,7 +872,7 @@ def main():
                     is_ipaddr = False
 
             if is_ipaddr:
-                logger.info()
+                logger.info("")
                 logger.warning(
                     "It seems that you are using an IP address "
                     "instead of FQDN as an argument to --server. The "


### PR DESCRIPTION
TASK [ipaclient : Install - IPA client test] was failing because of missing ""

logs:
`FAILED! => {"changed": false, "module_stderr": "Shared connection to 10.167.0.197 closed.\r\n", "module_stdout": "Traceback (most recent call last):\r\n  File \"/home/ubuntu/.ansible/tmp/ansible-tmp-1577129785.7906408-237202665885733/AnsiballZ_ipaclient_test.py\", line 102, in <module>\r\n    _ansiballz_main()\r\n  File \"/home/ubuntu/.ansible/tmp/ansible-tmp-1577129785.7906408-237202665885733/AnsiballZ_ipaclient_test.py\", line 94, in _ansiballz_main\r\n    invoke_module(zipped_mod, temp_path, ANSIBALLZ_PARAMS)\r\n  File \"/home/ubuntu/.ansible/tmp/ansible-tmp-1577129785.7906408-237202665885733/AnsiballZ_ipaclient_test.py\", line 40, in invoke_module\r\n    runpy.run_module(mod_name='ansible.modules.ipaclient_test', init_globals=None, run_name='__main__', alter_sys=True)\r\n  File \"/usr/lib/python2.7/runpy.py\", line 188, in run_module\r\n    fname, loader, pkg_name)\r\n  File \"/usr/lib/python2.7/runpy.py\", line 82, in _run_module_code\r\n    mod_name, mod_fname, mod_loader, pkg_name)\r\n  File \"/usr/lib/python2.7/runpy.py\", line 72, in _run_code\r\n    exec code in run_globals\r\n  File \"/tmp/ansible_ipaclient_test_payload_jg4ZGp/ansible_ipaclient_test_payload.zip/ansible/modules/ipaclient_test.py\", line 932, in <module>\r\n  File \"/tmp/ansible_ipaclient_test_payload_jg4ZGp/ansible_ipaclient_test_payload.zip/ansible/modules/ipaclient_test.py\", line 875, in main\r\nTypeError: info() takes at least 2 arguments (1 given)\r\n", "msg": "MODULE FAILURE\nSee stdout/stderr for the exact error", "rc": 1}`