### PR TITLE
Fixes behavior of ipavault when no user, service or shared is given.

### DIFF
--- a/README-vault.md
+++ b/README-vault.md
@@ -181,8 +181,8 @@ Variable | Description | Required
 `vault_public_key` \| `ipavaultpublickey` | Vault public key. | no
 `vault_salt` \| `ipavaultsalt` | Vault salt. | no
 `vault_type` \| `ipavaulttype` | Vault types are based on security level. It can be one of `standard`, `symmetric` or `asymmetric`, default: `symmetric` | no
+`user` \| `username` | Any user can own one or more user vaults. | no
 `service` | Any service can own one or more service vaults. | no
-`user` | Any user can own one or more user vaults. | no
 `shared` | Vault is shared. Default to false. (bool) | no
 `users` | Users that are members of the vault. | no
 `groups` | Groups that are member of the vault. | no

--- a/plugins/modules/ipavault.py
+++ b/plugins/modules/ipavault.py
@@ -402,7 +402,6 @@ def main():
         ),
         supports_check_mode=True,
         mutually_exclusive=[['username', 'service', 'shared']],
-        required_one_of=[['username', 'service', 'shared']]
     )
 
     ansible_module._ansible_debug = True

--- a/tests/vault/test_vault.yml
+++ b/tests/vault/test_vault.yml
@@ -65,12 +65,53 @@
       shared: True
       state: absent
 
-  - name: Ensure service vaults are absent
+  - name: Ensure standard vault is absent
+    ipavault:
+      ipaadmin_password: SomeADMINpassword
+      name: stdvault
+      state: absent
+
+  - name: Ensure service vault is absent
     ipavault:
       ipaadmin_password: SomeADMINpassword
       name: svcvault
       service: "HTTP/{{ groups.ipaserver[0] }}"
       state: absent
+
+  # tests
+  - name: Ensure standard vault is present
+    ipavault:
+      ipaadmin_password: SomeADMINpassword
+      name: stdvault
+      vault_type: standard
+    register: result
+    failed_when: not result.changed
+
+  - name: Ensure standard vault is present, again
+    ipavault:
+      ipaadmin_password: SomeADMINpassword
+      name: stdvault
+      vault_type: standard
+    register: result
+    failed_when: result.changed
+
+  - name: Ensure standard vault is absent
+    ipavault:
+      ipaadmin_password: SomeADMINpassword
+      name: stdvault
+      vault_type: standard
+      state: absent
+    register: result
+    failed_when: not result.changed
+
+  - name: Ensure standard vault is absent, again
+    ipavault:
+      ipaadmin_password: SomeADMINpassword
+      name: stdvault
+      vault_type: standard
+      state: absent
+    register: result
+    failed_when: result.changed
 
   - name: Ensure symmetric vault is present
     ipavault:


### PR DESCRIPTION
This patch makes the module behavior similar to the IPA CLI command `vault_add`.

Tests are updated to reflect this change.