### PR TITLE
Not delete keytab when ipaclient_on_master is true

### DIFF
--- a/roles/ipaclient/tasks/install.yml
+++ b/roles/ipaclient/tasks/install.yml
@@ -191,7 +191,7 @@
     #   5 - Principal name or realm not found in keytab
     failed_when: result_ipa_rmkeytab.rc != 0 and
                  result_ipa_rmkeytab.rc != 3 and result_ipa_rmkeytab.rc != 5
-    when: ipaclient_use_otp | bool or ipaclient_force_join | bool
+    when: (ipaclient_use_otp | bool or ipaclient_force_join | bool) and not ipaclient_on_master | bool
 
   - name: Install - Backup and set hostname
     ipaclient_set_hostname:


### PR DESCRIPTION
Keep the valid keytab file pre-existent in the master node. This fixes #191.

**Please, review carefully. It seems to work correctly in my environment but I don't know if there is any possible side effect related to https://github.com/freeipa/ansible-freeipa/commit/f366fb5270c00d289721562d4b8582d48407bf89.**