### PR TITLE
ipapwpolicy: Use global_policy if name is not set

### DIFF
--- a/README-pwpolicy.md
+++ b/README-pwpolicy.md
@@ -56,7 +56,7 @@ Example playbook to ensure presence of pwpolicies for exisiting group ops:
       maxfail: 3
 ```
 
-Example playbook to ensure absence of pwpolicies for group ops
+Example playbook to ensure absence of pwpolicies for group ops:
 
 ```yaml
 ---
@@ -72,6 +72,21 @@ Example playbook to ensure absence of pwpolicies for group ops
       state: absent
 ```
 
+Example playbook to ensure maxlife is set to 49 in global policy:
+
+```yaml
+---
+- name: Playbook to handle pwpolicies
+  hosts: ipaserver
+  become: true
+
+  tasks:
+  # Ensure absence of pwpolicies for group ops
+  - ipapwpolicy:
+      ipaadmin_password: MyPassword123
+      maxlife: 49
+```
+
 
 Variables
 =========
@@ -83,7 +98,7 @@ Variable | Description | Required
 -------- | ----------- | --------
 `ipaadmin_principal` | The admin principal is a string and defaults to `admin` | no
 `ipaadmin_password` | The admin password is a string and is required if there is no admin ticket available on the node | no
-`name` \| `cn` | The list of pwpolicy name strings. | no
+`name` \| `cn` | The list of pwpolicy name strings. If name is not given, `global_policy` will be used automatically. | no
 `maxlife` \| `krbmaxpwdlife` | Maximum password lifetime in days. (int) | no
 `minlife` \| `krbminpwdlife` | Minimum password lifetime in hours. (int) | no
 `history` \| `krbpwdhistorylength` | Password history size. (int) | no

--- a/plugins/modules/ipapwpolicy.py
+++ b/plugins/modules/ipapwpolicy.py
@@ -167,7 +167,7 @@ def main():
             ipaadmin_password=dict(type="str", required=False, no_log=True),
 
             name=dict(type="list", aliases=["cn"], default=None,
-                      required=True),
+                      required=False),
             # present
 
             maxlife=dict(type="int", aliases=["krbmaxpwdlife"], default=None),
@@ -218,6 +218,9 @@ def main():
 
     # Check parameters
 
+    if names is None:
+        names = ["global_policy"]
+
     if state == "present":
         if len(names) != 1:
             ansible_module.fail_json(
@@ -225,8 +228,10 @@ def main():
 
     if state == "absent":
         if len(names) < 1:
+            ansible_module.fail_json(msg="No name given.")
+        if "global_policy" in names:
             ansible_module.fail_json(
-                msg="No name given.")
+                msg="'global_policy' can not be made absent.")
         invalid = ["maxlife", "minlife", "history", "minclasses",
                    "minlength", "priority", "maxfail", "failinterval",
                    "lockouttime"]

--- a/tests/pwpolicy/test_pwpolicy.yml
+++ b/tests/pwpolicy/test_pwpolicy.yml
@@ -5,10 +5,30 @@
   gather_facts: false
 
   tasks:
+  - name: Ensure maxlife of 90 for global_policy
+    ipapwpolicy:
+      ipaadmin_password: SomeADMINpassword
+      maxlife: 90
+
+  - name: Ensure absence of group ops
+    ipagroup:
+      ipaadmin_password: SomeADMINpassword
+      name: ops
+      state: absent
+
+  - name: Ensure absence of pwpolicies for group ops
+    ipapwpolicy:
+      ipaadmin_password: SomeADMINpassword
+      name: ops
+      state: absent
+
   - name: Ensure presence of group ops
     ipagroup:
       ipaadmin_password: SomeADMINpassword
       name: ops
+      state: present
+    register: result
+    failed_when: not result.changed
 
   - name: Ensure presence of pwpolicies for group ops
     ipapwpolicy:
@@ -42,11 +62,40 @@
     register: result
     failed_when: result.changed
 
+  - name: Ensure maxlife of 49 for global_policy
+    ipapwpolicy:
+      ipaadmin_password: SomeADMINpassword
+      maxlife: 49
+    register: result
+    failed_when: not result.changed
+
+  - name: Ensure maxlife of 49 for global_policy again
+    ipapwpolicy:
+      ipaadmin_password: SomeADMINpassword
+      maxlife: 49
+    register: result
+    failed_when: result.changed
+
+  - name: Ensure absence of pwpoliciy global_policy will fail
+    ipapwpolicy:
+      ipaadmin_password: SomeADMINpassword
+      state: absent
+    register: result
+    ignore_errors: True
+    failed_when: result is defined and result
+
   - name: Ensure absence of pwpolicies for group ops
     ipapwpolicy:
       ipaadmin_password: SomeADMINpassword
       name: ops
       state: absent
+    register: result
+    failed_when: not result.changed
+
+  - name: Ensure maxlife of 90 for global_policy
+    ipapwpolicy:
+      ipaadmin_password: MyPassword123
+      maxlife: 90
     register: result
     failed_when: not result.changed
 


### PR DESCRIPTION
If the name is not set, the policy global_policy is now used. It was needed
before to explicitly name the global_policy. Also a check has been added
to fail early if global_policy is used with state absent.

The README for pwpolicy has been extended with an example for global_policy
and also the description of the name variable.

The test has also been extended to check a change of maxlife for
global_policy and that global_policy can not be used with state: absent

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1797532