### PR TITLE
ipahostgroup: Add support for group membership management

### DIFF
--- a/README-hostgroup.md
+++ b/README-hostgroup.md
@@ -137,6 +137,8 @@ Variable | Description | Required
 `nomembers` | Suppress processing of membership attributes. (bool) | no
 `host` | List of host name strings assigned to this hostgroup. | no
 `hostgroup` | List of hostgroup name strings assigned to this hostgroup. | no
+`membermanager_user` | List of member manager users assigned to this hostgroup. Only usable with IPA versions 4.8.4 and up. | no
+`membermanager_group` | List of member manager groups assigned to this hostgroup. Only usable with IPA versions 4.8.4 and up. | no
 `action` | Work on hostgroup or member level. It can be on of `member` or `hostgroup` and defaults to `hostgroup`. | no
 `state` | The state to ensure. It can be one of `present` or `absent`, default: `present`. | no
 

--- a/tests/hostgroup/test_hostgroup_membermanager.yml
+++ b/tests/hostgroup/test_hostgroup_membermanager.yml
@@ -1,0 +1,210 @@
+---
+- name: Test hostgroup membermanagers
+  hosts: ipaserver
+  become: true
+  gather_facts: false
+
+  tasks:
+  - name: Ensure host-group testhostgroup is absent
+    ipahostgroup:
+      ipaadmin_password: SomeADMINpassword
+      name:
+      - testhostgroup
+      state: absent
+
+  - name: Ensure user manangeruser1 and manageruser2 is absent
+    ipauser:
+      ipaadmin_password: SomeADMINpassword
+      name: manageruser1,manageruser2
+      state: absent
+
+  - name: Ensure group managergroup1 and managergroup2 are absent
+    ipagroup:
+      ipaadmin_password: SomeADMINpassword
+      name: managergroup1,managergroup2
+      state: absent
+
+  - name: Ensure host-group testhostgroup is present
+    ipahostgroup:
+      ipaadmin_password: SomeADMINpassword
+      name:
+      - testhostgroup
+
+  - name: Ensure user manageruser1 and manageruser2 are present
+    ipauser:
+      ipaadmin_password: SomeADMINpassword
+      users:
+      - name: manageruser1
+        first: manageruser1
+        last: Last1
+      - name: manageruser2
+        first: manageruser2
+        last: Last2
+    register: result
+    failed_when: not result.changed
+
+  - name: Ensure managergroup1 is present
+    ipagroup:
+      ipaadmin_password: SomeADMINpassword
+      name: managergroup1
+    register: result
+    failed_when: not result.changed
+
+  - name: Ensure managergroup2 is present
+    ipagroup:
+      ipaadmin_password: SomeADMINpassword
+      name: managergroup2
+    register: result
+    failed_when: not result.changed
+
+  - name: Ensure membermanager user1 is present for testhostgroup
+    ipahostgroup:
+      ipaadmin_password: SomeADMINpassword
+      name: testhostgroup
+      membermanager_user: manageruser1
+    register: result
+    failed_when: not result.changed
+
+  - name: Ensure membermanager user1 is present for testhostgroup again
+    ipahostgroup:
+      ipaadmin_password: SomeADMINpassword
+      name: testhostgroup
+      membermanager_user: manageruser1
+    register: result
+    failed_when: result.changed
+
+  - name: Ensure membermanager group1 is present for testhostgroup
+    ipahostgroup:
+      ipaadmin_password: SomeADMINpassword
+      name: testhostgroup
+      membermanager_group: managergroup1
+    register: result
+    failed_when: not result.changed
+
+  - name: Ensure membermanager group1 is present for testhostgroup again
+    ipahostgroup:
+      ipaadmin_password: SomeADMINpassword
+      name: testhostgroup
+      membermanager_group: managergroup1
+    register: result
+    failed_when: result.changed
+
+  - name: Ensure membermanager user2 and group2 members are present for testhostgroup
+    ipahostgroup:
+      ipaadmin_password: SomeADMINpassword
+      name: testhostgroup
+      membermanager_user: manageruser2
+      membermanager_group: managergroup2
+      action: member
+    register: result
+    failed_when: not result.changed
+
+  - name: Ensure membermanager user2 and group2 members are present for testhostgroup again
+    ipahostgroup:
+      ipaadmin_password: SomeADMINpassword
+      name: testhostgroup
+      membermanager_user: manageruser2
+      membermanager_group: managergroup2
+      action: member
+    register: result
+    failed_when: result.changed
+
+  - name: Ensure membermanager user and group members are present for testhostgroup again
+    ipahostgroup:
+      ipaadmin_password: SomeADMINpassword
+      name: testhostgroup
+      membermanager_user: manageruser1,manageruser2
+      membermanager_group: managergroup1,managergroup2
+      action: member
+    register: result
+    failed_when: result.changed
+
+  - name: Ensure membermanager user1 and group1 members are absent for testhostgroup
+    ipahostgroup:
+      ipaadmin_password: SomeADMINpassword
+      name: testhostgroup
+      membermanager_user: manageruser1
+      membermanager_group: managergroup1
+      action: member
+      state: absent
+    register: result
+    failed_when: not result.changed
+
+  - name: Ensure membermanager user1 and group1 members are absent for testhostgroup again
+    ipahostgroup:
+      ipaadmin_password: SomeADMINpassword
+      name: testhostgroup
+      membermanager_user: manageruser1
+      membermanager_group: managergroup1
+      action: member
+      state: absent
+    register: result
+    failed_when: result.changed
+
+
+  - name: Ensure membermanager user1 and group1 members are present for testhostgroup
+    ipahostgroup:
+      ipaadmin_password: SomeADMINpassword
+      name: testhostgroup
+      membermanager_user: manageruser1
+      membermanager_group: managergroup1
+      action: member
+    register: result
+    failed_when: not result.changed
+
+  - name: Ensure membermanager user1 and group1 members are present for testhostgroup again
+    ipahostgroup:
+      ipaadmin_password: SomeADMINpassword
+      name: testhostgroup
+      membermanager_user: manageruser1
+      membermanager_group: managergroup1
+      action: member
+    register: result
+    failed_when: result.changed
+
+  - name: Ensure membermanager user and group members are absent for testhostgroup
+    ipahostgroup:
+      ipaadmin_password: SomeADMINpassword
+      name: testhostgroup
+      membermanager_user: manageruser1,manageruser2
+      membermanager_group: managergroup1,managergroup2
+      action: member
+      state: absent
+    register: result
+    failed_when: not result.changed
+
+  - name: Ensure membermanager user and group members are absent for testhostgroup again
+    ipahostgroup:
+      ipaadmin_password: SomeADMINpassword
+      name: testhostgroup
+      membermanager_user: manageruser1,manageruser2
+      membermanager_group: managergroup1,managergroup2
+      action: member
+      state: absent
+    register: result
+    failed_when: result.changed
+
+  - name: Ensure user manangeruser1 and manageruser2 is absent
+    ipauser:
+      ipaadmin_password: SomeADMINpassword
+      name: manageruser1,manageruser2
+      state: absent
+    register: result
+    failed_when: not result.changed
+
+  - name: Ensure group managergroup1 and managergroup2 are absent
+    ipagroup:
+      ipaadmin_password: SomeADMINpassword
+      name: managergroup1,managergroup2
+      state: absent
+    register: result
+    failed_when: not result.changed
+
+  - name: Ensure host-group testhostgroup is absent
+    ipahostgroup:
+      ipaadmin_password: SomeADMINpassword
+      name:
+      - testhostgroup
+      state: absent
+    register: result
+    failed_when: not result.changed


### PR DESCRIPTION
A group membership manager is a user or a group that can add members to
a group or remove members from a hostgroup.

This is related to https://pagure.io/freeipa/issue/8114

New parameters have been added to the module:
- `membermanager_user`: List of member manager users assigned to this
  group. Only usable with IPA versions 4.8.4 and up.
- `membermanager_group`: List of member manager groups assigned to this
  group. Only usable with IPA versions 4.8.4 and up.

These parameters behave like member parameters.

A new test has been added:
- tests/hostgroup/test_hostgroup_membermanager.yml