### PR TITLE
ipahost: Do not fail on missing DNS or zone when no IP address given

### DIFF
--- a/plugins/module_utils/ansible_freeipa_module.py
+++ b/plugins/module_utils/ansible_freeipa_module.py
@@ -28,6 +28,7 @@ import shutil
 import gssapi
 from datetime import datetime
 from ipalib import api
+from ipalib import errors as ipalib_errors
 from ipalib.config import Env
 from ipalib.constants import DEFAULT_CONFIG, LDAP_GENERALIZED_TIME_FORMAT
 try:

--- a/tests/host/test_host_ipaddresses.yml
+++ b/tests/host/test_host_ipaddresses.yml
@@ -301,6 +301,15 @@
     register: result
     failed_when: result.changed
 
+  - name: Absent host01.ihavenodns.info test
+    ipahost:
+      ipaadmin_password: MyPassword123
+      hosts:
+      - name: host01.ihavenodns.info
+      state: absent
+    register: result
+    failed_when: result.changed
+
   - name: Host absent
     ipahost:
       ipaadmin_password: MyPassword123


### PR DESCRIPTION
If no IP address is given and either DNS is not configured or if the zone is
not found then ipahost may not fail in dnsrecord_find.

The error happened for example by ensuring the absence of a host that is not
part of the domain or for a host that has been added with force and is using
a domain that is not served by the DNS server in the domain. It also
happened if there was no DNS server in the domain at all.

A new test case has been added to test_host_ipaddresses.yml

The fix requires ipalib_errors provided by ansible_freeipa_module.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1804838

--

ansible_freeipa_module: Import ipalib.errors as ipalib_errors

For beeing able to catch ipalib.errors.NotFound errors in ipahost it is
needed to import ipalib.errors. ipalib.errors is now imported as
ipalib_errors to not have name conflicts with the errors list used in some
of the modules.

Related: https://bugzilla.redhat.com/show_bug.cgi?id=1804838
