### PR TITLE
Add missing validation in ipasudocmd

### DIFF
--- a/plugins/modules/ipasudocmd.py
+++ b/plugins/modules/ipasudocmd.py
@@ -97,7 +97,7 @@ def find_sudocmd(module, name):
 def gen_args(description):
     _args = {}
     if description is not None:
-        _args["description"] = description
+        _args["description"] = to_text(description)
 
     return _args
 


### PR DESCRIPTION
This fixes the issue https://github.com/freeipa/ansible-freeipa/issues/185, where the python script was launching an exception
There was a lack of verification that the input string (for the description  field) was a text string