### PR TITLE
ipahost: Use dnsrecord_show instead of dnsrecord_find command

### DIFF
--- a/plugins/modules/ipahost.py
+++ b/plugins/modules/ipahost.py
@@ -445,24 +445,19 @@ def find_dnsrecord(module, name):
 
     _args = {
         "all": True,
-        "idnsname": to_text(host_name),
+        "idnsname": to_text(host_name)
     }
 
-    _result = api_command(module, "dnsrecord_find", to_text(domain_name),
-                          _args)
+    try:
+        _result = api_command(module, "dnsrecord_show", to_text(domain_name),
+                              _args)
+    except ipalib_errors.NotFound as e:
+        msg = str(e)
+        if "record not found" in msg:
+            return None
+        module.fail_json(msg="dnsrecord_show failed: %s" % msg)
 
-    if len(_result["result"]) > 1:
-        module.fail_json(
-            msg="There is more than one host '%s'" % (name))
-    elif len(_result["result"]) == 1:
-        _res = _result["result"][0]
-        certs = _res.get("usercertificate")
-        if certs is not None:
-            _res["usercertificate"] = [encode_certificate(cert) for
-                                       cert in certs]
-        return _res
-    else:
-        return None
+    return _result["result"]
 
 
 def show_host(module, name):


### PR DESCRIPTION
The host_find command had to be replaced to get the "has_password" and
"has_keytab" return values. This commit replaces the dnsrecord_find
with the dnsrecord_show command to have consistent find functions in
the module.