### PR TITLE
Create log files before the "testing installation" tasks

### DIFF
--- a/roles/ipaclient/tasks/install.yml
+++ b/roles/ipaclient/tasks/install.yml
@@ -30,6 +30,14 @@
     ipaadmin_principal: admin
   when: ipaadmin_principal is undefined and ipaclient_keytab is undefined
 
+- name: Create ipaclient-install log file if not exists
+  file:
+    path: /var/log/ipaclient-install.log
+    owner: root
+    group: root
+    mode: '0660'
+    state: touch
+
 - name: Install - IPA client test
   ipaclient_test:
     ### basic ###

--- a/roles/ipareplica/tasks/install.yml
+++ b/roles/ipareplica/tasks/install.yml
@@ -48,6 +48,22 @@
     ipaadmin_principal: admin
   when: ipaadmin_principal is undefined and ipaclient_keytab is undefined
 
+- name: Create ipaserver-install log file if not exists
+  file:
+    path: /var/log/ipaserver-install.log
+    owner: root
+    group: root
+    mode: '0660'
+    state: touch
+
+- name: Create ipaclient-install log file if not exists
+  file:
+    path: /var/log/ipaclient-install.log
+    owner: root
+    group: root
+    mode: '0660'
+    state: touch
+
 - name: Install - Replica installation test
   ipareplica_test:
     ### basic ###

--- a/roles/ipaserver/tasks/install.yml
+++ b/roles/ipaserver/tasks/install.yml
@@ -43,6 +43,22 @@
         ipaserver_external_cert_files_from_controller|length > 0 and
         not ipaserver_external_cert_files is defined
 
+- name: Create ipaserver-install log file if not exists
+  file:
+    path: /var/log/ipaserver-install.log
+    owner: root
+    group: root
+    mode: '0660'
+    state: touch
+
+- name: Create ipaclient-install log file if not exists
+  file:
+    path: /var/log/ipaclient-install.log
+    owner: root
+    group: root
+    mode: '0660'
+    state: touch
+
 - name: Install - Server installation test
   ipaserver_test:
     ### basic ###


### PR DESCRIPTION
When trying to execute the roles `ipaclient`, `ipaserver` or `ipareplica` in order to perform an installation, they are going to fail in the task "- name: Install - IPA ***** test".

This is caused because log files for ipaclient-install and/or ipaserver-install are going to be used but does not exists.

More information can be seen at the issue https://github.com/freeipa/ansible-freeipa/issues/184 (this pull requests solves the issue).

Touching the files if don't exists is a quick solution, but can be interesting to open a discourse to a better solution (why the log files are not created when packages are installed, for example).