### PR TITLE
Wrong variable names in the documentation

### DIFF
--- a/roles/ipaserver/README.md
+++ b/roles/ipaserver/README.md
@@ -235,6 +235,9 @@ Variable | Description | Required
 `ipaserver_dirsrv_cert_name` | Name of the Directory Server SSL certificate to install. (string) | no
 `ipaserver_http_cert_name` | Name of the Apache Server SSL certificate to install. (string) | no
 `ipaserver_pkinit_cert_name` | Name of the Kerberos KDC SSL certificate to install. (string) | no
+`ipaserver_no_pkinit` | Disable pkinit setup steps (boolean) | no
+
+NOTE: If one of the `ipaserver_http_cert_files` or `ipaserver_pkinit_cert_files` is specified, then both are required, so declaring only one of them will raise an error. Additionally, one of `ipaserver_pkinit_cert_files` or `ipaserver_no_pkinit` must be provided as well.
 
 Client Variables
 ----------------

--- a/roles/ipaserver/README.md
+++ b/roles/ipaserver/README.md
@@ -227,8 +227,8 @@ SSL certificate Variables
 Variable | Description | Required
 -------- | ----------- | --------
 `ipaserver_dirsrv_cert_files` | Files containing the Directory Server SSL certificate and private keys. (list of strings) | no
-`ipaserver_http_cert_file` | File containing the Apache Server SSL certificate and private key. (string) | no
-`ipaserver_pkinit_cert_file` | File containing the Kerberos KDC SSL certificate and private key. (string) | no
+`ipaserver_http_cert_files` | File containing the Apache Server SSL certificate and private key. (list of string) | no
+`ipaserver_pkinit_cert_files` | File containing the Kerberos KDC SSL certificate and private key. (list of string) | no
 `ipaserver_dirsrv_pin` | The password to unlock the Directory Server private key. (string) | no
 `ipaserver_http_pin` | The password to unlock the Apache Server private key. (string) | no
 `ipaserver_pkinit_pin` | The password to unlock the Kerberos KDC private key. (string) | no


### PR DESCRIPTION
Corrected variable names and description.
Added useful notes and the missing variable ipaserver_no_pkinit.
