### PR TITLE
added OracleLinux role variables for support

### DIFF
--- a/roles/ipaclient/vars/OracleLinux-7.yml
+++ b/roles/ipaclient/vars/OracleLinux-7.yml
@@ -1,0 +1,4 @@
+# defaults file for ipaclient
+# vars/OracleLinux-7.yml
+ipaclient_packages: [ "ipa-client", "libselinux-python" ]
+#ansible_python_interpreter: '/usr/bin/python2'

--- a/roles/ipareplica/vars/OracleLinux-7.yml
+++ b/roles/ipareplica/vars/OracleLinux-7.yml
@@ -1,0 +1,5 @@
+# defaults file for ipareplica
+# vars/OracleLinux-7.yml
+ipareplica_packages: [ "ipa-server", "libselinux-python" ]
+ipareplica_packages_dns: [ "ipa-server-dns" ]
+ipareplica_packages_adtrust: [ "ipa-server-trust-ad" ]

--- a/roles/ipaserver/vars/OracleLinux-7.yml
+++ b/roles/ipaserver/vars/OracleLinux-7.yml
@@ -1,0 +1,5 @@
+# defaults file for ipaserver
+# vars/OracleLinux-7.yml
+ipaserver_packages: [ "ipa-server", "libselinux-python"]
+ipaserver_packages_dns: [ "ipa-server-dns" ]
+ipaserver_packages_adtrust: [ "ipa-server-trust-ad" ]


### PR DESCRIPTION
By default ansible will use CentOS role variables if ran against an
Oracle Linux instance. This will fail the install as the package names
do not match. Instead Oracle Linux packages are equivalent to its Red
Hat counterpart.