### PR TITLE
Add suppport for changing password of symmetric vaults.

### DIFF
--- a/README-vault.md
+++ b/README-vault.md
@@ -165,6 +165,22 @@ Example playbook to make sure vault data is absent in a symmetric vault:
       state: absent
 ```
 
+Example playbook to change the password of a symmetric:
+
+```yaml
+---
+- name: Playbook to handle vaults
+  hosts: ipaserver
+  become: true
+
+  tasks:
+  - ipavault:
+      ipaadmin_password: SomeADMINpassword
+      name: symvault
+      old_password: SomeVAULTpassword
+      new_password: SomeNEWpassword
+```
+
 Example playbook to make sure vault is absent:
 
 ```yaml
@@ -197,8 +213,11 @@ Variable | Description | Required
 `name` \| `cn` | The list of vault name strings. | yes
 `description` | The vault description string. | no
 `nomembers` | Suppress processing of membership attributes. (bool) | no
-`password ` \| `vault_password` \| `ipavaultpassword` | Vault password. | no
-`public_key ` \| `vault_public_key` \| `ipavaultpublickey` | Base64 encoded vault public key. | no
+`password` \| `vault_password` \| `ipavaultpassword` \| `old_password`| Vault password. | no
+`password_file` \| `vault_password_file` \| `old_password_file`| File containing Base64 encoded Vault password. | no
+`new_password` | Vault new password. | no
+`new_password_file` | File containing Base64 encoded new Vault password. | no
+`public_key ` \| `vault_public_key` \| `old_password_file` | Base64 encoded vault public key. | no
 `public_key_file` \| `vault_public_key_file` | Path to file with public key. | no
 `private_key `\| `vault_private_key` | Base64 encoded vault private key. Used only to retrieve data. | no
 `private_key_file` \| `vault_private_key_file` | Path to file with private key. Used only to retrieve data. | no

--- a/playbooks/vault/change-password-symmetric-vault.yml
+++ b/playbooks/vault/change-password-symmetric-vault.yml
@@ -10,7 +10,7 @@
       ipaadmin_password: SomeADMINpassword
       name: symvault
       password: SomeVAULTpassword
-  - name: Change vault passord.
+  - name: Change vault password.
     ipavault:
       ipaadmin_password: SomeADMINpassword
       name: symvault

--- a/tests/vault/test_vault_symmetric.yml
+++ b/tests/vault/test_vault_symmetric.yml
@@ -178,6 +178,61 @@
     register: result
     failed_when: result.data != 'Hello World.' or result.changed
 
+  - name: Change vault password.
+    ipavault:
+      ipaadmin_password: SomeADMINpassword
+      name: symvault
+      password: SomeVAULTpassword
+      new_password: SomeNEWpassword
+    register: result
+    failed_when: not result.changed
+
+  - name: Retrieve data from symmetric vault, with wrong password.
+    ipavault:
+      ipaadmin_password: SomeADMINpassword
+      name: symvault
+      password: SomeVAULTpassword
+      state: retrieved
+    register: result
+    failed_when: not result.failed or "Invalid credentials" not in result.msg
+
+  - name: Change vault password, with wrong `old_password`.
+    ipavault:
+      ipaadmin_password: SomeADMINpassword
+      name: symvault
+      password: SomeVAULTpassword
+      new_password: SomeNEWpassword
+    register: result
+    failed_when: not result.failed or "Invalid credentials" not in result.msg
+
+  - name: Retrieve data from symmetric vault, with new password.
+    ipavault:
+      ipaadmin_password: SomeADMINpassword
+      name: symvault
+      password: SomeNEWpassword
+      state: retrieved
+    register: result
+    failed_when: result.data != 'Hello World.' or result.changed
+
+  - name: Try to add vault with multiple passwords.
+    ipavault:
+      ipaadmin_password: SomeADMINpassword
+      name: inexistentvault
+      password: SomeVAULTpassword
+      password_file: "{{ ansible_env.HOME }}/password.txt"
+    register: result
+    failed_when: not result.failed or "parameters are mutually exclusive" not in result.msg
+
+  - name: Try to add vault with multiple new passwords.
+    ipavault:
+      ipaadmin_password: SomeADMINpassword
+      name: inexistentvault
+      password: SomeVAULTpassword
+      new_password: SomeVAULTpassword
+      new_password_file: "{{ ansible_env.HOME }}/password.txt"
+    register: result
+    failed_when: not result.failed or "parameters are mutually exclusive" not in result.msg
+
   - name: Ensure symmetric vault is absent
     ipavault:
       ipaadmin_password: SomeADMINpassword
@@ -193,6 +248,15 @@
       state: absent
     register: result
     failed_when: result.changed
+
+  - name: Try to change password of inexistent vault.
+    ipavault:
+      ipaadmin_password: SomeADMINpassword
+      name: inexistentvault
+      password: SomeVAULTpassword
+      new_password: SomeNEWpassword
+    register: result
+    failed_when: not result.failed or "Cannot modify password of inexistent vault" not in result.msg
 
   - name: Cleanup testing environment.
     import_tasks: env_cleanup.yml


### PR DESCRIPTION
Allows changing passwords of symmetric waults, using a new variable
`new_password` (or the file-base version, `new_password_file`). The
old password must be passed using the `password` or `password_file`
variables that also received new aliases `old_password` and
`old_password_file`, respectively.

Tests were modyfied to reflect the changes.