### PR TITLE
Add new inventory plugin for fetching IpaHostGroups

### DIFF
--- a/README-ldap3_orm.md
+++ b/README-ldap3_orm.md
@@ -1,0 +1,80 @@
+Hostgroup inventory plugin
+==========================
+
+Description
+-----------
+
+
+Features
+--------
+* Creates inventory from ``ipaHostGroup`` entries.
+* Uses [ldap3_orm configuration files](http://code.bsm-felder.de/doc/ldap3-orm/latest/classes/config.html).
+
+
+Supported FreeIPA Versions
+--------------------------
+
+FreeIPA versions 4.4.0 and up are supported by the ``freeipa_ldap3_orm`` inventory plugin.
+
+
+Requirements
+------------
+
+**Controller**
+* Ansible version: 2.8+
+* [ldap3-orm module](http://code.bsm-felder.de/doc/ldap3-orm) 2.6+
+* [keyring module](https://keyring.readthedocs.io) (optional)
+
+**Node**
+* Supported FreeIPA version (see above)
+
+
+Usage
+=====
+
+Ansible configuration file ``ansible.cfg``
+
+```ini
+[inventory]
+enable_plugins = freeipa.ansible_freeipa.freeipa_ldap3_orm
+```
+
+Example inventory file (needs [keyring module](https://keyring.readthedocs.io))
+
+```python
+url = "ldaps://ldap.example.com"
+base_dn = "cn=accounts,dc=example,dc=com"
+
+connconfig = dict(
+    user = "uid=guest,cn=users,cn=accounts,dc=example,dc=com",
+    password = keyring,
+)
+```
+
+By default freeipa does not allow to read out ``ipaHostGroup`` entries using
+anonymous binds. Therefore it is necessary to provide some credentials in
+the ``connconfig`` dictionary. Using keyring for safe password storage is
+recommended but not mandatory here. A plain-text password may be provided
+using ``password = "unencryptedSecret"``.
+
+The inventory file can be specified in ansible calls using the ``-i <path>``
+option, e.g.:
+
+    $ ansible-inventory -i ./example --list
+
+ldap3-orm configuration files can be specified using ``-i <path>``, allowing
+reusing existing configuration files.
+
+Hostgroups can be specified in playbooks as usual and will be fetched
+dynamically from the corresponding freeipa server, e.g.
+
+``ping.yml``
+```yaml
+---
+- hosts: ipaservers
+  tasks:
+    - name: ping all freeipa instances in hostgroup ipaservers
+      ping:
+```
+
+``$ ansible-playbook -i example ping.yml``

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Features
 * Cluster deployments: Server, replicas and clients in one playbook
 * One-time-password (OTP) support for client installation
 * Repair mode for clients
+* Ansible dynamic inventory plugin for using ipaHostGroups
 * Modules for dns forwarder management
 * Modules for dns record management
 * Modules for dns zone management

--- a/plugins/inventory/freeipa_ldap3_orm.py
+++ b/plugins/inventory/freeipa_ldap3_orm.py
@@ -1,0 +1,79 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2020 Christian Felder <webmaster@bsm-felder.de>
+# GNU General Public License v3.0+
+# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = """
+    name: freeipa_ldap3_orm
+    plugin_type: inventory
+    author:
+      - Christian Felder <webmaster@bsm-felder.de>
+    short_description: Ansible dynamic inventory plugin for ipaHostGroups.
+    description:
+      - Creates inventory from ipaHostGroup entries.
+      - Uses ldap3_orm configuration files.
+    requirements:
+    - "ldap3_orm >= 2.6.0"
+"""
+
+EXAMPLES = """
+# Reuses existing ldap3_orm configuration files
+# see: :py:class:`~ldap3_orm.config.config` for more details
+# example configuration file (needs keyring module), e.g.
+# ~/.config/ldap3-orm/default
+
+url = "ldaps://ldap.example.com"
+base_dn = "cn=accounts,dc=example,dc=com"
+
+connconfig = dict(
+    user = "uid=guest,cn=users,cn=accounts,dc=example,dc=com",
+    password = keyring,
+)
+"""
+
+
+from ldap3_orm import ObjectDef, Reader
+from ldap3_orm._config import read_config, config
+
+from ansible.module_utils.six import iteritems
+from ansible.plugins.inventory import BaseInventoryPlugin
+
+
+class InventoryModule(BaseInventoryPlugin):
+
+    NAME = "freeipa_ldap3_orm"
+
+    def verify_file(self, path):
+        # the following commands may raise an exception otherwise return True
+        cfg = read_config(path)
+        config.apply(cfg)
+        return True
+
+    def parse(self, inventory, loader, path, cache=True):
+        BaseInventoryPlugin.parse(self, inventory, loader, path, cache)
+        # late import to create connection in respect to loaded config
+        from ldap3_orm.connection import conn
+
+        hg_base_dn = config.userconfig.get("hostgroup_base_dn",
+                                           "cn=hostgroups," + config.base_dn)
+        group_bases = {}  # collect one-level of inherited host groups
+        r = Reader(conn, ObjectDef("ipaHostGroup", conn), hg_base_dn)
+        for hg in r.search():
+            group_name = hg.cn.value
+            group = self.inventory.add_group(group_name)
+            for dn in hg.member:
+                host = dn.split(',')[0].replace("fqdn=", '')
+                self.inventory.add_host(host, group)
+                for hg_member in hg.memberOf:
+                    if hg_member.endswith(hg_base_dn):
+                        hg_name = hg_member.split(',')[0].replace("cn=", '')
+                        group_bases.setdefault(hg_name, []).append(group_name)
+
+        # update host groups with one-level of indirect host members
+        for name, groups in iteritems(group_bases):
+            for group_name in groups:
+                self.inventory.add_child(name, group_name)

--- a/tests/ansible.cfg
+++ b/tests/ansible.cfg
@@ -1,5 +1,10 @@
 [defaults]
+inventory_plugins = ../plugins/inventory
 roles_path = ../roles:~/.ansible/roles:/usr/share/ansible/roles:/etc/ansible/roles
 library = ../plugins/modules:~/.ansible/plugins/modules:/usr/share/ansible/plugins/modules
 module_utils = ../plugins/module_utils:~/.ansible/plugins/module_utils:/usr/share/ansible/plugins/module_utils
 host_key_checking = false
+
+[inventory]
+# freeipa.ansible_freeipa.freeipa_ldap3_orm
+enable_plugins = freeipa_ldap3_orm

--- a/tests/test_inventory.py
+++ b/tests/test_inventory.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python
+
+import os
+import tempfile
+import textwrap
+import json
+
+from subprocess import Popen, PIPE
+
+import pytest
+
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+
+
+def get_inventory_content():
+    ipa_server_host = os.getenv("IPA_SERVER_HOST")
+    ipa_base_dn = os.getenv("IPA_BASE_DN")
+    return textwrap.dedent('''\
+    url = "ldaps://{}"
+    base_dn = "{}"
+
+    connconfig = dict(
+        user = "cn=Directory Manager",
+        password = "SomeDMpassword",
+    )
+    ''').format(ipa_server_host, ipa_base_dn).encode("utf8")
+
+
+def run_inventory():
+    with tempfile.NamedTemporaryFile() as inventory_file:
+        inventory_file.write(get_inventory_content())
+        inventory_file.flush()
+        cmd = [
+            "ansible-inventory",
+            "-i",
+            inventory_file.name,
+            "--list",
+        ]
+        process = Popen(cmd, stdout=PIPE, stderr=PIPE, cwd=SCRIPT_DIR)
+        process.wait()
+    return process
+
+
+@pytest.mark.skipif(
+    os.getenv("IPA_SERVER_HOST") is None or os.getenv("IPA_BASE_DN") is None,
+    reason="Environment variable IPA_SERVER_HOST and IPA_BASE_DN must be set",
+)
+def test_inventory():
+    process = run_inventory()
+    stdout, stderr = process.communicate()
+    result = json.loads(stdout)
+    assert "ipaservers" in result


### PR DESCRIPTION
* Creates inventory from ipaHostGroup entries.
* (Re-)uses ldap3_orm configuration files.
* Does not use ipalib which needs python-ldap which is not pure python
* Uses ldap3_orm which depends on ldap3 package (both pure python)

Imho ipalib is not avaiblable on macOS. Using this module one can query inventory from ipa servers using ipaHosts listed in ipaHostGroups