### PR TITLE
ansible_freeipa_module: Fix comparison of bool parameters in compare_…

### DIFF
--- a/plugins/module_utils/ansible_freeipa_module.py
+++ b/plugins/module_utils/ansible_freeipa_module.py
@@ -222,10 +222,20 @@ def compare_args_ipa(module, args, ipa):
                     arg = [to_text(_arg) for _arg in arg]
                 if isinstance(ipa_arg[0], unicode) and isinstance(arg[0], int):
                     arg = [to_text(_arg) for _arg in arg]
-            # module.warn("%s <=> %s" % (arg, ipa_arg))
-            if set(arg) != set(ipa_arg):
-                # module.warn("DIFFERENT")
-                return False
+            # module.warn("%s <=> %s" % (repr(arg), repr(ipa_arg)))
+            try:
+                arg_set = set(arg)
+                ipa_arg_set = set(ipa_arg)
+            except TypeError:
+                if arg != ipa_arg:
+                    # module.warn("%s != %s" % (repr(arg), repr(ipa_arg)))
+                    return False
+            else:
+                if arg_set != ipa_arg_set:
+                    # module.warn("%s != %s" % (repr(arg), repr(ipa_arg)))
+                    return False
+
+        # module.warn("%s == %s" % (repr(arg), repr(ipa_arg)))
 
     return True
 

--- a/tests/host/test_host_bool_params.yml
+++ b/tests/host/test_host_bool_params.yml
@@ -1,0 +1,119 @@
+---
+- name: Test host bool parameters
+  hosts: ipaserver
+  become: true
+
+  tasks:
+  - name: Get Domain from server name
+    set_fact:
+      ipaserver_domain: "{{ groups.ipaserver[0].split('.')[1:] | join ('.') }}"
+    when: ipaserver_domain is not defined
+
+  - name: Set host1_fqdn .. host6_fqdn
+    set_fact:
+      host1_fqdn: "{{ 'host1.' + ipaserver_domain }}"
+
+  - name: Host absent
+    ipahost:
+      ipaadmin_password: MyPassword123
+      name:
+      - "{{ host1_fqdn }}"
+      update_dns: yes
+      state: absent
+
+  - name: Host "{{ host1_fqdn }}" present with requires_pre_auth, ok_as_delegate and ok_to_auth_as_delegate
+    ipahost:
+      ipaadmin_password: MyPassword123
+      name: "{{ host1_fqdn }}"
+      force: yes
+      requires_pre_auth: yes
+      ok_as_delegate: yes
+      ok_to_auth_as_delegate: yes
+    register: result
+    failed_when: not result.changed
+
+  - name: Host "{{ host1_fqdn }}" present with requires_pre_auth, ok_as_delegate and ok_to_auth_as_delegate again
+    ipahost:
+      ipaadmin_password: MyPassword123
+      name: "{{ host1_fqdn }}"
+      requires_pre_auth: yes
+      ok_as_delegate: yes
+      ok_to_auth_as_delegate: yes
+    register: result
+    failed_when: result.changed
+
+  - name: Host "{{ host1_fqdn }}" present with requires_pre_auth, ok_as_delegate and ok_to_auth_as_delegate set to no
+    ipahost:
+      ipaadmin_password: MyPassword123
+      name: "{{ host1_fqdn }}"
+      requires_pre_auth: no
+      ok_as_delegate: no
+      ok_to_auth_as_delegate: no
+    register: result
+    failed_when: not result.changed
+
+  - name: Host "{{ host1_fqdn }}" present with requires_pre_auth, ok_as_delegate and ok_to_auth_as_delegate set to no again
+    ipahost:
+      ipaadmin_password: MyPassword123
+      name: "{{ host1_fqdn }}"
+      requires_pre_auth: no
+      ok_as_delegate: no
+      ok_to_auth_as_delegate: no
+    register: result
+    failed_when: result.changed
+
+  - name: Host "{{ host1_fqdn }}" present with requires_pre_auth
+    ipahost:
+      ipaadmin_password: MyPassword123
+      name: "{{ host1_fqdn }}"
+      requires_pre_auth: yes
+    register: result
+    failed_when: not result.changed
+
+  - name: Host "{{ host1_fqdn }}" present with requires_pre_auth again
+    ipahost:
+      ipaadmin_password: MyPassword123
+      name: "{{ host1_fqdn }}"
+      requires_pre_auth: yes
+    register: result
+    failed_when: result.changed
+
+  - name: Host "{{ host1_fqdn }}" present with ok_as_delegate
+    ipahost:
+      ipaadmin_password: MyPassword123
+      name: "{{ host1_fqdn }}"
+      ok_as_delegate: yes
+    register: result
+    failed_when: not result.changed
+
+  - name: Host "{{ host1_fqdn }}" present with ok_as_delegate again
+    ipahost:
+      ipaadmin_password: MyPassword123
+      name: "{{ host1_fqdn }}"
+      ok_as_delegate: yes
+    register: result
+    failed_when: result.changed
+
+  - name: Host "{{ host1_fqdn }}" present with ok_to_auth_as_delegate
+    ipahost:
+      ipaadmin_password: MyPassword123
+      name: "{{ host1_fqdn }}"
+      ok_to_auth_as_delegate: yes
+    register: result
+    failed_when: not result.changed
+
+  - name: Host "{{ host1_fqdn }}" present with ok_to_auth_as_delegate again
+    ipahost:
+      ipaadmin_password: MyPassword123
+      name: "{{ host1_fqdn }}"
+      ok_to_auth_as_delegate: yes
+    register: result
+    failed_when: result.changed
+
+  - name: Host absent
+    ipahost:
+      ipaadmin_password: MyPassword123
+      name:
+      - "{{ host1_fqdn }}"
+      update_dns: yes
+      state: absent


### PR DESCRIPTION
…args_ipa

Bool types are not iterable. Therefore the comparison using sets was failing
with a TypeError. This prevented to change the bool parameters for hosts.

A test for the host module has been added to verify that the bool parameters
can be modified.

New test:

  tests/host/test_host_bool_params.yml

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1784514