### PR TITLE
Handle RuntimeError in fail_json

### DIFF
--- a/roles/ipaserver/library/ipaserver_test.py
+++ b/roles/ipaserver/library/ipaserver_test.py
@@ -211,6 +211,7 @@ import inspect
 import random
 
 from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils._text import to_native
 from ansible.module_utils.ansible_ipa_server import (
     AnsibleModuleLog, options, adtrust_imported, kra_imported, PKIIniLoader,
     MIN_DOMAIN_LEVEL, MAX_DOMAIN_LEVEL, check_zone_overlap,
@@ -583,7 +584,7 @@ def main():
                         "--auto-forwarders, or --no-forwarders options")
 
     except RuntimeError as e:
-        ansible_module.fail_json(msg=e)
+        ansible_module.fail_json(msg=to_native(e))
 
     # #######################################################################
 


### PR DESCRIPTION
##### SUMMARY

Gracefully handle RuntimeError raised during parameter validation
in fail_json.

Fixes: #115

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
roles/ipaserver/library/ipaserver_test.py
