### PR TITLE
Modify roles README for consistency.

### DIFF
--- a/roles/ipareplica/README.md
+++ b/roles/ipareplica/README.md
@@ -47,60 +47,72 @@ Usage
 
 Example inventory file with fixed principal using auto-discovery with DNS records:
 
-    [ipareplicas]
-    ipareplica1.example.com
-    ipareplica2.example.com
-    
-    [ipareplicas:vars]
-    ipaadmin_principal=admin
+```ini
+[ipareplicas]
+ipareplica1.example.com
+ipareplica2.example.com
+
+[ipareplicas:vars]
+ipaadmin_principal=admin
+```
 
 Example playbook to setup the IPA client(s) using principal from inventory file and password from an [Ansible Vault](http://docs.ansible.com/ansible/latest/playbooks_vault.html) file:
 
-    - name: Playbook to configure IPA replicas
-      hosts: ipareplicas
-      become: true
-      vars_files:
-      - playbook_sensitive_data.yml
-    
-      roles:
-      - role: ipareplica
-        state: present
+```yaml
+---
+- name: Playbook to configure IPA replicas
+  hosts: ipareplicas
+  become: true
+  vars_files:
+  - playbook_sensitive_data.yml
+
+  roles:
+  - role: ipareplica
+    state: present
+```
 
 Example playbook to unconfigure the IPA client(s) using principal and password from inventory file:
 
-    - name: Playbook to unconfigure IPA replicas
-      hosts: ipareplicas
-      become: true
-    
-      roles:
-      - role: ipareplica
-        state: absent
+```yaml
+---
+- name: Playbook to unconfigure IPA replicas
+  hosts: ipareplicas
+  become: true
+
+  roles:
+  - role: ipareplica
+    state: absent
+```
 
 Example inventory file with fixed server, principal, password and domain:
 
-    [ipaserver]
-    ipaserver.example.com
-    
-    [ipareplicas]
-    ipareplica1.example.com
-    ipareplica2.example.com
-    
-    [ipareplicas:vars]
-    ipaclient_domain=example.com
-    ipaadmin_principal=admin
-    ipaadmin_password=MySecretPassword123
-    ipadm_password=MySecretPassword456
+```ini
+[ipaserver]
+ipaserver.example.com
+
+[ipareplicas]
+ipareplica1.example.com
+ipareplica2.example.com
+
+[ipareplicas:vars]
+ipaclient_domain=example.com
+ipaadmin_principal=admin
+ipaadmin_password=MySecretPassword123
+ipadm_password=MySecretPassword456
+```
 
 Example playbook to setup the IPA client(s) using principal and password from inventory file:
 
-    - name: Playbook to configure IPA replicas with username/password
-      hosts: ipareplicas
-      become: true
-    
-      roles:
-      - role: ipareplica
-        state: present
+```yaml
+---
+- name: Playbook to configure IPA replicas with username/password
+  hosts: ipareplicas
+  become: true
 
+  roles:
+  - role: ipareplica
+    state: present
+```
 
 Playbooks
 =========

--- a/roles/ipaserver/README.md
+++ b/roles/ipaserver/README.md
@@ -42,8 +42,7 @@ Requirements
 Limitations
 -----------
 
-External signed CA
-
+**External signed CA**
 External signed CA is now supported. But the currently needed two step process is an issue for the processing in a simple playbook.
 
 Work is planned to have a new method to handle CSR for external signed CAs in a separate step before starting the server installation.
@@ -54,57 +53,70 @@ Usage
 
 Example inventory file with fixed domain and realm, setting up of the DNS server and using forwarders from /etc/resolv.conf:
 
-    [ipaserver]
-    ipaserver2.example.com
-    
-    [ipaserver:vars]
-    ipaserver_domain=example.com
-    ipaserver_realm=EXAMPLE.COM
-    ipaserver_setup_dns=yes
-    ipaserver_auto_forwarders=yes
+```ini
+[ipaserver]
+ipaserver2.example.com
+
+[ipaserver:vars]
+ipaserver_domain=example.com
+ipaserver_realm=EXAMPLE.COM
+ipaserver_setup_dns=yes
+ipaserver_auto_forwarders=yes
+```
 
 Example playbook to setup the IPA server using admin and dirman passwords from an [Ansible Vault](http://docs.ansible.com/ansible/latest/playbooks_vault.html) file:
 
-    - name: Playbook to configure IPA server
-      hosts: ipaserver
-      become: true
-      vars_files:
-      - playbook_sensitive_data.yml
-    
-      roles:
-      - role: ipaserver
-        state: present
+```yaml
+---
+- name: Playbook to configure IPA server
+  hosts: ipaserver
+  become: true
+  vars_files:
+  - playbook_sensitive_data.yml
+
+  roles:
+  - role: ipaserver
+    state: present
+```
 
 Example playbook to unconfigure the IPA client(s) using principal and password from inventory file:
 
-    - name: Playbook to unconfigure IPA server
-      hosts: ipaserver
-      become: true
-    
-      roles:
-      - role: ipaserver
-        state: absent
+```yaml
+---
+- name: Playbook to unconfigure IPA server
+  hosts: ipaserver
+  become: true
+
+  roles:
+  - role: ipaserver
+    state: absent
+```
 
 Example inventory file with fixed domain, realm, admin and dirman passwords:
 
-    [ipaserver]
-    ipaserver.example.com
-    
-    [ipaserver:vars]
-    ipaserver_domain=example.com
-    ipaserver_realm=EXAMPLE.COM
-    ipaadmin_password=MySecretPassword123
-    ipadm_password=MySecretPassword234
+```ini
+[ipaserver]
+ipaserver.example.com
+
+[ipaserver:vars]
+ipaserver_domain=example.com
+ipaserver_realm=EXAMPLE.COM
+ipaadmin_password=MySecretPassword123
+ipadm_password=MySecretPassword234
+```
 
 Example playbook to setup the IPA server using admin and dirman passwords from inventory file:
 
-    - name: Playbook to configure IPA server
-      hosts: ipaserver
-      become: true
-    
-      roles:
-      - role: ipaserver
-        state: present
+```yaml
+---
+- name: Playbook to configure IPA server
+  hosts: ipaserver
+  become: true
+
+  roles:
+  - role: ipaserver
+    state: present
+```
 
 Example playbook to setup the IPA primary with external signed CA using the previous inventory file:
 
@@ -135,6 +147,7 @@ Sign with CA: This is up to you
 Server installation step 2: Copy `<ipaserver hostname>-chain.crt` to the IPA server and continue with installation of the primary.
 
 ```yaml
+---
 - name: Playbook to configure IPA server step3
   hosts: ipaserver
   become: true


### PR DESCRIPTION
Modify examples in server and replica roles for consistency with client
role, by defining language for code blocks.