### PR TITLE
ipa[server,replica,client]: setup_logging wrapper for standard_logging setup

### DIFF
--- a/roles/ipaclient/library/ipaclient_api.py
+++ b/roles/ipaclient/library/ipaclient_api.py
@@ -76,6 +76,7 @@ import inspect
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.ansible_ipa_client import (
+    setup_logging,
     paths, x509, NUM_VERSION, serialization, certdb, api,
     delete_persistent_client_session_data, write_tmp_file,
     ipa_generate_password, CalledProcessError, errors, disable_ra, DN,
@@ -95,6 +96,8 @@ def main():
     )
 
     module._ansible_debug = True
+    setup_logging()
+
     realm = module.params.get('realm')
     hostname = module.params.get('hostname')
     servers = module.params.get('servers')

--- a/roles/ipaclient/library/ipaclient_fix_ca.py
+++ b/roles/ipaclient/library/ipaclient_fix_ca.py
@@ -67,6 +67,7 @@ import os
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.ansible_ipa_client import (
+    setup_logging,
     SECURE_PATH, paths, sysrestore, options, NUM_VERSION, get_ca_cert,
     get_ca_certs, errors
 )
@@ -83,6 +84,8 @@ def main():
     )
 
     module._ansible_debug = True
+    setup_logging()
+
     servers = module.params.get('servers')
     realm = module.params.get('realm')
     basedn = module.params.get('basedn')

--- a/roles/ipaclient/library/ipaclient_fstore.py
+++ b/roles/ipaclient/library/ipaclient_fstore.py
@@ -53,7 +53,7 @@ RETURN = '''
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.ansible_ipa_client import (
-    paths, sysrestore
+    setup_logging, paths, sysrestore
 )
 
 
@@ -65,6 +65,8 @@ def main():
     )
 
     module._ansible_debug = True
+    setup_logging()
+
     backup = module.params.get('backup')
 
     fstore = sysrestore.FileStore(paths.IPA_CLIENT_SYSRESTORE)

--- a/roles/ipaclient/library/ipaclient_ipa_conf.py
+++ b/roles/ipaclient/library/ipaclient_ipa_conf.py
@@ -70,7 +70,7 @@ RETURN = '''
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.ansible_ipa_client import (
-    paths, sysrestore, configure_ipa_conf
+    setup_logging, paths, sysrestore, configure_ipa_conf
 )
 
 
@@ -87,6 +87,8 @@ def main():
     )
 
     module._ansible_debug = True
+    setup_logging()
+
     servers = module.params.get('servers')
     domain = module.params.get('domain')
     realm = module.params.get('realm')

--- a/roles/ipaclient/library/ipaclient_join.py
+++ b/roles/ipaclient/library/ipaclient_join.py
@@ -127,6 +127,7 @@ import tempfile
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.ansible_ipa_client import (
+    setup_logging,
     SECURE_PATH, sysrestore, paths, options, configure_krb5_conf,
     realm_to_suffix, kinit_keytab, GSSError, kinit_password, NUM_VERSION,
     get_ca_cert, get_ca_certs, errors, run
@@ -155,6 +156,8 @@ def main():
     )
 
     module._ansible_debug = True
+    setup_logging()
+
     servers = module.params.get('servers')
     domain = module.params.get('domain')
     realm = module.params.get('realm')

--- a/roles/ipaclient/library/ipaclient_set_hostname.py
+++ b/roles/ipaclient/library/ipaclient_set_hostname.py
@@ -54,7 +54,7 @@ RETURN = '''
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.ansible_ipa_client import (
-    sysrestore, paths, tasks
+    setup_logging, sysrestore, paths, tasks
 )
 
 
@@ -67,6 +67,8 @@ def main():
     )
 
     module._ansible_debug = True
+    setup_logging()
+
     hostname = module.params.get('hostname')
 
     fstore = sysrestore.FileStore(paths.IPA_CLIENT_SYSRESTORE)

--- a/roles/ipaclient/library/ipaclient_setup_automount.py
+++ b/roles/ipaclient/library/ipaclient_setup_automount.py
@@ -60,7 +60,7 @@ RETURN = '''
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.ansible_ipa_client import (
-    options, configure_automount
+    setup_logging, options, configure_automount
 )
 
 
@@ -77,6 +77,8 @@ def main():
     # os.environ['KRB5CCNAME'] = paths.IPA_DNS_CCACHE
 
     module._ansible_debug = True
+    setup_logging()
+
     options.servers = module.params.get('servers')
     options.server = options.servers
     options.sssd = module.params.get('sssd')

--- a/roles/ipaclient/library/ipaclient_setup_firefox.py
+++ b/roles/ipaclient/library/ipaclient_setup_firefox.py
@@ -60,7 +60,7 @@ RETURN = '''
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.ansible_ipa_client import (
-    sysrestore, paths, options, configure_firefox
+    setup_logging, sysrestore, paths, options, configure_firefox
 )
 
 
@@ -74,6 +74,8 @@ def main():
     )
 
     module._ansible_debug = True
+    setup_logging()
+
     domain = module.params.get('domain')
     options.firefox_dir = module.params.get('firefox_dir')
 

--- a/roles/ipaclient/library/ipaclient_setup_krb5.py
+++ b/roles/ipaclient/library/ipaclient_setup_krb5.py
@@ -81,7 +81,7 @@ RETURN = '''
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.ansible_ipa_client import (
-    sysrestore, paths, configure_krb5_conf, logger
+    setup_logging, sysrestore, paths, configure_krb5_conf, logger
 )
 
 
@@ -103,6 +103,8 @@ def main():
     )
 
     module._ansible_debug = True
+    setup_logging()
+
     servers = module.params.get('servers')
     domain = module.params.get('domain')
     realm = module.params.get('realm')

--- a/roles/ipaclient/library/ipaclient_setup_nis.py
+++ b/roles/ipaclient/library/ipaclient_setup_nis.py
@@ -58,7 +58,7 @@ import inspect
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.ansible_ipa_client import (
-    options,  sysrestore, paths, configure_nisdomain
+    setup_logging, options, sysrestore, paths, configure_nisdomain
 )
 
 
@@ -72,6 +72,8 @@ def main():
     )
 
     module._ansible_debug = True
+    setup_logging()
+
     domain = module.params.get('domain')
     options.nisdomain = module.params.get('nisdomain')
 

--- a/roles/ipaclient/library/ipaclient_setup_nss.py
+++ b/roles/ipaclient/library/ipaclient_setup_nss.py
@@ -138,6 +138,7 @@ import inspect
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.ansible_ipa_client import (
+    setup_logging,
     options, sysrestore, paths, ansible_module_get_parsed_ip_addresses,
     api, errors, create_ipa_nssdb, ipautil, ScriptError, CLIENT_INSTALL_ERROR,
     get_certs_from_ldap, DN, certstore, x509, logger, certdb,
@@ -179,6 +180,8 @@ def main():
     )
 
     module._ansible_debug = True
+    setup_logging()
+
     cli_server = module.params.get('servers')
     cli_realm = module.params.get('realm')
     hostname = module.params.get('hostname')

--- a/roles/ipaclient/library/ipaclient_setup_ntp.py
+++ b/roles/ipaclient/library/ipaclient_setup_ntp.py
@@ -67,6 +67,7 @@ import inspect
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.ansible_ipa_client import (
+    setup_logging,
     options, sysrestore, paths, sync_time, logger, ipadiscovery,
     timeconf
 )
@@ -89,6 +90,8 @@ def main():
     )
 
     # module._ansible_debug = True
+    setup_logging()
+
     options.ntp_servers = module.params.get('ntp_servers')
     options.ntp_pool = module.params.get('ntp_pool')
     options.no_ntp = module.params.get('no_ntp')

--- a/roles/ipaclient/library/ipaclient_setup_ssh.py
+++ b/roles/ipaclient/library/ipaclient_setup_ssh.py
@@ -68,6 +68,7 @@ RETURN = '''
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.ansible_ipa_client import (
+    setup_logging,
     options, sysrestore, paths, configure_ssh_config, configure_sshd_config
 )
 
@@ -85,6 +86,8 @@ def main():
     )
 
     module._ansible_debug = True
+    setup_logging()
+
     options.servers = module.params.get('servers')
     options.server = options.servers
     options.no_ssh = module.params.get('no_ssh')

--- a/roles/ipaclient/library/ipaclient_setup_sssd.py
+++ b/roles/ipaclient/library/ipaclient_setup_sssd.py
@@ -101,7 +101,7 @@ RETURN = '''
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.ansible_ipa_client import (
-    options, sysrestore, paths, configure_sssd_conf, logger
+    setup_logging, options, sysrestore, paths, configure_sssd_conf, logger
 )
 
 
@@ -130,6 +130,8 @@ def main():
     # options.set_logger(ansible_log)
 
     module._ansible_debug = True
+    setup_logging()
+
     cli_server = module.params.get('servers')
     cli_domain = module.params.get('domain')
     cli_realm = module.params.get('realm')

--- a/roles/ipaclient/library/ipaclient_test.py
+++ b/roles/ipaclient/library/ipaclient_test.py
@@ -199,6 +199,7 @@ except ImportError:
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.ansible_ipa_client import (
+    setup_logging,
     paths, sysrestore, options, CheckedIPAddress, validate_domain_name,
     logger, x509, normalize_hostname, installer, version, ScriptError,
     CLIENT_INSTALL_ERROR, tasks, check_ldap_conf, timeconf, constants,
@@ -290,6 +291,8 @@ def main():
     )
 
     # module._ansible_debug = True
+    setup_logging()
+
     options.domain_name = module.params.get('domain')
     options.servers = module.params.get('servers')
     options.realm_name = module.params.get('realm')

--- a/roles/ipaclient/library/ipaclient_test_keytab.py
+++ b/roles/ipaclient/library/ipaclient_test_keytab.py
@@ -103,6 +103,7 @@ import tempfile
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.ansible_ipa_client import (
+    setup_logging,
     SECURE_PATH, paths, kinit_keytab, run, GSSError, configure_krb5_conf
 )
 
@@ -121,6 +122,8 @@ def main():
     )
 
     module._ansible_debug = True
+    setup_logging()
+
     servers = module.params.get('servers')
     domain = module.params.get('domain')
     realm = module.params.get('realm')

--- a/roles/ipaclient/module_utils/ansible_ipa_client.py
+++ b/roles/ipaclient/module_utils/ansible_ipa_client.py
@@ -259,15 +259,18 @@ if NUM_VERSION >= 40400:
         sssd_enable_ifp = None
 
     logger = logging.getLogger("ipa-client-install")
-    standard_logging_setup(
-        paths.IPACLIENT_INSTALL_LOG, verbose=False, debug=False,
-        filemode='a', console_format='%(message)s')
     root_logger = logger
 
 else:
     # IPA version < 4.4
 
     raise Exception("freeipa version '%s' is too old" % VERSION)
+
+
+def setup_logging():
+    standard_logging_setup(
+        paths.IPACLIENT_INSTALL_LOG, verbose=False, debug=False,
+        filemode='a', console_format='%(message)s')
 
 
 def ansible_module_get_parsed_ip_addresses(ansible_module,

--- a/roles/ipareplica/library/ipareplica_add_to_ipaservers.py
+++ b/roles/ipareplica/library/ipareplica_add_to_ipaservers.py
@@ -67,7 +67,7 @@ import six
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.ansible_ipa_replica import (
-    AnsibleModuleLog, installer, paths,
+    AnsibleModuleLog, setup_logging, installer, paths,
     gen_env_boostrap_finalize_core, constants, api_bootstrap_finalize,
     gen_remote_api, api
 )
@@ -91,6 +91,7 @@ def main():
     )
 
     ansible_module._ansible_debug = True
+    setup_logging()
     ansible_log = AnsibleModuleLog(ansible_module)
 
     # get parameters #

--- a/roles/ipareplica/library/ipareplica_create_ipa_conf.py
+++ b/roles/ipareplica/library/ipareplica_create_ipa_conf.py
@@ -137,7 +137,7 @@ import os
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.ansible_ipa_replica import (
-    AnsibleModuleLog, installer, DN, paths,
+    AnsibleModuleLog, setup_logging, installer, DN, paths,
     ansible_module_get_parsed_ip_addresses, sysrestore,
     gen_env_boostrap_finalize_core, constants, api_bootstrap_finalize,
     gen_ReplicaConfig, gen_remote_api, create_ipa_conf
@@ -186,6 +186,7 @@ def main():
     )
 
     ansible_module._ansible_debug = True
+    setup_logging()
     ansible_log = AnsibleModuleLog(ansible_module)
 
     # get parameters #

--- a/roles/ipareplica/library/ipareplica_custodia_import_dm_password.py
+++ b/roles/ipareplica/library/ipareplica_custodia_import_dm_password.py
@@ -99,7 +99,7 @@ import inspect
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.ansible_ipa_replica import (
-    AnsibleModuleLog, installer, DN, paths,
+    AnsibleModuleLog, setup_logging, installer, DN, paths,
     gen_env_boostrap_finalize_core, constants, api_bootstrap_finalize,
     gen_ReplicaConfig, gen_remote_api, redirect_stdout, custodiainstance
 )
@@ -131,6 +131,7 @@ def main():
     )
 
     ansible_module._ansible_debug = True
+    setup_logging()
     ansible_log = AnsibleModuleLog(ansible_module)
 
     # get parameters #

--- a/roles/ipareplica/library/ipareplica_ds_apply_updates.py
+++ b/roles/ipareplica/library/ipareplica_ds_apply_updates.py
@@ -100,7 +100,7 @@ import os
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.ansible_ipa_replica import (
-    AnsibleModuleLog, installer, DN, paths,
+    AnsibleModuleLog, setup_logging, installer, DN, paths,
     gen_env_boostrap_finalize_core, constants, api_bootstrap_finalize,
     gen_ReplicaConfig, gen_remote_api, api, redirect_stdout,
     replica_ds_init_info, dsinstance, upgradeinstance, installutils
@@ -133,6 +133,7 @@ def main():
     )
 
     ansible_module._ansible_debug = True
+    setup_logging()
     ansible_log = AnsibleModuleLog(ansible_module)
 
     # get parameters #

--- a/roles/ipareplica/library/ipareplica_ds_enable_ssl.py
+++ b/roles/ipareplica/library/ipareplica_ds_enable_ssl.py
@@ -97,7 +97,7 @@ import os
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.ansible_ipa_replica import (
-    AnsibleModuleLog, installer, DN, paths,
+    AnsibleModuleLog, setup_logging, installer, DN, paths,
     gen_env_boostrap_finalize_core, constants, api_bootstrap_finalize,
     gen_ReplicaConfig, gen_remote_api, api, redirect_stdout,
     replica_ds_init_info
@@ -129,6 +129,7 @@ def main():
     )
 
     ansible_module._ansible_debug = True
+    setup_logging()
     ansible_log = AnsibleModuleLog(ansible_module)
 
     # get parameters #

--- a/roles/ipareplica/library/ipareplica_enable_ipa.py
+++ b/roles/ipareplica/library/ipareplica_enable_ipa.py
@@ -77,7 +77,7 @@ import os
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.ansible_ipa_replica import (
-    AnsibleModuleLog, installer, DN, paths,
+    AnsibleModuleLog, setup_logging, installer, DN, paths,
     gen_env_boostrap_finalize_core, constants, api_bootstrap_finalize,
     gen_ReplicaConfig, gen_remote_api, api, redirect_stdout, service,
     find_providing_servers, services
@@ -103,6 +103,7 @@ def main():
     )
 
     ansible_module._ansible_debug = True
+    setup_logging()
     ansible_log = AnsibleModuleLog(ansible_module)
 
     # get parameters #

--- a/roles/ipareplica/library/ipareplica_install_ca_certs.py
+++ b/roles/ipareplica/library/ipareplica_install_ca_certs.py
@@ -137,7 +137,7 @@ import os
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.ansible_ipa_replica import (
-    AnsibleModuleLog, installer, DN, paths,
+    AnsibleModuleLog, setup_logging, installer, DN, paths,
     ansible_module_get_parsed_ip_addresses,
     gen_env_boostrap_finalize_core, constants, api_bootstrap_finalize,
     gen_ReplicaConfig, gen_remote_api, api, redirect_stdout, ipaldap,
@@ -186,6 +186,7 @@ def main():
     )
 
     ansible_module._ansible_debug = True
+    setup_logging()
     ansible_log = AnsibleModuleLog(ansible_module)
 
     # get parameters #

--- a/roles/ipareplica/library/ipareplica_krb_enable_ssl.py
+++ b/roles/ipareplica/library/ipareplica_krb_enable_ssl.py
@@ -86,7 +86,7 @@ import os
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.ansible_ipa_replica import (
-    AnsibleModuleLog, installer, DN, paths, sysrestore,
+    AnsibleModuleLog, setup_logging, installer, DN, paths, sysrestore,
     gen_env_boostrap_finalize_core, constants, api_bootstrap_finalize,
     gen_ReplicaConfig, gen_remote_api, api, krbinstance, redirect_stdout
 )
@@ -114,6 +114,7 @@ def main():
     )
 
     ansible_module._ansible_debug = True
+    setup_logging()
     ansible_log = AnsibleModuleLog(ansible_module)
 
     # get parameters #

--- a/roles/ipareplica/library/ipareplica_master_password.py
+++ b/roles/ipareplica/library/ipareplica_master_password.py
@@ -53,7 +53,7 @@ password:
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.ansible_ipa_replica import (
-    ipa_generate_password
+    setup_logging, ipa_generate_password
 )
 
 
@@ -67,6 +67,7 @@ def main():
     )
 
     module._ansible_debug = True
+    setup_logging()
 
     master_password = module.params.get('master_password')
 

--- a/roles/ipareplica/library/ipareplica_prepare.py
+++ b/roles/ipareplica/library/ipareplica_prepare.py
@@ -1430,7 +1430,7 @@ from ansible.module_utils.ansible_ipa_replica import (
     installutils, ReplicaConfig, load_pkcs12, kinit_keytab, create_api,
     rpc_client, check_remote_version, parse_version, check_remote_fips_mode,
     ReplicationManager, promotion_check_ipa_domain, current_domain_level,
-    check_domain_level_is_supported, errors, ScriptError,
+    check_domain_level_is_supported, errors, ScriptError, setup_logging,
     logger, check_dns_resolution, service, find_providing_server, ca, kra,
     dns, no_matching_interface_for_ip_address_warning, adtrust,
     constants, api, redirect_stdout, replica_conn_check, tasks
@@ -1505,6 +1505,7 @@ def main():
     )
 
     ansible_module._ansible_debug = True
+    setup_logging()
     ansible_log = AnsibleModuleLog(ansible_module)
 
     # get parameters #

--- a/roles/ipareplica/library/ipareplica_promote_openldap_conf.py
+++ b/roles/ipareplica/library/ipareplica_promote_openldap_conf.py
@@ -71,7 +71,7 @@ import os
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.ansible_ipa_replica import (
-    AnsibleModuleLog, installer, DN, paths,
+    AnsibleModuleLog, setup_logging, installer, DN, paths,
     gen_env_boostrap_finalize_core, constants, api_bootstrap_finalize,
     gen_ReplicaConfig, gen_remote_api, redirect_stdout, promote_openldap_conf
 )
@@ -94,6 +94,7 @@ def main():
     )
 
     ansible_module._ansible_debug = True
+    setup_logging()
     ansible_log = AnsibleModuleLog(ansible_module)
 
     # get parameters #

--- a/roles/ipareplica/library/ipareplica_promote_sssd.py
+++ b/roles/ipareplica/library/ipareplica_promote_sssd.py
@@ -71,7 +71,7 @@ import os
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.ansible_ipa_replica import (
-    AnsibleModuleLog, installer, DN, paths,
+    AnsibleModuleLog, setup_logging, installer, DN, paths,
     gen_env_boostrap_finalize_core, constants, api_bootstrap_finalize,
     gen_ReplicaConfig, gen_remote_api, redirect_stdout, promote_sssd
 )
@@ -94,6 +94,7 @@ def main():
     )
 
     ansible_module._ansible_debug = True
+    setup_logging()
     ansible_log = AnsibleModuleLog(ansible_module)
 
     # get parameters #

--- a/roles/ipareplica/library/ipareplica_restart_kdc.py
+++ b/roles/ipareplica/library/ipareplica_restart_kdc.py
@@ -83,7 +83,7 @@ import os
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.ansible_ipa_replica import (
-    AnsibleModuleLog, installer, DN, paths, sysrestore,
+    AnsibleModuleLog, setup_logging, installer, DN, paths, sysrestore,
     gen_env_boostrap_finalize_core, constants, api_bootstrap_finalize,
     gen_ReplicaConfig, gen_remote_api, api, redirect_stdout, service,
     krbinstance
@@ -111,6 +111,7 @@ def main():
     )
 
     ansible_module._ansible_debug = True
+    setup_logging()
     ansible_log = AnsibleModuleLog(ansible_module)
 
     # get parameters #

--- a/roles/ipareplica/library/ipareplica_setup_adtrust.py
+++ b/roles/ipareplica/library/ipareplica_setup_adtrust.py
@@ -87,7 +87,7 @@ import os
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.ansible_ipa_replica import (
-    AnsibleModuleLog, installer, DN, paths, sysrestore,
+    AnsibleModuleLog, setup_logging, installer, DN, paths, sysrestore,
     gen_env_boostrap_finalize_core, constants, api_bootstrap_finalize,
     gen_ReplicaConfig, gen_remote_api, api, redirect_stdout, adtrust
 )
@@ -117,6 +117,7 @@ def main():
     )
 
     ansible_module._ansible_debug = True
+    setup_logging()
     ansible_log = AnsibleModuleLog(ansible_module)
 
     # get parameters #

--- a/roles/ipareplica/library/ipareplica_setup_ca.py
+++ b/roles/ipareplica/library/ipareplica_setup_ca.py
@@ -113,7 +113,7 @@ import os
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.ansible_ipa_replica import (
-    AnsibleModuleLog, installer, DN, paths,
+    AnsibleModuleLog, setup_logging, installer, DN, paths,
     ansible_module_get_parsed_ip_addresses,
     gen_env_boostrap_finalize_core, constants, api_bootstrap_finalize,
     gen_ReplicaConfig, gen_remote_api, api, redirect_stdout, ca,
@@ -153,6 +153,7 @@ def main():
     )
 
     ansible_module._ansible_debug = True
+    setup_logging()
     ansible_log = AnsibleModuleLog(ansible_module)
 
     # get parameters #

--- a/roles/ipareplica/library/ipareplica_setup_certmonger.py
+++ b/roles/ipareplica/library/ipareplica_setup_certmonger.py
@@ -49,7 +49,7 @@ RETURN = '''
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.ansible_ipa_replica import (
-    AnsibleModuleLog, redirect_stdout, configure_certmonger
+    AnsibleModuleLog, setup_logging, redirect_stdout, configure_certmonger
 )
 
 
@@ -61,6 +61,7 @@ def main():
     )
 
     ansible_module._ansible_debug = True
+    setup_logging()
     ansible_log = AnsibleModuleLog(ansible_module)
 
     # get parameters #

--- a/roles/ipareplica/library/ipareplica_setup_custodia.py
+++ b/roles/ipareplica/library/ipareplica_setup_custodia.py
@@ -95,7 +95,7 @@ import os
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.ansible_ipa_replica import (
-    AnsibleModuleLog, installer, DN, paths,
+    AnsibleModuleLog, setup_logging, installer, DN, paths,
     gen_env_boostrap_finalize_core, constants, api_bootstrap_finalize,
     gen_ReplicaConfig, gen_remote_api, api, redirect_stdout, custodiainstance
 )
@@ -126,6 +126,7 @@ def main():
     )
 
     ansible_module._ansible_debug = True
+    setup_logging()
     ansible_log = AnsibleModuleLog(ansible_module)
 
     # get parameters #

--- a/roles/ipareplica/library/ipareplica_setup_dns.py
+++ b/roles/ipareplica/library/ipareplica_setup_dns.py
@@ -92,7 +92,7 @@ import os
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.ansible_ipa_replica import (
-    AnsibleModuleLog, installer, DN, paths,
+    AnsibleModuleLog, setup_logging, installer, DN, paths,
     gen_env_boostrap_finalize_core, constants, api_bootstrap_finalize,
     gen_ReplicaConfig, gen_remote_api, api, redirect_stdout, dns,
     ansible_module_get_parsed_ip_addresses
@@ -125,6 +125,7 @@ def main():
     )
 
     ansible_module._ansible_debug = True
+    setup_logging()
     ansible_log = AnsibleModuleLog(ansible_module)
 
     # get parameters #

--- a/roles/ipareplica/library/ipareplica_setup_ds.py
+++ b/roles/ipareplica/library/ipareplica_setup_ds.py
@@ -152,7 +152,7 @@ import inspect
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.ansible_ipa_replica import (
-    AnsibleModuleLog, installer, DN, paths, sysrestore,
+    AnsibleModuleLog, setup_logging, installer, DN, paths, sysrestore,
     ansible_module_get_parsed_ip_addresses,
     gen_env_boostrap_finalize_core, constants, api_bootstrap_finalize,
     gen_ReplicaConfig, gen_remote_api, redirect_stdout, ipaldap,
@@ -205,6 +205,7 @@ def main():
     )
 
     ansible_module._ansible_debug = True
+    setup_logging()
     ansible_log = AnsibleModuleLog(ansible_module)
 
     # get parameters #

--- a/roles/ipareplica/library/ipareplica_setup_http.py
+++ b/roles/ipareplica/library/ipareplica_setup_http.py
@@ -93,7 +93,7 @@ import inspect
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.ansible_ipa_replica import (
-    AnsibleModuleLog, installer, DN, paths, sysrestore,
+    AnsibleModuleLog, setup_logging, installer, DN, paths, sysrestore,
     gen_env_boostrap_finalize_core, constants, api_bootstrap_finalize,
     gen_ReplicaConfig, gen_remote_api, api, redirect_stdout, create_ipa_conf,
     install_http
@@ -123,6 +123,7 @@ def main():
     )
 
     ansible_module._ansible_debug = True
+    setup_logging()
     ansible_log = AnsibleModuleLog(ansible_module)
 
     # get parameters #

--- a/roles/ipareplica/library/ipareplica_setup_kra.py
+++ b/roles/ipareplica/library/ipareplica_setup_kra.py
@@ -137,7 +137,7 @@ import os
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.ansible_ipa_replica import (
-    AnsibleModuleLog, installer, DN, paths,
+    AnsibleModuleLog, setup_logging, installer, DN, paths,
     ansible_module_get_parsed_ip_addresses,
     gen_env_boostrap_finalize_core, constants, api_bootstrap_finalize,
     gen_ReplicaConfig, gen_remote_api, api, redirect_stdout, custodiainstance,
@@ -186,6 +186,7 @@ def main():
     )
 
     ansible_module._ansible_debug = True
+    setup_logging()
     ansible_log = AnsibleModuleLog(ansible_module)
 
     # get parameters #

--- a/roles/ipareplica/library/ipareplica_setup_krb.py
+++ b/roles/ipareplica/library/ipareplica_setup_krb.py
@@ -78,7 +78,7 @@ import inspect
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.ansible_ipa_replica import (
-    AnsibleModuleLog, installer, DN, paths, sysrestore,
+    AnsibleModuleLog, setup_logging, installer, DN, paths, sysrestore,
     gen_env_boostrap_finalize_core, constants, api_bootstrap_finalize,
     gen_ReplicaConfig, api, redirect_stdout, install_krb
 )
@@ -103,6 +103,7 @@ def main():
     )
 
     ansible_module._ansible_debug = True
+    setup_logging()
     ansible_log = AnsibleModuleLog(ansible_module)
 
     # get parameters #

--- a/roles/ipareplica/library/ipareplica_setup_otpd.py
+++ b/roles/ipareplica/library/ipareplica_setup_otpd.py
@@ -83,7 +83,7 @@ import os
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.ansible_ipa_replica import (
-    AnsibleModuleLog, installer, DN, paths,
+    AnsibleModuleLog, setup_logging, installer, DN, paths,
     gen_env_boostrap_finalize_core, constants, api_bootstrap_finalize,
     gen_ReplicaConfig, gen_remote_api, api, redirect_stdout, otpdinstance,
     ipautil
@@ -111,6 +111,7 @@ def main():
     )
 
     ansible_module._ansible_debug = True
+    setup_logging()
     ansible_log = AnsibleModuleLog(ansible_module)
 
     # get parameters #

--- a/roles/ipareplica/library/ipareplica_test.py
+++ b/roles/ipareplica/library/ipareplica_test.py
@@ -131,7 +131,7 @@ import inspect
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.ansible_ipa_replica import (
-    AnsibleModuleLog, options, installer, paths, sysrestore,
+    AnsibleModuleLog, setup_logging, options, installer, paths, sysrestore,
     ansible_module_get_parsed_ip_addresses, service,
     redirect_stdout, create_ipa_conf, ipautil,
     x509, validate_domain_name, common_check,
@@ -179,6 +179,7 @@ def main():
     )
 
     ansible_module._ansible_debug = True
+    setup_logging()
     ansible_log = AnsibleModuleLog(ansible_module)
 
     # get parameters #

--- a/roles/ipareplica/module_utils/ansible_ipa_replica.py
+++ b/roles/ipareplica/module_utils/ansible_ipa_replica.py
@@ -140,10 +140,13 @@ else:
 
 
 logger = logging.getLogger("ipa-server-install")
-# logger.setLevel(logging.DEBUG)
-standard_logging_setup(
-    paths.IPAREPLICA_INSTALL_LOG, verbose=False, debug=False,
-    filemode='a', console_format='%(message)s')
+
+
+def setup_logging():
+    # logger.setLevel(logging.DEBUG)
+    standard_logging_setup(
+        paths.IPAREPLICA_INSTALL_LOG, verbose=False, debug=False,
+        filemode='a', console_format='%(message)s')
 
 
 @contextlib_contextmanager

--- a/roles/ipaserver/library/ipaserver_enable_ipa.py
+++ b/roles/ipaserver/library/ipaserver_enable_ipa.py
@@ -57,7 +57,7 @@ RETURN = '''
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.ansible_ipa_server import (
-    AnsibleModuleLog, options, paths, api, sysrestore, tasks,
+    AnsibleModuleLog, setup_logging, options, paths, api, sysrestore, tasks,
     service, bindinstance, redirect_stdout, services
 )
 
@@ -72,6 +72,7 @@ def main():
     )
 
     ansible_module._ansible_debug = True
+    setup_logging()
     ansible_log = AnsibleModuleLog(ansible_module)
 
     # set values #############################################################

--- a/roles/ipaserver/library/ipaserver_load_cache.py
+++ b/roles/ipaserver/library/ipaserver_load_cache.py
@@ -53,7 +53,7 @@ import os
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.ansible_ipa_server import (
-    options, paths, read_cache
+    setup_logging, options, paths, read_cache
 )
 
 
@@ -66,6 +66,7 @@ def main():
     )
 
     ansible_module._ansible_debug = True
+    setup_logging()
 
     # set values ############################################################
 

--- a/roles/ipaserver/library/ipaserver_master_password.py
+++ b/roles/ipaserver/library/ipaserver_master_password.py
@@ -58,7 +58,7 @@ import os
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.ansible_ipa_server import (
-    options, paths, read_cache, ipa_generate_password
+    setup_logging, options, paths, read_cache, ipa_generate_password
 )
 
 
@@ -73,6 +73,7 @@ def main():
     )
 
     module._ansible_debug = True
+    setup_logging()
 
     options.dm_password = module.params.get('dm_password')
     options.master_password = module.params.get('master_password')

--- a/roles/ipaserver/library/ipaserver_prepare.py
+++ b/roles/ipaserver/library/ipaserver_prepare.py
@@ -157,7 +157,7 @@ import os
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.ansible_ipa_server import (
-    AnsibleModuleLog, options, sysrestore, paths,
+    AnsibleModuleLog, setup_logging, options, sysrestore, paths,
     ansible_module_get_parsed_ip_addresses,
     redirect_stdout, adtrust, api, default_subject_base,
     default_ca_subject_dn, ipautil, installutils, ca, kra, dns,
@@ -219,6 +219,7 @@ def main():
     )
 
     ansible_module._ansible_debug = True
+    setup_logging()
     ansible_log = AnsibleModuleLog(ansible_module)
 
     # initialize return values for flake ############################

--- a/roles/ipaserver/library/ipaserver_set_ds_password.py
+++ b/roles/ipaserver/library/ipaserver_set_ds_password.py
@@ -107,7 +107,7 @@ RETURN = '''
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.ansible_ipa_server import (
     MAX_DOMAIN_LEVEL, AnsibleModuleLog, options, sysrestore, paths,
-    api_Backend_ldap2, ds_init_info, redirect_stdout
+    api_Backend_ldap2, ds_init_info, redirect_stdout, setup_logging
 )
 
 
@@ -141,6 +141,7 @@ def main():
     )
 
     ansible_module._ansible_debug = True
+    setup_logging()
     ansible_log = AnsibleModuleLog(ansible_module)
 
     # set values ####################################################

--- a/roles/ipaserver/library/ipaserver_setup_adtrust.py
+++ b/roles/ipaserver/library/ipaserver_setup_adtrust.py
@@ -73,7 +73,7 @@ RETURN = '''
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.ansible_ipa_server import (
-    AnsibleModuleLog, options, sysrestore, paths,
+    AnsibleModuleLog, setup_logging, options, sysrestore, paths,
     api_Backend_ldap2, redirect_stdout, adtrust, api
 )
 
@@ -96,6 +96,7 @@ def main():
     )
 
     ansible_module._ansible_debug = True
+    setup_logging()
     ansible_log = AnsibleModuleLog(ansible_module)
 
     # set values ####################################################

--- a/roles/ipaserver/library/ipaserver_setup_ca.py
+++ b/roles/ipaserver/library/ipaserver_setup_ca.py
@@ -160,7 +160,7 @@ import os
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.ansible_ipa_server import (
-    AnsibleModuleLog, options, sysrestore, paths,
+    AnsibleModuleLog, setup_logging, options, sysrestore, paths,
     ansible_module_get_parsed_ip_addresses,
     api_Backend_ldap2, redirect_stdout, ca, installutils, ds_init_info,
     custodiainstance, write_cache, x509
@@ -214,6 +214,7 @@ def main():
     )
 
     ansible_module._ansible_debug = True
+    setup_logging()
     ansible_log = AnsibleModuleLog(ansible_module)
 
     # set values ############################################################

--- a/roles/ipaserver/library/ipaserver_setup_custodia.py
+++ b/roles/ipaserver/library/ipaserver_setup_custodia.py
@@ -57,7 +57,7 @@ RETURN = '''
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.ansible_ipa_server import (
-    AnsibleModuleLog, options,
+    setup_logging, AnsibleModuleLog, options,
     api_Backend_ldap2,
     custodiainstance, redirect_stdout
 )
@@ -74,6 +74,7 @@ def main():
     )
 
     ansible_module._ansible_debug = True
+    setup_logging()
     ansible_log = AnsibleModuleLog(ansible_module)
 
     # set values ############################################################

--- a/roles/ipaserver/library/ipaserver_setup_dns.py
+++ b/roles/ipaserver/library/ipaserver_setup_dns.py
@@ -84,7 +84,7 @@ RETURN = '''
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.ansible_ipa_server import (
-    AnsibleModuleLog, options, paths, dns,
+    AnsibleModuleLog, setup_logging, options, paths, dns,
     ansible_module_get_parsed_ip_addresses, sysrestore, api_Backend_ldap2,
     redirect_stdout, bindinstance
 )
@@ -114,6 +114,7 @@ def main():
     )
 
     ansible_module._ansible_debug = True
+    setup_logging()
     ansible_log = AnsibleModuleLog(ansible_module)
 
     # set values ############################################################

--- a/roles/ipaserver/library/ipaserver_setup_ds.py
+++ b/roles/ipaserver/library/ipaserver_setup_ds.py
@@ -103,7 +103,7 @@ RETURN = '''
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.ansible_ipa_server import (
-    AnsibleModuleLog, options, sysrestore, paths,
+    AnsibleModuleLog, setup_logging, options, sysrestore, paths,
     api_Backend_ldap2, redirect_stdout, api, NUM_VERSION, tasks,
     dsinstance, ntpinstance, IPAAPI_USER
 )
@@ -138,6 +138,7 @@ def main():
     )
 
     ansible_module._ansible_debug = True
+    setup_logging()
     ansible_log = AnsibleModuleLog(ansible_module)
 
     # set values ############################################################

--- a/roles/ipaserver/library/ipaserver_setup_http.py
+++ b/roles/ipaserver/library/ipaserver_setup_http.py
@@ -149,7 +149,7 @@ RETURN = '''
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.ansible_ipa_server import (
-    AnsibleModuleLog, options, sysrestore, paths,
+    AnsibleModuleLog, setup_logging, options, sysrestore, paths,
     ansible_module_get_parsed_ip_addresses,
     api_Backend_ldap2, redirect_stdout, ds_init_info,
     krbinstance, httpinstance, ca, service, tasks
@@ -205,6 +205,7 @@ def main():
     )
 
     ansible_module._ansible_debug = True
+    setup_logging()
     ansible_log = AnsibleModuleLog(ansible_module)
 
     # set values ############################################################

--- a/roles/ipaserver/library/ipaserver_setup_kra.py
+++ b/roles/ipaserver/library/ipaserver_setup_kra.py
@@ -66,7 +66,7 @@ RETURN = '''
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.ansible_ipa_server import (
-    AnsibleModuleLog, options,
+    AnsibleModuleLog, setup_logging, options,
     api_Backend_ldap2, redirect_stdout, api, custodiainstance, kra
 )
 
@@ -85,6 +85,7 @@ def main():
     )
 
     ansible_module._ansible_debug = True
+    setup_logging()
     ansible_log = AnsibleModuleLog(ansible_module)
 
     # set values ####################################################

--- a/roles/ipaserver/library/ipaserver_setup_krb.py
+++ b/roles/ipaserver/library/ipaserver_setup_krb.py
@@ -121,7 +121,7 @@ RETURN = '''
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.ansible_ipa_server import (
-    AnsibleModuleLog, options, sysrestore, paths,
+    AnsibleModuleLog, setup_logging, options, sysrestore, paths,
     ansible_module_get_parsed_ip_addresses,
     api_Backend_ldap2, redirect_stdout, krbinstance
 )
@@ -165,6 +165,7 @@ def main():
     )
 
     ansible_module._ansible_debug = True
+    setup_logging()
     ansible_log = AnsibleModuleLog(ansible_module)
 
     # set values ############################################################

--- a/roles/ipaserver/library/ipaserver_setup_ntp.py
+++ b/roles/ipaserver/library/ipaserver_setup_ntp.py
@@ -56,7 +56,7 @@ import inspect
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.ansible_ipa_server import (
-    AnsibleModuleLog, options, sysrestore, paths,
+    AnsibleModuleLog, setup_logging, options, sysrestore, paths,
     redirect_stdout, time_service, sync_time, ntpinstance, timeconf
 )
 
@@ -70,6 +70,7 @@ def main():
     )
 
     ansible_module._ansible_debug = True
+    setup_logging()
     ansible_log = AnsibleModuleLog(ansible_module)
 
     # set values ############################################################

--- a/roles/ipaserver/library/ipaserver_setup_otpd.py
+++ b/roles/ipaserver/library/ipaserver_setup_otpd.py
@@ -57,7 +57,7 @@ RETURN = '''
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.ansible_ipa_server import (
-    AnsibleModuleLog, options,
+    AnsibleModuleLog, setup_logging, options,
     api_Backend_ldap2, redirect_stdout, otpdinstance, ipautil
 )
 
@@ -73,6 +73,7 @@ def main():
     )
 
     ansible_module._ansible_debug = True
+    setup_logging()
     ansible_log = AnsibleModuleLog(ansible_module)
 
     # set values ####################################################

--- a/roles/ipaserver/library/ipaserver_test.py
+++ b/roles/ipaserver/library/ipaserver_test.py
@@ -212,8 +212,8 @@ import random
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.ansible_ipa_server import (
-    AnsibleModuleLog, options, adtrust_imported, kra_imported, PKIIniLoader,
-    MIN_DOMAIN_LEVEL, MAX_DOMAIN_LEVEL, check_zone_overlap,
+    AnsibleModuleLog, setup_logging, options, adtrust_imported, kra_imported,
+    PKIIniLoader, MIN_DOMAIN_LEVEL, MAX_DOMAIN_LEVEL, check_zone_overlap,
     redirect_stdout, validate_dm_password, validate_admin_password,
     NUM_VERSION, is_ipa_configured, sysrestore, paths, bindinstance,
     read_cache, ca, tasks, check_ldap_conf, timeconf, httpinstance,
@@ -302,6 +302,7 @@ def main():
     )
 
     ansible_module._ansible_debug = True
+    setup_logging()
     ansible_log = AnsibleModuleLog(ansible_module)
 
     # set values ############################################################

--- a/roles/ipaserver/module_utils/ansible_ipa_server.py
+++ b/roles/ipaserver/module_utils/ansible_ipa_server.py
@@ -144,10 +144,13 @@ else:
 
 
 logger = logging.getLogger("ipa-server-install")
-# logger.setLevel(logging.DEBUG)
-standard_logging_setup(
-    paths.IPASERVER_INSTALL_LOG, verbose=False, debug=False,
-    filemode='a', console_format='%(message)s')
+
+
+def setup_logging():
+    # logger.setLevel(logging.DEBUG)
+    standard_logging_setup(
+        paths.IPASERVER_INSTALL_LOG, verbose=False, debug=False,
+        filemode='a', console_format='%(message)s')
 
 
 @contextlib_contextmanager


### PR DESCRIPTION
The import of ansible_ipa_server, ansible_ipa_replica and ansible_ipa_client
might result in a permission denied error for the log file. It seems that
for collections the module utils seem to be loaded before the needed
permissions are aquired now.

The fix simply adds a wrapper for standard_logging_setup that is called in
all the modules of the server, replica and client roles to do the loggin
setup as one of the first steps of the module execution and not before.