### PR TITLE
Fix service module

### DIFF
--- a/README-service.md
+++ b/README-service.md
@@ -310,6 +310,7 @@ Variable | Description | Required
 `allow_retrieve_keytab_group` \| `ipaallowedtoperform_read_keys_group` | Groups allowed to retrieve a keytab of this host. | no
 `allow_retrieve_keytab_host` \| `ipaallowedtoperform_read_keys_host` | Hosts allowed to retrieve a keytab from of host. | no
 `allow_retrieve_keytab_hostgroup` \| `ipaallowedtoperform_read_keys_hostgroup` | Host groups allowed to retrieve a keytab of this host. | no
+`continue` | Continuous mode: don't stop on errors. Valid only if `state` is `absent`. Default: `no` (bool) | no
 `action` | Work on service or member level. It can be on of `member` or `service` and defaults to `service`. | no
 `state` | The state to ensure. It can be one of `present`, `absent`, or `disabled`, default: `present`. | no
 

--- a/plugins/modules/ipaservice.py
+++ b/plugins/modules/ipaservice.py
@@ -142,7 +142,7 @@ options:
   state:
     description: State to ensure
     default: present
-    choices: ["present", "absent", "enabled", "disabled"]
+    choices: ["present", "absent", "disabled"]
 author:
     - Rafael Jeffman
 """
@@ -365,8 +365,7 @@ def init_ansible_module():
                         choices=["member", "service"]),
             # state
             state=dict(type="str", default="present",
-                       choices=["present", "absent",
-                                "enabled", "disabled"]),
+                       choices=["present", "absent", "disabled"]),
         ),
         supports_check_mode=True,
     )

--- a/plugins/modules/ipaservice.py
+++ b/plugins/modules/ipaservice.py
@@ -304,8 +304,8 @@ def check_parameters(module, state, action, names, parameters):
     for _invalid in invalid:
         if parameters[_invalid] is not None:
             module.fail_json(
-                msg="Argument '%s' can not be used with state '%s'" %
-                (_invalid, state))
+                msg="Argument '%s' can not be used with state '%s', "
+                "action '%s'" % (_invalid, state, action))
 
 
 def init_ansible_module():

--- a/plugins/modules/ipaservice.py
+++ b/plugins/modules/ipaservice.py
@@ -324,7 +324,7 @@ def init_ansible_module():
                            default=None),
             pac_type=dict(type="list", aliases=["ipakrbauthzdata"],
                           choices=["MS-PAC", "PAD", "NONE"]),
-            auth_ind=dict(type="str",
+            auth_ind=dict(type="list",
                           aliases=["krbprincipalauthind"],
                           choices=["otp", "radius", "pkinit", "hardened"]),
             skip_host_check=dict(type="bool"),

--- a/plugins/modules/ipaservice.py
+++ b/plugins/modules/ipaservice.py
@@ -327,7 +327,7 @@ def init_ansible_module():
                           choices=["MS-PAC", "PAD", "NONE"]),
             auth_ind=dict(type="list",
                           aliases=["krbprincipalauthind"],
-                          choices=["otp", "radius", "pkinit", "hardened"]),
+                          choices=["otp", "radius", "pkinit", "hardened", ""]),
             skip_host_check=dict(type="bool"),
             force=dict(type="bool"),
             requires_pre_auth=dict(

--- a/plugins/modules/ipauser.py
+++ b/plugins/modules/ipauser.py
@@ -817,7 +817,7 @@ def main():
             preserve=dict(required=False, type='bool', default=None),
 
             # mod
-            update_password=dict(type='str', default=None,
+            update_password=dict(type='str', default=None, no_log=False,
                                  choices=['always', 'on_create']),
 
             # general

--- a/tests/service/test_service.yml
+++ b/tests/service/test_service.yml
@@ -541,6 +541,40 @@
     register: result
     failed_when: result.changed
 
+  - name: Ensure SMB service is present.
+    ipaservice:
+      ipaadmin_password: MyPassword123
+      name: "{{ host1_fqdn }}"
+      smb: yes
+      netbiosname: SAMBASVC
+    register: result
+    failed_when: not result.changed
+
+  - name: Ensure SMB service is again.
+    ipaservice:
+      ipaadmin_password: MyPassword123
+      name: "{{ host1_fqdn }}"
+      smb: yes
+      netbiosname: SAMBASVC
+    register: result
+    failed_when: result.changed
+
+  - name: Ensure SMB service is absent.
+    ipaservice:
+      ipaadmin_password: MyPassword123
+      name: "cifs/{{ host1_fqdn }}"
+      state: absent
+    register: result
+    failed_when: not result.changed
+
+  - name: Ensure SMB service is absent, again.
+    ipaservice:
+      ipaadmin_password: MyPassword123
+      name: "cifs/{{ host1_fqdn }}"
+      state: absent
+    register: result
+    failed_when: result.changed
+
   # cleanup
 
   - name: Ensure services are absent.
@@ -551,6 +585,7 @@
       - HTTP/www.ansible.com
       - HTTP/svc.ihavenodns.info
       - HTTP/no.idontexist.local
+      - "cifs/{{ host1_fqdn }}"
       state: absent
 
   - name: Ensure host "{{ svc_fqdn }}" is absent

--- a/tests/service/test_service.yml
+++ b/tests/service/test_service.yml
@@ -113,7 +113,7 @@
         - PAD
       auth_ind: otp
       skip_host_check: no
-      force: no
+      force: yes
       requires_pre_auth: yes
       ok_as_delegate: no
       ok_to_auth_as_delegate: no
@@ -472,6 +472,26 @@
       ipaadmin_password: SomeADMINpassword
       name: "HTTP/{{ svc_fqdn }}"
       state: absent
+    register: result
+    failed_when: result.changed
+
+  - name: Ensure service is present, with multiple auth_ind values.
+    ipaservice:
+      ipaadmin_password: SomeADMINpassword
+      name: "HTTP/{{ svc_fqdn }}"
+      auth_ind: otp,radius
+      skip_host_check: no
+      force: yes
+    register: result
+    failed_when: not result.changed
+
+  - name: Ensure service is present, with multiple auth_ind values, again.
+    ipaservice:
+      ipaadmin_password: SomeADMINpassword
+      name: "HTTP/{{ svc_fqdn }}"
+      auth_ind: otp,radius
+      skip_host_check: no
+      force: yes
     register: result
     failed_when: result.changed
 

--- a/tests/service/test_service.yml
+++ b/tests/service/test_service.yml
@@ -515,6 +515,32 @@
     register: result
     failed_when: result.changed
 
+  - name: Ensure services are absent.
+    ipaservice:
+      ipaadmin_password: SomeADMINpassword
+      name:
+      - "HTTP/{{ svc_fqdn }}"
+      - HTTP/www.ansible.com
+      - HTTP/svc.ihavenodns.info
+      - HTTP/no.idontexist.local
+      continue: yes
+      state: absent
+    register: result
+    failed_when: not result.changed
+
+  - name: Ensure services are absent.
+    ipaservice:
+      ipaadmin_password: SomeADMINpassword
+      name:
+      - "HTTP/{{ svc_fqdn }}"
+      - HTTP/www.ansible.com
+      - HTTP/svc.ihavenodns.info
+      - HTTP/no.idontexist.local
+      continue: yes
+      state: absent
+    register: result
+    failed_when: result.changed
+
   # cleanup
 
   - name: Ensure services are absent.

--- a/tests/service/test_service.yml
+++ b/tests/service/test_service.yml
@@ -495,6 +495,26 @@
     register: result
     failed_when: result.changed
 
+  - name: Clear auth_ind.
+    ipaservice:
+      ipaadmin_password: SomeADMINpassword
+      name: "HTTP/{{ svc_fqdn }}"
+      auth_ind: ""
+      skip_host_check: no
+      force: yes
+    register: result
+    failed_when: not result.changed
+
+  - name: Clear auth_ind, again.
+    ipaservice:
+      ipaadmin_password: SomeADMINpassword
+      name: "HTTP/{{ svc_fqdn }}"
+      auth_ind: ""
+      skip_host_check: no
+      force: yes
+    register: result
+    failed_when: result.changed
+
   # cleanup
 
   - name: Ensure services are absent.


### PR DESCRIPTION
This PR fixes some issues found with the ipaservice module:

- Wrong error message when adding pac_type with `action: member`.
- Wrong error message when adding a service with missing service name.
- Not possible to add more than one `auth_ind`.
- Not possible to clear `auth_ind`.
- Wrong option `enabled` for `state` removed from documentation and module variables.
- Support for option `continue` when `state: absent`.
- Support for `service-add-smb`.

The issues are fixed with this PR, and details can be found in the individual commits.
