### PR TITLE
tests: Fix top name tags in tests

### DIFF
--- a/tests/group/test_group.yml
+++ b/tests/group/test_group.yml
@@ -1,5 +1,5 @@
 ---
-- name: Tests
+- name: Test group
   hosts: ipaserver
   become: true
   gather_facts: false

--- a/tests/hbacrule/test_hbacrule.yml
+++ b/tests/hbacrule/test_hbacrule.yml
@@ -1,5 +1,5 @@
 ---
-- name: Playbook to handle hbacrules
+- name: Test hbacrule
   hosts: ipaserver
   become: true
 

--- a/tests/hbacsvc/test_hbacsvc.yml
+++ b/tests/hbacsvc/test_hbacsvc.yml
@@ -1,5 +1,5 @@
 ---
-- name: Tests
+- name: Test hbacsvc
   hosts: ipaserver
   become: true
   gather_facts: false

--- a/tests/hbacsvcgroup/test_hbacsvcgroup.yml
+++ b/tests/hbacsvcgroup/test_hbacsvcgroup.yml
@@ -1,5 +1,5 @@
 ---
-- name: Tests
+- name: Test hbacsvcgroup
   hosts: ipaserver
   become: true
   gather_facts: false

--- a/tests/hostgroup/test_hostgroup.yml
+++ b/tests/hostgroup/test_hostgroup.yml
@@ -1,5 +1,5 @@
 ---
-- name: Tests
+- name: Test hostgroup
   hosts: ipaserver
   become: true
   gather_facts: false

--- a/tests/pwpolicy/test_pwpolicy.yml
+++ b/tests/pwpolicy/test_pwpolicy.yml
@@ -1,5 +1,5 @@
 ---
-- name: Tests
+- name: Test pwpolicy
   hosts: ipaserver
   become: true
   gather_facts: false

--- a/tests/sudocmd/test_sudocmd.yml
+++ b/tests/sudocmd/test_sudocmd.yml
@@ -1,6 +1,6 @@
 ---
 
-- name: Tests
+- name: Test sudocmd
   hosts: ipaserver
   become: true
   gather_facts: false

--- a/tests/sudocmdgroup/test_sudocmdgroup.yml
+++ b/tests/sudocmdgroup/test_sudocmdgroup.yml
@@ -1,6 +1,6 @@
 ---
 
-- name: Tests
+- name: Test sudocmdgroup
   hosts: ipaserver
   become: true
   gather_facts: false

--- a/tests/sudorule/test_sudorule.yml
+++ b/tests/sudorule/test_sudorule.yml
@@ -1,6 +1,6 @@
 ---
 
-- name: Tests
+- name: Test sudorule
   hosts: ipaserver
   become: true
   gather_facts: false

--- a/tests/user/test_user.yml
+++ b/tests/user/test_user.yml
@@ -1,5 +1,5 @@
 ---
-- name: Tests
+- name: Test user
   hosts: ipaserver
   become: true
   gather_facts: false

--- a/tests/user/test_users.yml
+++ b/tests/user/test_users.yml
@@ -1,5 +1,5 @@
 ---
-- name: Tests
+- name: Test users
   hosts: ipaserver
   become: true
   gather_facts: false

--- a/tests/user/test_users_absent.yml
+++ b/tests/user/test_users_absent.yml
@@ -1,5 +1,5 @@
 ---
-- name: Tests
+- name: Test users absent
   hosts: ipaserver
   become: true
   gather_facts: false

--- a/tests/user/test_users_present.yml
+++ b/tests/user/test_users_present.yml
@@ -1,5 +1,5 @@
 ---
-- name: Tests
+- name: Test users present
   hosts: ipaserver
   become: true
   gather_facts: false

--- a/tests/user/test_users_present_slice.yml
+++ b/tests/user/test_users_present_slice.yml
@@ -1,5 +1,5 @@
 ---
-- name: Tests
+- name: Test users present slice
   hosts: ipaserver
   become: true
   gather_facts: false

--- a/tests/vault/test_vault.yml
+++ b/tests/vault/test_vault.yml
@@ -1,6 +1,6 @@
 ---
 
-- name: Tests
+- name: Test vault
   hosts: ipaserver
   become: true
   gather_facts: false


### PR DESCRIPTION
Most tests have simply been using the Tests as name, but this there is a
lack of information in automated runs. The name should be similar to the
test file name.