### PR TITLE
ipareplica: Use ipaserver_realm as a fallback for realm

### DIFF
--- a/roles/ipareplica/tasks/install.yml
+++ b/roles/ipareplica/tasks/install.yml
@@ -57,7 +57,7 @@
     domain: "{{ ipareplica_domain | default(ipaserver_domain) |
             default(omit) }}"
     servers: "{{ ipareplica_servers | default(omit) }}"
-    realm: "{{ ipareplica_realm | default(omit) }}"
+    realm: "{{ ipareplica_realm | default(ipaserver_realm) |default(omit) }}"
     hostname: "{{ ipareplica_hostname | default(ansible_fqdn) }}"
     ca_cert_files: "{{ ipareplica_ca_cert_files | default([]) }}"
     hidden_replica: "{{ ipareplica_hidden_replica }}"


### PR DESCRIPTION
Use ipaserver_realm as a fallback if ipareplica_realm is not defined. This
had been done for ipareplica_domain and ipaserver_domain, but was missing
for ipareplica_realm and ipaserver_realm.

Related: #114 (ipareplica 'Env' object has no attribute 'realm')