### PR TITLE
Changes the default name of parameters to match FreeIPA CLI.

### DIFF
--- a/playbooks/sudorule/ensure-sudorule-sudocmd-is-absent.yml
+++ b/playbooks/sudorule/ensure-sudorule-sudocmd-is-absent.yml
@@ -8,7 +8,7 @@
   - ipasudorule:
       ipaadmin_password: MyPassword123
       name: testrule1
-      cmd:
+      sudocmds:
       - /sbin/ifconfig
       - /usr/bin/vim
       action: member

--- a/playbooks/sudorule/ensure-sudorule-sudocmd-is-present.yml
+++ b/playbooks/sudorule/ensure-sudorule-sudocmd-is-present.yml
@@ -8,7 +8,7 @@
   - ipasudorule:
       ipaadmin_password: MyPassword123
       name: testrule1
-      cmd:
+      sudocmds:
       - /sbin/ifconfig
       - /usr/bin/vim
       action: member


### PR DESCRIPTION
This patch changes the default names of parameters to match FreeIPA CLI
names. To keep backward compatibility old names were kept as aliases.