### PR TITLE
ipahost: Add support for several IP addresses and also to change them

### DIFF
--- a/README-host.md
+++ b/README-host.md
@@ -65,6 +65,79 @@ Example playbook to ensure host presence:
       - "52:54:00:BD:97:1E"
       state: present
 ```
+Compared to `ipa host-add` command no IP address conflict check is done as the ipahost module supports to have several IPv4 and IPv6 addresses for a host.
+
+
+Example playbook to ensure host presence with several IP addresses:
+
+```yaml
+---
+- name: Playbook to handle hosts
+  hosts: ipaserver
+  become: true
+
+  tasks:
+  # Ensure host is present
+  - ipahost:
+      ipaadmin_password: MyPassword123
+      name: host01.example.com
+      description: Example host
+      ip_address:
+      - 192.168.0.123
+      - 192.168.0.124
+      - fe80::20c:29ff:fe02:a1b3
+      - fe80::20c:29ff:fe02:a1b4
+      locality: Lab
+      ns_host_location: Lab
+      ns_os_version: CentOS 7
+      ns_hardware_platform: Lenovo T61
+      mac_address:
+      - "08:00:27:E3:B1:2D"
+      - "52:54:00:BD:97:1E"
+      state: present
+```
+
+
+Example playbook to ensure IP addresses are present for a host:
+
+```yaml
+---
+- name: Playbook to handle hosts
+  hosts: ipaserver
+  become: true
+
+  tasks:
+  # Ensure host is present
+  - ipahost:
+      ipaadmin_password: MyPassword123
+      name: host01.example.com
+      ip_address:
+      - 192.168.0.124
+      - fe80::20c:29ff:fe02:a1b4
+      action: member
+      state: present
+```
+
+
+Example playbook to ensure IP addresses are absent for a host:
+
+```yaml
+---
+- name: Playbook to handle hosts
+  hosts: ipaserver
+  become: true
+
+  tasks:
+  # Ensure host is present
+  - ipahost:
+      ipaadmin_password: MyPassword123
+      name: host01.example.com
+      ip_address:
+      - 192.168.0.124
+      - fe80::20c:29ff:fe02:a1b4
+      action: member
+      state: absent
+```
 
 
 Example playbook to ensure host presence without DNS:
@@ -215,7 +288,7 @@ Example playbook to disable a host:
       update_dns: yes
       state: disabled
 ```
-`update_dns` controls if the DNS entries will be updated.
+`update_dns` controls if the DNS entries will be updated in this case. For `state` present it is controlling the update of the DNS SSHFP records, but not the the other DNS records.
 
 
 Example playbook to ensure a host is absent:
@@ -286,8 +359,8 @@ Variable | Description | Required
 `ok_to_auth_as_delegate` \| `ipakrboktoauthasdelegate` | The service is allowed to authenticate on behalf of a client (bool) | no
 `force` | Force host name even if not in DNS. | no
 `reverse` | Reverse DNS detection. | no
-`ip_address` \| `ipaddress` | The host IP address. | no
-`update_dns` | Update DNS entries. | no
+`ip_address` \| `ipaddress` | The host IP address list. It can contain IPv4 and IPv6 addresses. No conflict check for IP addresses is done. | no
+`update_dns` | For existing hosts: DNS SSHFP records are updated with `state` present and all DNS entries for a host removed with `state` absent. | no
 
 
 Return Values

--- a/playbooks/host/host-member-ipaddresses-absent.yml
+++ b/playbooks/host/host-member-ipaddresses-absent.yml
@@ -1,0 +1,17 @@
+---
+- name: Host member IP addresses absent
+  hosts: ipaserver
+  become: true
+
+  tasks:
+  - name: Ensure host01.example.com IP addresses absent
+    ipahost:
+      ipaadmin_password: MyPassword123
+      name: host01.example.com
+      ip_address:
+      - 192.168.0.123
+      - fe80::20c:29ff:fe02:a1b3
+      - 192.168.0.124
+      - fe80::20c:29ff:fe02:a1b4
+      action: member
+      state: absent

--- a/playbooks/host/host-member-ipaddresses-present.yml
+++ b/playbooks/host/host-member-ipaddresses-present.yml
@@ -1,0 +1,16 @@
+---
+- name: Host member IP addresses present
+  hosts: ipaserver
+  become: true
+
+  tasks:
+  - name: Ensure host01.example.com IP addresses present
+    ipahost:
+      ipaadmin_password: MyPassword123
+      name: host01.example.com
+      ip_address:
+      - 192.168.0.123
+      - fe80::20c:29ff:fe02:a1b3
+      - 192.168.0.124
+      - fe80::20c:29ff:fe02:a1b4
+      action: member

--- a/playbooks/host/host-present-with-several-ip-addresses.yml
+++ b/playbooks/host/host-present-with-several-ip-addresses.yml
@@ -1,0 +1,24 @@
+---
+- name: Host present with several IP addresses
+  hosts: ipaserver
+  become: true
+
+  tasks:
+  - name: Ensure host is present
+    ipahost:
+      ipaadmin_password: MyPassword123
+      name: host01.example.com
+      description: Example host
+      ip_address:
+      - 192.168.0.123
+      - fe80::20c:29ff:fe02:a1b3
+      - 192.168.0.124
+      - fe80::20c:29ff:fe02:a1b4
+      locality: Lab
+      ns_host_location: Lab
+      ns_os_version: CentOS 7
+      ns_hardware_platform: Lenovo T61
+      mac_address:
+      - "08:00:27:E3:B1:2D"
+      - "52:54:00:BD:97:1E"
+      state: present

--- a/plugins/module_utils/ansible_freeipa_module.py
+++ b/plugins/module_utils/ansible_freeipa_module.py
@@ -42,6 +42,7 @@ try:
     from ipalib.x509 import Encoding
 except ImportError:
     from cryptography.hazmat.primitives.serialization import Encoding
+import socket
 import base64
 import six
 
@@ -285,3 +286,25 @@ def encode_certificate(cert):
     if not six.PY2:
         encoded = encoded.decode('ascii')
     return encoded
+
+
+def is_ipv4_addr(ipaddr):
+    """
+    Test if figen IP address is a valid IPv4 address
+    """
+    try:
+        socket.inet_pton(socket.AF_INET, ipaddr)
+    except socket.error:
+        return False
+    return True
+
+
+def is_ipv6_addr(ipaddr):
+    """
+    Test if figen IP address is a valid IPv6 address
+    """
+    try:
+        socket.inet_pton(socket.AF_INET6, ipaddr)
+    except socket.error:
+        return False
+    return True

--- a/tests/host/test_host.yml
+++ b/tests/host/test_host.yml
@@ -129,7 +129,7 @@
   - name: Host "{{ host5_fqdn }}" present again
     ipahost:
       ipaadmin_password: MyPassword123
-      name: "{{ host1_fqdn }}"
+      name: "{{ host5_fqdn }}"
       ip_address: "{{ ipv4_prefix + '.205' }}"
       update_dns: yes
       reverse: no

--- a/tests/host/test_host_ipaddresses.yml
+++ b/tests/host/test_host_ipaddresses.yml
@@ -1,0 +1,312 @@
+---
+- name: Test host IP addresses
+  hosts: ipaserver
+  become: true
+
+  tasks:
+  - name: Get Domain from server name
+    set_fact:
+      ipaserver_domain: "{{ groups.ipaserver[0].split('.')[1:] | join ('.') }}"
+    when: ipaserver_domain is not defined
+
+  - name: Set host1_fqdn .. host6_fqdn
+    set_fact:
+      host1_fqdn: "{{ 'host1.' + ipaserver_domain }}"
+      host2_fqdn: "{{ 'host2.' + ipaserver_domain }}"
+      host3_fqdn: "{{ 'host3.' + ipaserver_domain }}"
+
+  - name: Get IPv4 address prefix from server node
+    set_fact:
+      ipv4_prefix: "{{ ansible_default_ipv4.address.split('.')[:-1] |
+                       join('.') }}"
+
+  - name: Host absent
+    ipahost:
+      ipaadmin_password: MyPassword123
+      name:
+      - "{{ host1_fqdn }}"
+      - "{{ host2_fqdn }}"
+      - "{{ host3_fqdn }}"
+      update_dns: yes
+      state: absent
+
+  - name: Host "{{ host1_fqdn }}" present
+    ipahost:
+      ipaadmin_password: MyPassword123
+      name: "{{ host1_fqdn }}"
+      ip_address:
+      - "{{ ipv4_prefix + '.201' }}"
+      - fe80::20c:29ff:fe02:a1b2
+      update_dns: yes
+      reverse: no
+    register: result
+    failed_when: not result.changed
+
+  - name: Host "{{ host1_fqdn }}" present again
+    ipahost:
+      ipaadmin_password: MyPassword123
+      name: "{{ host1_fqdn }}"
+      ip_address:
+      - "{{ ipv4_prefix + '.201' }}"
+      - fe80::20c:29ff:fe02:a1b2
+      update_dns: yes
+      reverse: no
+    register: result
+    failed_when: result.changed
+
+  - name: Host "{{ host1_fqdn }}" present again with new IP address
+    ipahost:
+      ipaadmin_password: MyPassword123
+      name: "{{ host1_fqdn }}"
+      ip_address:
+      - "{{ ipv4_prefix + '.211' }}"
+      - fe80::20c:29ff:fe02:a1b3
+      - "{{ ipv4_prefix + '.221' }}"
+      - fe80::20c:29ff:fe02:a1b4
+      update_dns: yes
+      reverse: no
+    register: result
+    failed_when: not result.changed
+
+  - name: Host "{{ host1_fqdn }}" present again with new IP address again
+    ipahost:
+      ipaadmin_password: MyPassword123
+      name: "{{ host1_fqdn }}"
+      ip_address:
+      - "{{ ipv4_prefix + '.211' }}"
+      - fe80::20c:29ff:fe02:a1b3
+      - "{{ ipv4_prefix + '.221' }}"
+      - fe80::20c:29ff:fe02:a1b4
+      update_dns: yes
+      reverse: no
+    register: result
+    failed_when: result.changed
+
+  - name: Host "{{ host1_fqdn }}" member IPv4 address present
+    ipahost:
+      ipaadmin_password: MyPassword123
+      name: "{{ host1_fqdn }}"
+      ip_address: "{{ ipv4_prefix + '.201' }}"
+      action: member
+    register: result
+    failed_when: not result.changed
+
+  - name: Host "{{ host1_fqdn }}" member IPv4 address present again
+    ipahost:
+      ipaadmin_password: MyPassword123
+      name: "{{ host1_fqdn }}"
+      ip_address: "{{ ipv4_prefix + '.201' }}"
+      action: member
+    register: result
+    failed_when: result.changed
+
+  - name: Host "{{ host1_fqdn }}" member IPv4 address absent
+    ipahost:
+      ipaadmin_password: MyPassword123
+      name: "{{ host1_fqdn }}"
+      ip_address: "{{ ipv4_prefix + '.201' }}"
+      action: member
+      state: absent
+    register: result
+    failed_when: not result.changed
+
+  - name: Host "{{ host1_fqdn }}" member IPv4 address absent again
+    ipahost:
+      ipaadmin_password: MyPassword123
+      name: "{{ host1_fqdn }}"
+      ip_address: "{{ ipv4_prefix + '.201' }}"
+      action: member
+      state: absent
+    register: result
+    failed_when: result.changed
+
+  - name: Host "{{ host1_fqdn }}" member IPv6 address present
+    ipahost:
+      ipaadmin_password: MyPassword123
+      name: "{{ host1_fqdn }}"
+      ip_address: fe80::20c:29ff:fe02:a1b2
+      action: member
+    register: result
+    failed_when: not result.changed
+
+  - name: Host "{{ host1_fqdn }}" member IPv6 address present again
+    ipahost:
+      ipaadmin_password: MyPassword123
+      name: "{{ host1_fqdn }}"
+      ip_address: fe80::20c:29ff:fe02:a1b2
+      action: member
+    register: result
+    failed_when: result.changed
+
+  - name: Host "{{ host1_fqdn }}" member IPv6 address absent
+    ipahost:
+      ipaadmin_password: MyPassword123
+      name: "{{ host1_fqdn }}"
+      ip_address: fe80::20c:29ff:fe02:a1b2
+      action: member
+      state: absent
+    register: result
+    failed_when: not result.changed
+
+  - name: Host "{{ host1_fqdn }}" member IPv6 address absent again
+    ipahost:
+      ipaadmin_password: MyPassword123
+      name: "{{ host1_fqdn }}"
+      ip_address: fe80::20c:29ff:fe02:a1b2
+      action: member
+      state: absent
+    register: result
+
+  - name: Host "{{ host1_fqdn }}" member all ip-addresses absent
+    ipahost:
+      ipaadmin_password: MyPassword123
+      name: "{{ host1_fqdn }}"
+      ip_address:
+      - "{{ ipv4_prefix + '.211' }}"
+      - fe80::20c:29ff:fe02:a1b3
+      - "{{ ipv4_prefix + '.221' }}"
+      - fe80::20c:29ff:fe02:a1b4
+      action: member
+      state: absent
+    register: result
+    failed_when: not result.changed
+
+  - name: Host "{{ host1_fqdn }}" all member ip-addresses absent again
+    ipahost:
+      ipaadmin_password: MyPassword123
+      name: "{{ host1_fqdn }}"
+      ip_address:
+      - "{{ ipv4_prefix + '.211' }}"
+      - fe80::20c:29ff:fe02:a1b3
+      - "{{ ipv4_prefix + '.221' }}"
+      - fe80::20c:29ff:fe02:a1b4
+      action: member
+      state: absent
+    register: result
+    failed_when: result.changed
+
+  - name: Hosts "{{ host1_fqdn }}" and "{{ host2_fqdn }}" present with same IP addresses
+    ipahost:
+      ipaadmin_password: MyPassword123
+      hosts:
+      - name: "{{ host1_fqdn }}"
+        ip_address:
+        - "{{ ipv4_prefix + '.211' }}"
+        - fe80::20c:29ff:fe02:a1b3
+        - "{{ ipv4_prefix + '.221' }}"
+        - fe80::20c:29ff:fe02:a1b4
+      - name: "{{ host2_fqdn }}"
+        ip_address:
+        - "{{ ipv4_prefix + '.211' }}"
+        - fe80::20c:29ff:fe02:a1b3
+        - "{{ ipv4_prefix + '.221' }}"
+        - fe80::20c:29ff:fe02:a1b4
+    register: result
+    failed_when: not result.changed
+
+  - name: Hosts "{{ host1_fqdn }}" and "{{ host2_fqdn }}" present with same IP addresses again
+    ipahost:
+      ipaadmin_password: MyPassword123
+      hosts:
+      - name: "{{ host1_fqdn }}"
+        ip_address:
+        - "{{ ipv4_prefix + '.211' }}"
+        - fe80::20c:29ff:fe02:a1b3
+        - "{{ ipv4_prefix + '.221' }}"
+        - fe80::20c:29ff:fe02:a1b4
+      - name: "{{ host2_fqdn }}"
+        ip_address:
+        - "{{ ipv4_prefix + '.211' }}"
+        - fe80::20c:29ff:fe02:a1b3
+        - "{{ ipv4_prefix + '.221' }}"
+        - fe80::20c:29ff:fe02:a1b4
+    register: result
+    failed_when: result.changed
+
+  - name: Hosts "{{ host3_fqdn }}" present with same IP addresses
+    ipahost:
+      ipaadmin_password: MyPassword123
+      hosts:
+      - name: "{{ host3_fqdn }}"
+        ip_address:
+        - "{{ ipv4_prefix + '.211' }}"
+        - fe80::20c:29ff:fe02:a1b3
+        - "{{ ipv4_prefix + '.221' }}"
+        - fe80::20c:29ff:fe02:a1b4
+    register: result
+    failed_when: not result.changed
+
+  - name: Hosts "{{ host3_fqdn }}" present with same IP addresses again
+    ipahost:
+      ipaadmin_password: MyPassword123
+      hosts:
+      - name: "{{ host3_fqdn }}"
+        ip_address:
+        - "{{ ipv4_prefix + '.211' }}"
+        - fe80::20c:29ff:fe02:a1b3
+        - "{{ ipv4_prefix + '.221' }}"
+        - fe80::20c:29ff:fe02:a1b4
+    register: result
+    failed_when: result.changed
+
+  - name: Host "{{ host3_fqdn }}" present with differnt IP addresses
+    ipahost:
+      ipaadmin_password: MyPassword123
+      hosts:
+      - name: "{{ host3_fqdn }}"
+        ip_address:
+        - "{{ ipv4_prefix + '.111' }}"
+        - fe80::20c:29ff:fe02:a1b1
+        - "{{ ipv4_prefix + '.121' }}"
+        - fe80::20c:29ff:fe02:a1b2
+    register: result
+    failed_when: not result.changed
+
+  - name: Host "{{ host3_fqdn }}" present with different IP addresses again
+    ipahost:
+      ipaadmin_password: MyPassword123
+      hosts:
+      - name: "{{ host3_fqdn }}"
+        ip_address:
+        - "{{ ipv4_prefix + '.111' }}"
+        - fe80::20c:29ff:fe02:a1b1
+        - "{{ ipv4_prefix + '.121' }}"
+        - fe80::20c:29ff:fe02:a1b2
+    register: result
+    failed_when: result.changed
+
+  - name: Host "{{ host3_fqdn }}" present with old IP addresses
+    ipahost:
+      ipaadmin_password: MyPassword123
+      hosts:
+      - name: "{{ host3_fqdn }}"
+        ip_address:
+        - "{{ ipv4_prefix + '.211' }}"
+        - fe80::20c:29ff:fe02:a1b3
+        - "{{ ipv4_prefix + '.221' }}"
+        - fe80::20c:29ff:fe02:a1b4
+    register: result
+    failed_when: not result.changed
+
+  - name: Host "{{ host3_fqdn }}" present with old IP addresses again
+    ipahost:
+      ipaadmin_password: MyPassword123
+      hosts:
+      - name: "{{ host3_fqdn }}"
+        ip_address:
+        - "{{ ipv4_prefix + '.211' }}"
+        - fe80::20c:29ff:fe02:a1b3
+        - "{{ ipv4_prefix + '.221' }}"
+        - fe80::20c:29ff:fe02:a1b4
+    register: result
+    failed_when: result.changed
+
+  - name: Host absent
+    ipahost:
+      ipaadmin_password: MyPassword123
+      name:
+      - "{{ host1_fqdn }}"
+      - "{{ host2_fqdn }}"
+      - "{{ host3_fqdn }}"
+      update_dns: yes
+      state: absent


### PR DESCRIPTION
ipahost was so far ignoring IP addresses when the host already existed.
This happened because host_mod is not providing functionality to do this.
Now ipaddress is a list and it is possible to ensure a host with several
IP addresses (these can be IPv4 and IPv6). Also it is possible to ensure
presence and absence of IP addresses for an exising host using action
member.

There are no IP address conclict checks as this would lead into issues with
updating an existing host that already is using a duplicate IP address for
example for round-robin (RR). Also this might lead into issues with ensuring
a new host with several IP addresses in this case. Also to ensure a list of
hosts with changing the IP address of one host to another in the list would
result in issues here.

New example playbooks have been added:

    playbooks/host/host-present-with-several-ip-addresses.yml
    playbooks/host/host-member-ipaddresses-absent.yml
    playbooks/host/host-member-ipaddresses-present.yml

A new test has been added for verification:

    tests/host/test_host_ipaddresses.yml

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1783976
       https://bugzilla.redhat.com/show_bug.cgi?id=1783979