### PR TITLE
Add support for parameter `rename` on ipahostgroup.

### DIFF
--- a/README-hostgroup.md
+++ b/README-hostgroup.md
@@ -19,6 +19,8 @@ Supported FreeIPA Versions
 
 FreeIPA versions 4.4.0 and up are supported by the ipahostgroup module.
 
+Some variables are only supported on newer versions of FreeIPA. Check `Variables` section for details.
+
 
 Requirements
 ------------
@@ -105,6 +107,23 @@ Example playbook to make sure hosts and hostgroups are absent in databases hostg
       state: absent
 ```
 
+Example playbook to rename an existing playbook:
+
+```yaml
+---
+- name: Playbook to handle hostgroups
+  hosts: ipaserver
+  become: true
+
+  tasks:
+  # Ensure host-group databases is absent
+  - ipahostgroup:
+      ipaadmin_password: SomeADMINpassword
+      name: databases
+      rename: datalake
+      state: renamed
+```
+
 Example playbook to make sure host-group databases is absent:
 
 ```yaml
@@ -120,7 +139,6 @@ Example playbook to make sure host-group databases is absent:
       name: databases
       state: absent
 ```
-
 
 Variables
 =========
@@ -139,8 +157,9 @@ Variable | Description | Required
 `hostgroup` | List of hostgroup name strings assigned to this hostgroup. | no
 `membermanager_user` | List of member manager users assigned to this hostgroup. Only usable with IPA versions 4.8.4 and up. | no
 `membermanager_group` | List of member manager groups assigned to this hostgroup. Only usable with IPA versions 4.8.4 and up. | no
+`rename` \| `new_name` | Rename hostgroup to the provided name. Only usable with IPA versions 4.8.7 and up. | no
 `action` | Work on hostgroup or member level. It can be on of `member` or `hostgroup` and defaults to `hostgroup`. | no
-`state` | The state to ensure. It can be one of `present` or `absent`, default: `present`. | no
+`state` | The state to ensure. It can be one of `present`, `absent` or `renamed`, default: `present`. | no
 
 
 Authors

--- a/playbooks/hostgroup/rename-hostgroup.yml
+++ b/playbooks/hostgroup/rename-hostgroup.yml
@@ -1,0 +1,12 @@
+---
+- name: Playbook to handle hostgroups
+  hosts: ipaserver
+  become: yes
+
+  tasks:
+  - name : Rename host-group from `databases` to `datalake`
+    ipahostgroup:
+      ipaadmin_password: SomeADMINpassword
+      name: databases
+      rename: datalake
+      state: renamed

--- a/tests/hostgroup/test_hostgroup_rename.yml
+++ b/tests/hostgroup/test_hostgroup_rename.yml
@@ -1,0 +1,105 @@
+---
+- name: Test hostgroup
+  hosts: ipaserver
+  become: true
+  gather_facts: false
+
+  tasks:
+  - name: Ensure testing host-group are absent
+    ipahostgroup:
+      ipaadmin_password: SomeADMINpassword
+      name:
+      - databases
+      - datalake
+      - inexistenthostgroup
+      state: absent
+
+  - name: Ensure host-group databases is present
+    ipahostgroup:
+      ipaadmin_password: SomeADMINpassword
+      name: databases
+      state: present
+    register: result
+    failed_when: not result.changed
+
+  - name: Rename host-group from `databases` to `datalake`
+    ipahostgroup:
+      ipaadmin_password: SomeADMINpassword
+      name: databases
+      rename: datalake
+      state: renamed
+    register: result
+    failed_when: not result.changed
+
+  - name: Ensure host-group database was already absent
+    ipahostgroup:
+      ipaadmin_password: SomeADMINpassword
+      name: database
+      state: absent
+    register: result
+    failed_when: result.changed
+
+  - name: Rename host-group from `databases` to `datalake`, again
+    ipahostgroup:
+      ipaadmin_password: SomeADMINpassword
+      name: databases
+      rename: datalake
+      state: renamed
+    register: result
+    failed_when: result.changed or result.failed
+
+  - name: Rename host-group with same name.
+    ipahostgroup:
+      ipaadmin_password: SomeADMINpassword
+      name: datalake
+      rename: datalake
+      state: renamed
+    register: result
+    failed_when: result.changed
+
+  - name: Ensure testing hostgroups do not exist.
+    ipahostgroup:
+      ipaadmin_password: SomeADMINpassword
+      name: inexistenthostgroup,alsoinexistent
+      state: absent
+
+  - name: Rename inexistent host-group to an existing one.
+    ipahostgroup:
+      ipaadmin_password: SomeADMINpassword
+      name: inexistenthostgroup
+      rename: datalake
+      state: renamed
+    register: result
+    failed_when: result.changed or result.failed
+
+  - name: Rename inexistent host-group to a non-existing one.
+    ipahostgroup:
+      ipaadmin_password: SomeADMINpassword
+      name: inexistenthostgroup
+      rename: alsoinexistent
+      state: renamed
+    register: result
+    failed_when: not result.failed or "Attribute `rename` can not be used, unless hostgroup exists." not in result.msg
+
+  - name: Ensure host-group databases is present
+    ipahostgroup:
+      ipaadmin_password: SomeADMINpassword
+      name: databases
+      state: present
+
+  - name: Rename host-group to an existing one.
+    ipahostgroup:
+      ipaadmin_password: SomeADMINpassword
+      name: databases
+      rename: datalake
+      state: renamed
+    register: result
+    failed_when: not result.failed or "This entry already exists" not in result.msg
+
+  - name: Ensure host-group databases and datalake are absent
+    ipahostgroup:
+      ipaadmin_password: SomeADMINpassword
+      name:
+      - databases
+      - datalake
+      state: absent


### PR DESCRIPTION
FreeIPA 4.8.7 introduced an option to rename an existing hostgroup.
This patch adds support for renaming hostgroups if the option is
available on installed IPA version.