### PR TITLE
ipagroup: Add lacking service check for group_remove_member with old IPA

### DIFF
--- a/plugins/modules/ipagroup.py
+++ b/plugins/modules/ipagroup.py
@@ -386,12 +386,20 @@ def main():
                     if res_find is None:
                         ansible_module.fail_json(msg="No group '%s'" % name)
 
-                    commands.append([name, "group_remove_member",
-                                     {
-                                         "user": user,
-                                         "group": group,
-                                         "service": service,
-                                     }])
+                    if has_add_member_service:
+                        commands.append([name, "group_remove_member",
+                                         {
+                                             "user": user,
+                                             "group": group,
+                                             "service": service,
+                                         }])
+                    else:
+                        commands.append([name, "group_remove_member",
+                                         {
+                                             "user": user,
+                                             "group": group,
+                                         }])
+
             else:
                 ansible_module.fail_json(msg="Unkown state '%s'" % state)
 


### PR DESCRIPTION
group_remove_member is not able to handle services in old IPA releases.
In one case the check was missing and the removal of a user from a group
failed because of this with an older IPA version. The missing check has
been added.

Fixes #257 (ipagroup fails to remove user from group ipausers)