### PR TITLE
ipaserver/library/ipaserver_setup_ca.py: Fix bug introduced with ca-less PR

### DIFF
--- a/roles/ipaserver/library/ipaserver_setup_ca.py
+++ b/roles/ipaserver/library/ipaserver_setup_ca.py
@@ -265,7 +265,7 @@ def main():
     # additional
     options.domainlevel = ansible_module.params.get('domainlevel')
     options._http_ca_cert = ansible_module.params.get('_http_ca_cert')
-    if options._http_ca_cert is not None:
+    if options._http_ca_cert:
         options._http_ca_cert = decode_certificate(options._http_ca_cert)
 
     # init #################################################################


### PR DESCRIPTION
The ca-less PR introduced a bug when http_ca_cert is not set. The test
for loading the certificate is testing for None, but the string will only
be empty in this case.

Related: #298 (Install server and replicas without CA)