### PR TITLE
Fixes host absent when DNS zone is not found.

### DIFF
--- a/plugins/modules/ipahost.py
+++ b/plugins/modules/ipahost.py
@@ -452,7 +452,7 @@ def find_dnsrecord(module, name):
                               _args)
     except ipalib_errors.NotFound as e:
         msg = str(e)
-        if "record not found" in msg:
+        if "record not found" in msg or "zone not found" in msg:
             return None
         module.fail_json(msg="dnsrecord_show failed: %s" % msg)
 

--- a/tests/host/test_host_no_zone.yml
+++ b/tests/host/test_host_no_zone.yml
@@ -1,0 +1,12 @@
+---
+- name: Test host
+  hosts: ipaserver
+  become: yes
+
+  tasks:
+  - name: Ensure host with inexistent zone is absent.
+    ipahost:
+      name: host01.absentzone.test
+      state: absent
+    register: result
+    failed_when: result.failed or result.changed


### PR DESCRIPTION
Since ipahost uses dnsrecord-show, it raises an error when DNS zone is
not found, but it should not be an ipahost concern.

This patch fixes this behavior by returning no record if DNS zone is
not found, so processing resumes as if there is no record for the host.
It fixes behavior when `state: absent` and dnszone does not exist, so,
host should not exist either, and the ipahost answer is correct and
indifferent to DNS Zone state.