### PR TITLE
ipauser: Fix certmapdata, add missing certmapdata data option

### DIFF
--- a/README-user.md
+++ b/README-user.md
@@ -417,10 +417,11 @@ Variable | Description | Required
 `employeetype` | Employee Type | no
 `preferredlanguage` | Preferred Language | no
 `certificate` | List of base-64 encoded user certificates. | no
-`certmapdata` | List of certificate mappings. Either `certificate` or `issuer` together with `subject` need to be specified. <br>Options: | no
-&nbsp; | `certificate` - Base-64 encoded user certificate | no
-&nbsp; | `issuer` - Issuer of the certificate | no
-&nbsp; | `subject` - Subject of the certificate | no
+`certmapdata` | List of certificate mappings. Either `data` or `certificate` or `issuer` together with `subject` need to be specified. Only usable with IPA versions 4.5 and up. <br>Options: | no
+&nbsp; | `certificate` - Base-64 encoded user certificate, not usable with other certmapdata options. | no
+&nbsp; | `issuer` - Issuer of the certificate, only usable together with `usbject` option. | no
+&nbsp; | `subject` - Subject of the certificate, only usable together with `issuer` option. | no
+&nbsp; | `data` - Certmap data, not usable with other certmapdata options. | no
 `noprivate` | Do not create user private group. (bool) | no
 `nomembers` | Suppress processing of membership attributes. (bool) | no
 

--- a/plugins/module_utils/ansible_freeipa_module.py
+++ b/plugins/module_utils/ansible_freeipa_module.py
@@ -39,6 +39,7 @@ try:
 except ImportError:
     from ipapython.ipautil import kinit_password, kinit_keytab
 from ipapython.ipautil import run
+from ipapython.dn import DN
 from ipaplatform.paths import paths
 from ipalib.krb_utils import get_credentials_if_valid
 from ansible.module_utils.basic import AnsibleModule
@@ -342,6 +343,16 @@ def load_cert_from_str(cert):
     else:
         cert = load_certificate(cert.encode('utf-8'))
     return cert
+
+
+def DN_x500_text(text):
+    if hasattr(DN, "x500_text"):
+        return DN(text).x500_text()
+    else:
+        # Emulate x500_text
+        dn = DN(text)
+        dn.rdns = reversed(dn.rdns)
+        return str(dn)
 
 
 def is_valid_port(port):

--- a/plugins/module_utils/ansible_freeipa_module.py
+++ b/plugins/module_utils/ansible_freeipa_module.py
@@ -48,6 +48,13 @@ try:
     from ipalib.x509 import Encoding
 except ImportError:
     from cryptography.hazmat.primitives.serialization import Encoding
+
+try:
+    from ipalib.x509 import load_pem_x509_certificate
+except ImportError:
+    from ipalib.x509 import load_certificate
+    load_pem_x509_certificate = None
+
 import socket
 import base64
 import six
@@ -321,6 +328,20 @@ def encode_certificate(cert):
     if not six.PY2:
         encoded = encoded.decode('ascii')
     return encoded
+
+
+def load_cert_from_str(cert):
+    cert = cert.strip()
+    if not cert.startswith("-----BEGIN CERTIFICATE-----"):
+        cert = "-----BEGIN CERTIFICATE-----\n" + cert
+    if not cert.endswith("-----END CERTIFICATE-----"):
+        cert += "\n-----END CERTIFICATE-----"
+
+    if load_pem_x509_certificate is not None:
+        cert = load_pem_x509_certificate(cert.encode('utf-8'))
+    else:
+        cert = load_certificate(cert.encode('utf-8'))
+    return cert
 
 
 def is_valid_port(port):

--- a/plugins/module_utils/ansible_freeipa_module.py
+++ b/plugins/module_utils/ansible_freeipa_module.py
@@ -175,6 +175,11 @@ def api_command_no_name(module, command, args):
     return api.Command[command](**args)
 
 
+def api_check_command(command):
+    """Return if command exists in command list."""
+    return command in api.Command
+
+
 def api_check_param(command, name):
     """Check if param exists in command param list."""
     return name in api.Command[command].params

--- a/tests/user/certmapdata/test_user_certmapdata.yml
+++ b/tests/user/certmapdata/test_user_certmapdata.yml
@@ -126,8 +126,6 @@
       certmapdata:
       - issuer: CN=issuer1
         subject: CN=subject1
-      - issuer: CN=issuer2
-        subject: CN=subject2
       - issuer: CN=issuer3
         subject: CN=subject3
       action: member
@@ -142,10 +140,87 @@
       certmapdata:
       - issuer: CN=issuer1
         subject: CN=subject1
-      - issuer: CN=issuer2
-        subject: CN=subject2
       - issuer: CN=issuer3
         subject: CN=subject3
+      action: member
+      state: absent
+    register: result
+    failed_when: result.changed
+
+  - name: User test certmapdata members absent
+    ipauser:
+      ipaadmin_password: SomeADMINpassword
+      name: test
+      certmapdata:
+      - issuer: CN=issuer2
+        subject: CN=subject2
+      action: member
+      state: absent
+    register: result
+    failed_when: not result.changed
+
+  - name: User test certmapdata members absent again
+    ipauser:
+      ipaadmin_password: SomeADMINpassword
+      name: test
+      certmapdata:
+      - issuer: CN=issuer2
+        subject: CN=subject2
+      action: member
+      state: absent
+    register: result
+    failed_when: result.changed
+
+  - name: User test certmapdata member present
+    ipauser:
+      ipaadmin_password: SomeADMINpassword
+      name: test
+      certmapdata:
+      - issuer: CN=ca,dc=example,dc=com
+        subject: CN=test,dc=example,dc=com
+      action: member
+    register: result
+    failed_when: not result.changed
+
+  - name: User test certmapdata member present again
+    ipauser:
+      ipaadmin_password: SomeADMINpassword
+      name: test
+      certmapdata:
+      - issuer: CN=ca,dc=example,dc=com
+        subject: CN=test,dc=example,dc=com
+      action: member
+    register: result
+    failed_when: result.changed
+
+  - name: User test certmapdata member (data) present again
+    ipauser:
+      ipaadmin_password: SomeADMINpassword
+      name: test
+      certmapdata:
+      - data: X509:<I>dc=com,dc=example,CN=ca<S>dc=com,dc=example,CN=test
+      action: member
+    register: result
+    failed_when: result.changed
+
+  - name: User test certmapdata member absent
+    ipauser:
+      ipaadmin_password: SomeADMINpassword
+      name: test
+      certmapdata:
+      - issuer: CN=ca,dc=example,dc=com
+        subject: CN=test,dc=example,dc=com
+      action: member
+      state: absent
+    register: result
+    failed_when: not result.changed
+
+  - name: User test certmapdata member (data) absent again
+    ipauser:
+      ipaadmin_password: SomeADMINpassword
+      name: test
+      certmapdata:
+      - data: X509:<I>dc=com,dc=example,CN=ca<S>dc=com,dc=example,CN=test
       action: member
       state: absent
     register: result


### PR DESCRIPTION
ipauser: Fix certmapdata, add missing certmapdata data option

    certmapdata was not processed properly. The certificate was not loaded and
    therefore the `issuer` and `subject` could not be compared to the
    certmapdata entries in the user record. The function `load_cert_from_str`
    from ansible_freeipa_moduleis used for this.
    
    Additionally there was no way to use the certmapdata data format. This
    is now possible with the `data` option in the certmapdata dict.
    
    Example: "data: X509:<I>dc=com,dc=example,CN=ca<S>dc=com,dc=example,CN=test"
    
    `data` may not be used together with `certificate`, `issuer` and `subject`
    in the same record.
    
    Given certmapdata for the ipauser module is now converted to the internal
    data representation using also the new function `DN_x500_text` from
    `ansible_freeipa_module`.
    
    New functions `convert_certmapdata` and `check_certmapdata` have been added
    to ipauser.
    
    tests/user/certmapdata/test_user_certmapdata.yml has been extended with
    additional tasks to verify more complex issuer and subjects and also using
    the data format.


ansible_freeipa_module: New function api_check_command
    
    This function can be used to check if a command is available in the API.
    
    This is used in ipauser module to check if user_add_certmapdata is available
    in the API.

ansible_freeipa_module: New function DN_x500_text
    
    This function is needed to properly convert issuer and subject from a
    certificate or the issuer and subject parameters in ipauser for certmapdata
    to the data representation where the items in DN are reversed.
    
    The function additionally provides a fallback solution for IPA < 4.5.
    Certmapdata is not supported for IPA < 4.5, but the conversion is done
    before the API version can be checked.

ansible_freeipa_module: New function load_cert_from_str
    
    For certmapdata processing in ipauser it is needed to be able to load a cert
    from a string given in the task to be able to get the issuer and subject of
    the certificate. The format of the certifiacte here is lacking the markers
    for the begin and end of the certificate. Therefore load_pem_x509_certificate
    can not be used directly. Also in IPA < 4.5 it is needed to load the
    certificate with load_certificate instead of load_pem_x509_certificate. The
    function is implementing this properly.