### PR TITLE
Add missing attribute `services` to vault module.

### DIFF
--- a/README-vault.md
+++ b/README-vault.md
@@ -186,6 +186,7 @@ Variable | Description | Required
 `shared` | Vault is shared. Default to false. (bool) | no
 `users` | Users that are members of the vault. | no
 `groups` | Groups that are member of the vault. | no
+`services` | Services that are member of the vault. | no
 `vault_data` \| `ipavaultdata` | Data to be stored in the vault. | no
 `action` | Work on vault or member level. It can be on of `member` or `vault` and defaults to `vault`. | no
 `state` | The state to ensure. It can be one of `present` or `absent`, default: `present`. | no

--- a/tests/vault/test_vault.yml
+++ b/tests/vault/test_vault.yml
@@ -348,6 +348,48 @@
     register: result
     failed_when: result.changed
 
+  - name: Ensure vault member service is present.
+    ipavault:
+      ipaadmin_password: SomeADMINpassword
+      name: stdvault
+      username: user01
+      action: member
+      services: "HTTP/{{ groups.ipaserver[0] }}"
+    register: result
+    failed_when: not result.changed
+
+  - name: Ensure vault member service is present, again.
+    ipavault:
+      ipaadmin_password: SomeADMINpassword
+      name: stdvault
+      username: user01
+      action: member
+      services: "HTTP/{{ groups.ipaserver[0] }}"
+    register: result
+    failed_when: result.changed
+
+  - name: Ensure vault member service is absent.
+    ipavault:
+      ipaadmin_password: SomeADMINpassword
+      name: stdvault
+      username: user01
+      action: member
+      services: "HTTP/{{ groups.ipaserver[0] }}"
+      state: absent
+    register: result
+    failed_when: not result.changed
+
+  - name: Ensure vault member service is absent, again.
+    ipavault:
+      ipaadmin_password: SomeADMINpassword
+      name: stdvault
+      username: user01
+      action: member
+      services: "HTTP/{{ groups.ipaserver[0] }}"
+      state: absent
+    register: result
+    failed_when: result.changed
+
   - name: Ensure vault is absent.
     ipavault:
       ipaadmin_password: SomeADMINpassword
@@ -509,6 +551,90 @@
       name: stdvault
       username: user01
       owners: user03
+      state: absent
+      action: member
+    register: result
+    failed_when: result.changed
+
+  - name: Ensure vaultgroup is owner of stdvault.
+    ipavault:
+      ipaadmin_password: SomeADMINpassword
+      name: stdvault
+      username: user01
+      ownergroups: vaultgroup
+      action: member
+    register: result
+    failed_when: not result.changed
+
+  - name: Ensure vaultgroup is owner of stdvault, again.
+    ipavault:
+      ipaadmin_password: SomeADMINpassword
+      name: stdvault
+      username: user01
+      ownergroups: vaultgroup
+      action: member
+    register: result
+    failed_when: result.changed
+
+  - name: Ensure vaultgroup is not owner of stdvault.
+    ipavault:
+      ipaadmin_password: SomeADMINpassword
+      name: stdvault
+      username: user01
+      ownergroups: vaultgroup
+      state: absent
+      action: member
+    register: result
+    failed_when: not result.changed
+
+  - name: Ensure vaultgroup is not owner of stdvault, again.
+    ipavault:
+      ipaadmin_password: SomeADMINpassword
+      name: stdvault
+      username: user01
+      ownergroups: vaultgroup
+      state: absent
+      action: member
+    register: result
+    failed_when: result.changed
+
+  - name: Ensure vault is owned by HTTP service.
+    ipavault:
+      ipaadmin_password: SomeADMINpassword
+      name: stdvault
+      username: user01
+      ownerservices: "HTTP/{{ groups.ipaserver[0] }}"
+      action: member
+    register: result
+    failed_when: not result.changed
+
+  - name: Ensure vault is owned by HTTP service, again.
+    ipavault:
+      ipaadmin_password: SomeADMINpassword
+      name: stdvault
+      username: user01
+      ownerservices: "HTTP/{{ groups.ipaserver[0] }}"
+      action: member
+    register: result
+    failed_when: result.changed
+
+  - name: Ensure vault is not owned by HTTP service.
+    ipavault:
+      ipaadmin_password: SomeADMINpassword
+      name: stdvault
+      username: user01
+      ownerservices: "HTTP/{{ groups.ipaserver[0] }}"
+      state: absent
+      action: member
+    register: result
+    failed_when: not result.changed
+
+  - name: Ensure vault is not owned by HTTP service, again.
+    ipavault:
+      ipaadmin_password: SomeADMINpassword
+      name: stdvault
+      username: user01
+      ownerservices: "HTTP/{{ groups.ipaserver[0] }}"
       state: absent
       action: member
     register: result


### PR DESCRIPTION
The `services` member attribute was missing from vault module. This
change adds it.

Handling of owner and ownergroups needed to be changed to fix `services`
and, due to this, have also been fixed.