### PR TITLE
test_pwpolicy: unite admin passwords

### DIFF
--- a/tests/pwpolicy/test_pwpolicy.yml
+++ b/tests/pwpolicy/test_pwpolicy.yml
@@ -94,7 +94,7 @@
 
   - name: Ensure maxlife of 90 for global_policy
     ipapwpolicy:
-      ipaadmin_password: MyPassword123
+      ipaadmin_password: SomeADMINpassword
       maxlife: 90
     register: result
     failed_when: not result.changed


### PR DESCRIPTION
One test did not use the admin password as the rest of the tests.
This caused the tests/pwpolicy/test_pwpolicy.yml suite to fail.

Changing the password to the same as in others fixes the issue.

Signed-off-by: Petr Vobornik <pvoborni@redhat.com>