### PR TITLE
ansible_freeipa_module: Set KRB5CCNAME for api_connect (non root)

### DIFF
--- a/plugins/module_utils/ansible_freeipa_module.py
+++ b/plugins/module_utils/ansible_freeipa_module.py
@@ -108,6 +108,7 @@ def temp_kinit(principal, password):
     except RuntimeError as e:
         raise RuntimeError("Kerberos authentication failed: {}".format(e))
 
+    os.environ["KRB5CCNAME"] = ccache_name
     return ccache_dir, ccache_name
 
 
@@ -117,6 +118,7 @@ def temp_kdestroy(ccache_dir, ccache_name):
     """
     if ccache_name is not None:
         run([paths.KDESTROY, '-c', ccache_name], raiseonerr=False)
+        del os.environ['KRB5CCNAME']
     if ccache_dir is not None:
         shutil.rmtree(ccache_dir, ignore_errors=True)
 
@@ -142,7 +144,7 @@ def api_connect(context=None):
         backend = api.Backend.rpcclient
 
     if not backend.isconnected():
-        backend.connect()
+        backend.connect(ccache=os.environ.get('KRB5CCNAME', None))
 
 
 def api_command(module, command, name, args):


### PR DESCRIPTION
In the case that the admin password has been set and become was not set
the call to backend.connect in api_connect failed. The solution is simply
to set os.environ["KRB5CCNAME"] in temp_kinit after kinit_password has
been called using the temporary ccache. os.environ["KRB5CCNAME"] is not
used automatically by api.Backend.[ldap2,rpcclient].connect.

Fixes: #249 (Kerberos errors while using the modules with a non-sudoer user)