### PR TITLE
Fix forwardzone issues

### DIFF
--- a/README-dnsforwardzone.md
+++ b/README-dnsforwardzone.md
@@ -104,6 +104,7 @@ Variable | Description | Required
 &nbsp; | `port`: The forwarder IP port. | no
 `forwardpolicy` \| `idnsforwardpolicy` | Per-zone conditional forwarding policy. Possible values are `only`, `first`, `none`. Set to "none" to disable forwarding to global forwarder for this zone. In that case, conditional zone forwarders are disregarded. | no
 `skip_overlap_check` | Force DNS zone creation even if it will overlap with an existing zone. Defaults to False. | no
+`permission` | Allow DNS Forward Zone to be managed. (bool) | no
 `action` | Work on group or member level. It can be on of `member` or `dnsforwardzone` and defaults to `dnsforwardzone`. | no
 `state` | The state to ensure. It can be one of `present`, `absent`, `enabled` or `disabled`, default: `present`. | yes
 

--- a/README-dnsforwardzone.md
+++ b/README-dnsforwardzone.md
@@ -49,7 +49,7 @@ Example playbook to ensure presence of a forwardzone to ipa DNS:
   tasks:
   - name: ensure presence of forwardzone for DNS requests for example.com to 8.8.8.8
     ipadnsforwardzone:
-      ipaadmin_password: password01
+      ipaadmin_password: SomeADMINpassword
       state: present
       name: example.com
       forwarders:
@@ -59,13 +59,13 @@ Example playbook to ensure presence of a forwardzone to ipa DNS:
 
   - name: ensure the forward zone is disabled
     ipadnsforwardzone:
-      ipaadmin_password: password01
+      ipaadmin_password: SomeADMINpassword
       name: example.com
       state: disabled
 
   - name: ensure presence of multiple upstream DNS servers for example.com
     ipadnsforwardzone:
-      ipaadmin_password: password01
+      ipaadmin_password: SomeADMINpassword
       state: present
       name: example.com
       forwarders:
@@ -74,7 +74,7 @@ Example playbook to ensure presence of a forwardzone to ipa DNS:
 
   - name: ensure presence of another forwarder to any existing ones for example.com
     ipadnsforwardzone:
-      ipaadmin_password: password01
+      ipaadmin_password: SomeADMINpassword
       state: present
       name: example.com
       forwarders:
@@ -83,7 +83,7 @@ Example playbook to ensure presence of a forwardzone to ipa DNS:
 
   - name: ensure the forwarder for example.com does not exists (delete it if needed)
     ipadnsforwardzone:
-      ipaadmin_password: password01
+      ipaadmin_password: SomeADMINpassword
       name: example.com
       state: absent
 ```

--- a/README-dnsforwardzone.md
+++ b/README-dnsforwardzone.md
@@ -99,8 +99,10 @@ Variable | Description | Required
 `ipaadmin_principal` | The admin principal is a string and defaults to `admin` | no
 `ipaadmin_password` | The admin password is a string and is required if there is no admin ticket available on the node | no
 `name` \| `cn` | Zone name (FQDN). | yes if `state` == `present`
-`forwarders` \| `idnsforwarders` |  Per-zone conditional forwarding policy. Possible values are `only`, `first`, `none`) | no
-`forwardpolicy` \| `idnsforwardpolicy` | Per-zone conditional forwarding policy. Set to "none" to disable forwarding to global forwarder for this zone. In that case, conditional zone forwarders are disregarded. | no
+`forwarders` \| `idnsforwarders` |  Per-zone forwarders. A custom port can be specified for each forwarder. Options | no
+&nbsp; | `ip_address`: The forwarder IP address. | yes
+&nbsp; | `port`: The forwarder IP port. | no
+`forwardpolicy` \| `idnsforwardpolicy` | Per-zone conditional forwarding policy. Possible values are `only`, `first`, `none`. Set to "none" to disable forwarding to global forwarder for this zone. In that case, conditional zone forwarders are disregarded. | no
 `skip_overlap_check` | Force DNS zone creation even if it will overlap with an existing zone. Defaults to False. | no
 `action` | Work on group or member level. It can be on of `member` or `dnsforwardzone` and defaults to `dnsforwardzone`. | no
 `state` | The state to ensure. It can be one of `present`, `absent`, `enabled` or `disabled`, default: `present`. | yes

--- a/plugins/modules/ipadnsforwardzone.py
+++ b/plugins/modules/ipadnsforwardzone.py
@@ -217,6 +217,11 @@ def main():
             # Make sure forwardzone exists
             existing_resource = find_dnsforwardzone(ansible_module, name)
 
+            # validate parameters
+            if state == 'present':
+                if existing_resource is None and not forwarders:
+                    ansible_module.fail_json(msg='No forwarders specified.')
+
             if existing_resource is None and operation == "update":
                 # does not exist and is updating
                 # trying to update something that doesn't exist, so error

--- a/tests/dnsforwardzone/test_dnsforwardzone.yml
+++ b/tests/dnsforwardzone/test_dnsforwardzone.yml
@@ -106,6 +106,22 @@
     register: result
     failed_when: not result.changed
 
+  - name: change zone forward policy
+    ipadnsforwardzone:
+      ipaadmin_password: SomeADMINpassword
+      name: example.com
+      forwardpolicy: first
+    register: result
+    failed_when: not result.changed
+
+  - name: change zone forward policy, again
+    ipadnsforwardzone:
+      ipaadmin_password: SomeADMINpassword
+      name: example.com
+      forwardpolicy: first
+    register: result
+    failed_when: result.changed
+
   - name: ensure forwardzone example.com is absent.
     ipadnsforwardzone:
       ipaadmin_password: SomeADMINpassword
@@ -256,27 +272,15 @@
       action: member
       skip_overlap_check: true
     register: result
-    failed_when: result.changed
+    failed_when: not result.failed or "not found" not in result.msg
 
   - name: try to create a new forwarder with disabled state
     ipadnsforwardzone:
       ipaadmin_password: SomeADMINpassword
-      state: disabled
-      name: example.com
-      forwarders:
-        - ip_address: 4.4.4.4
-          port: 8053
-      skip_overlap_check: yes
-    register: result
-    failed_when: not result.changed
-
-  - name: ensure it stays disabled
-    ipadnsforwardzone:
-      ipaadmin_password: SomeADMINpassword
       name: example.com
       state: disabled
     register: result
-    failed_when: result.changed
+    failed_when: not result.failed or "not found" not in result.msg
 
   - name: Ensure forwardzone is not added without forwarders, with correct message.
     ipadnsforwardzone:

--- a/tests/dnsforwardzone/test_dnsforwardzone.yml
+++ b/tests/dnsforwardzone/test_dnsforwardzone.yml
@@ -7,13 +7,13 @@
   tasks:
   - name: ensure forwardzone example.com is absent - prep
     ipadnsforwardzone:
-      ipaadmin_password: password01
+      ipaadmin_password: SomeADMINpassword
       name: example.com
       state: absent
 
   - name: ensure forwardzone example.com is created
     ipadnsforwardzone:
-      ipaadmin_password: password01
+      ipaadmin_password: SomeADMINpassword
       state: present
       name: example.com
       forwarders:
@@ -25,7 +25,7 @@
 
   - name: ensure forwardzone example.com is present again
     ipadnsforwardzone:
-      ipaadmin_password: password01
+      ipaadmin_password: SomeADMINpassword
       state: present
       name: example.com
       forwarders:
@@ -37,7 +37,7 @@
 
   - name: ensure forwardzone example.com has two forwarders
     ipadnsforwardzone:
-      ipaadmin_password: password01
+      ipaadmin_password: SomeADMINpassword
       state: present
       name: example.com
       forwarders:
@@ -50,7 +50,7 @@
 
   - name: ensure forwardzone example.com has one forwarder again
     ipadnsforwardzone:
-      ipaadmin_password: password01
+      ipaadmin_password: SomeADMINpassword
       name: example.com
       forwarders:
         - 8.8.8.8
@@ -62,7 +62,7 @@
 
   - name: skip_overlap_check can only be set on creation so change nothing
     ipadnsforwardzone:
-      ipaadmin_password: password01
+      ipaadmin_password: SomeADMINpassword
       name: example.com
       forwarders:
         - 8.8.8.8
@@ -74,7 +74,7 @@
 
   - name: change all the things at once
     ipadnsforwardzone:
-      ipaadmin_password: password01
+      ipaadmin_password: SomeADMINpassword
       state: present
       name: example.com
       forwarders:
@@ -87,13 +87,13 @@
 
   - name: ensure forwardzone example.com is absent for next testset
     ipadnsforwardzone:
-      ipaadmin_password: password01
+      ipaadmin_password: SomeADMINpassword
       name: example.com
       state: absent
 
   - name: ensure forwardzone example.com is created with minimal args
     ipadnsforwardzone:
-      ipaadmin_password: password01
+      ipaadmin_password: SomeADMINpassword
       state: present
       name: example.com
       skip_overlap_check: true
@@ -104,7 +104,7 @@
 
   - name: add a forwarder to any existing ones
     ipadnsforwardzone:
-      ipaadmin_password: password01
+      ipaadmin_password: SomeADMINpassword
       state: present
       name: example.com
       forwarders:
@@ -115,7 +115,7 @@
 
   - name: check the list of forwarders is what we expect
     ipadnsforwardzone:
-      ipaadmin_password: password01
+      ipaadmin_password: SomeADMINpassword
       state: present
       name: example.com
       forwarders:
@@ -127,7 +127,7 @@
 
   - name: remove a single forwarder
     ipadnsforwardzone:
-      ipaadmin_password: password01
+      ipaadmin_password: SomeADMINpassword
       state: absent
       name: example.com
       forwarders:
@@ -138,7 +138,7 @@
 
   - name: check the list of forwarders is what we expect now
     ipadnsforwardzone:
-      ipaadmin_password: password01
+      ipaadmin_password: SomeADMINpassword
       state: present
       name: example.com
       forwarders:
@@ -149,13 +149,13 @@
 
   - name: ensure forwardzone example.com is absent again
     ipadnsforwardzone:
-      ipaadmin_password: password01
+      ipaadmin_password: SomeADMINpassword
       name: example.com
       state: absent
 
   - name: try to create a new forwarder with action=member
     ipadnsforwardzone:
-      ipaadmin_password: password01
+      ipaadmin_password: SomeADMINpassword
       state: present
       name: example.com
       forwarders:
@@ -167,13 +167,13 @@
 
   - name: ensure forwardzone example.com is absent - tidy up
     ipadnsforwardzone:
-      ipaadmin_password: password01
+      ipaadmin_password: SomeADMINpassword
       name: example.com
       state: absent
 
   - name: try to create a new forwarder is disabled state
     ipadnsforwardzone:
-      ipaadmin_password: password01
+      ipaadmin_password: SomeADMINpassword
       state: disabled
       name: example.com
       forwarders:
@@ -184,7 +184,7 @@
 
   - name: enable the forwarder
     ipadnsforwardzone:
-      ipaadmin_password: password01
+      ipaadmin_password: SomeADMINpassword
       name: example.com
       state: enabled
     register: result
@@ -192,7 +192,7 @@
 
   - name: disable the forwarder again
     ipadnsforwardzone:
-      ipaadmin_password: password01
+      ipaadmin_password: SomeADMINpassword
       name: example.com
       state: disabled
       action: member
@@ -201,7 +201,7 @@
 
   - name: ensure it stays disabled
     ipadnsforwardzone:
-      ipaadmin_password: password01
+      ipaadmin_password: SomeADMINpassword
       name: example.com
       state: disabled
     register: result
@@ -209,6 +209,6 @@
 
   - name: ensure forwardzone example.com is absent - tidy up
     ipadnsforwardzone:
-      ipaadmin_password: password01
+      ipaadmin_password: SomeADMINpassword
       name: example.com
       state: absent

--- a/tests/dnsforwardzone/test_dnsforwardzone.yml
+++ b/tests/dnsforwardzone/test_dnsforwardzone.yml
@@ -5,10 +5,12 @@
   gather_facts: false
 
   tasks:
-  - name: ensure forwardzone example.com is absent - prep
+  - name: ensure test forwardzones are absent - prep
     ipadnsforwardzone:
       ipaadmin_password: SomeADMINpassword
-      name: example.com
+      name:
+      - example.com
+      - newfailzone.com
       state: absent
 
   - name: ensure forwardzone example.com is created
@@ -206,6 +208,13 @@
       state: disabled
     register: result
     failed_when: result.changed
+
+  - name: Ensure forwardzone is not added without forwarders, with correct message.
+    ipadnsforwardzone:
+      ipaadmin_password: SomeADMINpassword
+      name: newfailzone.com
+    register: result
+    failed_when: not result.failed or "No forwarders specified" not in result.msg
 
   - name: ensure forwardzone example.com is absent - tidy up
     ipadnsforwardzone:

--- a/tests/dnsforwardzone/test_dnsforwardzone.yml
+++ b/tests/dnsforwardzone/test_dnsforwardzone.yml
@@ -5,7 +5,7 @@
   gather_facts: false
 
   tasks:
-  - name: ensure test forwardzones are absent - prep
+  - name: ensure test forwardzones are absent
     ipadnsforwardzone:
       ipaadmin_password: SomeADMINpassword
       name:
@@ -19,7 +19,7 @@
       state: present
       name: example.com
       forwarders:
-        - 8.8.8.8
+        - ip_address: 8.8.8.8
       forwardpolicy: first
       skip_overlap_check: true
     register: result
@@ -31,7 +31,7 @@
       state: present
       name: example.com
       forwarders:
-        - 8.8.8.8
+        - ip_address: 8.8.8.8
       forwardpolicy: first
       skip_overlap_check: true
     register: result
@@ -43,19 +43,22 @@
       state: present
       name: example.com
       forwarders:
-        - 8.8.8.8
-        - 4.4.4.4
+        - ip_address: 8.8.8.8
+        - ip_address: 4.4.4.4
+          port: 8053
       forwardpolicy: first
       skip_overlap_check: true
     register: result
     failed_when: not result.changed
+
+  - pause:
 
   - name: ensure forwardzone example.com has one forwarder again
     ipadnsforwardzone:
       ipaadmin_password: SomeADMINpassword
       name: example.com
       forwarders:
-        - 8.8.8.8
+        - ip_address: 8.8.8.8
       forwardpolicy: first
       skip_overlap_check: true
       state: present
@@ -67,7 +70,7 @@
       ipaadmin_password: SomeADMINpassword
       name: example.com
       forwarders:
-        - 8.8.8.8
+        - ip_address: 8.8.8.8
       forwardpolicy: first
       skip_overlap_check: false
       state: present
@@ -80,8 +83,9 @@
       state: present
       name: example.com
       forwarders:
-        - 8.8.8.8
-        - 4.4.4.4
+        - ip_address: 8.8.8.8
+        - ip_address: 4.4.4.4
+          port: 8053
       forwardpolicy: only
       skip_overlap_check: false
     register: result
@@ -100,7 +104,7 @@
       name: example.com
       skip_overlap_check: true
       forwarders:
-        - 8.8.8.8
+        - ip_address: 8.8.8.8
     register: result
     failed_when: not result.changed
 
@@ -110,7 +114,8 @@
       state: present
       name: example.com
       forwarders:
-        - 4.4.4.4
+        - ip_address: 4.4.4.4
+          port: 8053
       action: member
     register: result
     failed_when: not result.changed
@@ -121,8 +126,9 @@
       state: present
       name: example.com
       forwarders:
-        - 4.4.4.4
-        - 8.8.8.8
+        - ip_address: 4.4.4.4
+          port: 8053
+        - ip_address: 8.8.8.8
       action: member
     register: result
     failed_when: result.changed
@@ -133,7 +139,7 @@
       state: absent
       name: example.com
       forwarders:
-        - 8.8.8.8
+        - ip_address: 8.8.8.8
       action: member
     register: result
     failed_when: not result.changed
@@ -144,7 +150,8 @@
       state: present
       name: example.com
       forwarders:
-        - 4.4.4.4
+        - ip_address: 4.4.4.4
+          port: 8053
       action: member
     register: result
     failed_when: result.changed
@@ -161,7 +168,8 @@
       state: present
       name: example.com
       forwarders:
-        - 4.4.4.4
+        - ip_address: 4.4.4.4
+          port: 8053
       action: member
       skip_overlap_check: true
     register: result
@@ -179,7 +187,8 @@
       state: disabled
       name: example.com
       forwarders:
-        - 4.4.4.4
+        - ip_address: 4.4.4.4
+          port: 8053
       skip_overlap_check: true
     register: result
     failed_when: not result.changed

--- a/tests/dnsforwardzone/test_dnsforwardzone.yml
+++ b/tests/dnsforwardzone/test_dnsforwardzone.yml
@@ -51,8 +51,6 @@
     register: result
     failed_when: not result.changed
 
-  - pause:
-
   - name: ensure forwardzone example.com has one forwarder again
     ipadnsforwardzone:
       ipaadmin_password: SomeADMINpassword
@@ -63,7 +61,7 @@
       skip_overlap_check: true
       state: present
     register: result
-    failed_when: not result.changed
+    failed_when: result.changed
 
   - name: skip_overlap_check can only be set on creation so change nothing
     ipadnsforwardzone:
@@ -77,6 +75,22 @@
     register: result
     failed_when: result.changed
 
+  - name: ensure forwardzone example.com is absent.
+    ipadnsforwardzone:
+      ipaadmin_password: SomeADMINpassword
+      name: example.com
+      state: absent
+    register: result
+    failed_when: not result.changed
+
+  - name: ensure forwardzone example.com is absent, again.
+    ipadnsforwardzone:
+      ipaadmin_password: SomeADMINpassword
+      name: example.com
+      state: absent
+    register: result
+    failed_when: result.changed
+
   - name: change all the things at once
     ipadnsforwardzone:
       ipaadmin_password: SomeADMINpassword
@@ -87,11 +101,12 @@
         - ip_address: 4.4.4.4
           port: 8053
       forwardpolicy: only
-      skip_overlap_check: false
+      skip_overlap_check: true
+      permission: yes
     register: result
     failed_when: not result.changed
 
-  - name: ensure forwardzone example.com is absent for next testset
+  - name: ensure forwardzone example.com is absent.
     ipadnsforwardzone:
       ipaadmin_password: SomeADMINpassword
       name: example.com
@@ -156,6 +171,74 @@
     register: result
     failed_when: result.changed
 
+  - name: Add a permission for per-forward zone access delegation.
+    ipadnsforwardzone:
+      ipaadmin_password: SomeADMINpassword
+      name: example.com
+      permission: yes
+      action: member
+    register: result
+    failed_when: not result.changed
+
+  - name: Add a permission for per-forward zone access delegation, again.
+    ipadnsforwardzone:
+      ipaadmin_password: SomeADMINpassword
+      name: example.com
+      permission: yes
+      action: member
+    register: result
+    failed_when: result.changed
+
+  - name: Remove a permission for per-forward zone access delegation.
+    ipadnsforwardzone:
+      ipaadmin_password: SomeADMINpassword
+      name: example.com
+      permission: no
+      action: member
+    register: result
+    failed_when: not result.changed
+
+  - name: Remove a permission for per-forward zone access delegation, again.
+    ipadnsforwardzone:
+      ipaadmin_password: SomeADMINpassword
+      name: example.com
+      permission: no
+      action: member
+    register: result
+    failed_when: result.changed
+
+  - name: disable the forwarder
+    ipadnsforwardzone:
+      ipaadmin_password: SomeADMINpassword
+      name: example.com
+      state: disabled
+    register: result
+    failed_when: not result.changed
+
+  - name: disable the forwarder again
+    ipadnsforwardzone:
+      ipaadmin_password: SomeADMINpassword
+      name: example.com
+      state: disabled
+    register: result
+    failed_when: result.changed
+
+  - name: enable the forwarder
+    ipadnsforwardzone:
+      ipaadmin_password: SomeADMINpassword
+      name: example.com
+      state: enabled
+    register: result
+    failed_when: not result.changed
+
+  - name: enable the forwarder, again
+    ipadnsforwardzone:
+      ipaadmin_password: SomeADMINpassword
+      name: example.com
+      state: enabled
+    register: result
+    failed_when: result.changed
+
   - name: ensure forwardzone example.com is absent again
     ipadnsforwardzone:
       ipaadmin_password: SomeADMINpassword
@@ -175,13 +258,7 @@
     register: result
     failed_when: result.changed
 
-  - name: ensure forwardzone example.com is absent - tidy up
-    ipadnsforwardzone:
-      ipaadmin_password: SomeADMINpassword
-      name: example.com
-      state: absent
-
-  - name: try to create a new forwarder is disabled state
+  - name: try to create a new forwarder with disabled state
     ipadnsforwardzone:
       ipaadmin_password: SomeADMINpassword
       state: disabled
@@ -189,24 +266,7 @@
       forwarders:
         - ip_address: 4.4.4.4
           port: 8053
-      skip_overlap_check: true
-    register: result
-    failed_when: not result.changed
-
-  - name: enable the forwarder
-    ipadnsforwardzone:
-      ipaadmin_password: SomeADMINpassword
-      name: example.com
-      state: enabled
-    register: result
-    failed_when: not result.changed
-
-  - name: disable the forwarder again
-    ipadnsforwardzone:
-      ipaadmin_password: SomeADMINpassword
-      name: example.com
-      state: disabled
-      action: member
+      skip_overlap_check: yes
     register: result
     failed_when: not result.changed
 
@@ -228,5 +288,7 @@
   - name: ensure forwardzone example.com is absent - tidy up
     ipadnsforwardzone:
       ipaadmin_password: SomeADMINpassword
-      name: example.com
+      name:
+      - example.com
+      - newfailzone.com
       state: absent


### PR DESCRIPTION
This PR adresses several issues on ipadnsforwardzone module:

* Change ipaadmin_password in tests to ease test automation;
* Allow exclusion of multiple zones in the same playbook;
* Fix error messages in several places;
* Add support for defining forwarders with `ip_address` and `port`, using variables;
* Add support for attribute `permission`;
* Allow modification of forward policy;

Please, see individual commits for more details.