### PR TITLE
Properly handle certificates stored as bytes in encode_certificate.

### DIFF
--- a/plugins/module_utils/ansible_freeipa_module.py
+++ b/plugins/module_utils/ansible_freeipa_module.py
@@ -268,7 +268,7 @@ def encode_certificate(cert):
     Encode a certificate using base64 with also taking FreeIPA and Python
     versions into account
     """
-    if isinstance(cert, str) or isinstance(cert, unicode):
+    if isinstance(cert, (str, unicode, bytes)):
         encoded = base64.b64encode(cert)
     else:
         encoded = base64.b64encode(cert.public_bytes(Encoding.DER))


### PR DESCRIPTION
When implementing the ipaservice module, certificates are returned as
'bytes', and they need to be base64 encoded directly.