### PR TITLE
tests/host/test_hosts_principal.yml: Remove dudplicate hosts tag

### DIFF
--- a/tests/host/test_hosts_principal.yml
+++ b/tests/host/test_hosts_principal.yml
@@ -141,7 +141,6 @@
         principal:
         - "{{ 'host/testhost1.' + ipaserver_domain + '@' + ipaserver_realm }}"
         - "{{ 'host/myhost1.' + ipaserver_domain + '@' + ipaserver_realm }}"
-      hosts:
       - name: "{{ host2_fqdn }}"
         principal:
         - "{{ 'host/testhost2.' + ipaserver_domain + '@' + ipaserver_realm }}"
@@ -159,7 +158,6 @@
         principal:
         - "{{ 'host/testhost1.' + ipaserver_domain + '@' + ipaserver_realm }}"
         - "{{ 'host/myhost1.' + ipaserver_domain + '@' + ipaserver_realm }}"
-      hosts:
       - name: "{{ host2_fqdn }}"
         principal:
         - "{{ 'host/testhost2.' + ipaserver_domain + '@' + ipaserver_realm }}"


### PR DESCRIPTION
The hosts tag is used twice in some tests. This leads to a warning in
Ansible. The commit removes the duplicate tags.