### PR TITLE
Fixes service disable when service has no certificates attached.

### DIFF
--- a/plugins/modules/ipaservice.py
+++ b/plugins/modules/ipaservice.py
@@ -812,9 +812,11 @@ def main():
 
             elif state == "disabled":
                 if action == "service":
-                    if res_find is not None and \
-                       len(res_find.get('usercertificate', [])) > 0:
-                        commands.append([name, 'service_disable', {}])
+                    if res_find is not None:
+                        has_cert = bool(res_find.get('usercertificate'))
+                        has_keytab = res_find.get('has_keytab', False)
+                        if has_cert or has_keytab:
+                            commands.append([name, 'service_disable', {}])
                 else:
                     ansible_module.fail_json(
                         msg="Invalid action '%s' for state '%s'" %

--- a/tests/service/test_service_disable.yml
+++ b/tests/service/test_service_disable.yml
@@ -1,0 +1,68 @@
+---
+- name: Playbook to manage IPA service.
+  hosts: ipaserver
+  become: yes
+  gather_facts: yes
+
+  tasks:
+  - name: Ensure service is absent
+    ipaservice:
+      ipaadmin_password: SomeADMINpassword
+      name: "mysvc1/{{ ansible_fqdn }}"
+
+  - name: Ensure service is present
+    ipaservice:
+      ipaadmin_password: SomeADMINpassword
+      name: "mysvc1/{{ ansible_fqdn }}"
+      certificate:
+        - MIIC/zCCAeegAwIBAgIUMNHIbn+hhrOVew/2WbkteisV29QwDQYJKoZIhvcNAQELBQAwDzENMAsGA1UEAwwEdGVzdDAeFw0yMDAyMDQxNDQxMDhaFw0zMDAyMDExNDQxMDhaMA8xDTALBgNVBAMMBHRlc3QwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC+XVVGFYpHVkcDfVnNInE1Y/pFciegdzqTjMwUWlRL4Zt3u96GhaMLRbtk+OfEkzLUAhWBOwEraELJzMLJOMvjYF3C+TiGO7dStFLikZmccuSsSIXjnzIPwBXa8KvgRVRyGLoVvGbLJvmjfMXp0nIToTx/i74KF9S++WEes9H5ErJ99CDhLKFgq0amnvsgparYXhypHaRLnikn0vQINt55YoEd1s4KrvEcD2VdZkIMPbLRu2zFvMprF3cjQQG4LT9ggfEXNIPZ1nQWAnAsu7OJEkNF+E4Mkmpcxj9aGUVt5bsq1D+Tzj3GsidSX0nSNcZ2JltXRnL/5v63g5cZyE+nAgMBAAGjUzBRMB0GA1UdDgQWBBRV0j7JYukuH/r/t9+QeNlRLXDlEDAfBgNVHSMEGDAWgBRV0j7JYukuH/r/t9+QeNlRLXDlEDAPBgNVHRMBAf8EBTADAQH/MA0GCSqGSIb3DQEBCwUAA4IBAQCgVy1+1kNwHs5y1Zp0WjMWGCJC6/zw7FDG4OW5r2GJiCXZYdJ0UonY9ZtoVLJPrp2/DAv1m5DtnDhBYqicuPgLzEkOS1KdTi20Otm/J4yxLLrZC5W4x0XOeSVPXOJuQWfwQ5pPvKkn6WxYUYkGwIt1OH2nSMngkbami3CbSmKZOCpgQIiSlQeDJ8oGjWFMLDymYSHoVOIXHwNoooyEiaio3693l6noobyGv49zyCVLVR1DC7i6RJ186ql0av+D4vPoiF5mX7+sKC2E8xEj9uKQ5GTWRh59VnRBVC/SiMJ/H78tJnBAvoBwXxSEvj8Z3Kjm/BQqZfv4IBsA5yqV7MVq
+      force: no
+    register: result
+    failed_when: not result.changed
+
+  - name: Obtain keytab
+    shell: ipa-getkeytab -s "{{ ansible_fqdn }}" -p "mysvc1/{{ ansible_fqdn }}" -k mysvc1.keytab
+
+  - name: Verify keytab
+    shell: ipa service-find "mysvc1/{{ ansible_fqdn }}"
+    register: result
+    failed_when: result.failed or result.stdout | regex_search(" Keytab. true")
+
+  - name: Ensure service is disabled
+    ipaservice:
+      ipaadmin_password: SomeADMINpassword
+      name: "mysvc1/{{ ansible_fqdn }}"
+      state: disabled
+    register: result
+    failed_when: not result.changed
+
+  - name: Verify keytab
+    shell: ipa service-find "mysvc1/{{ ansible_fqdn }}"
+    register: result
+    failed_when: result.failed or result.stdout | regex_search(" Keytab. true")
+
+  - name: Obtain keytab
+    shell: ipa-getkeytab -s "{{ ansible_fqdn }}" -p "mysvc1/{{ ansible_fqdn }}" -k mysvc1.keytab
+
+  - name: Verify keytab
+    shell: ipa service-find "mysvc1/{{ ansible_fqdn }}"
+    register: result
+    failed_when: result.failed or result.stdout | regex_search(" Keytab. true")
+
+  - name: Ensure service is disabled
+    ipaservice:
+      ipaadmin_password: SomeADMINpassword
+      name: "mysvc1/{{ ansible_fqdn }}"
+      state: disabled
+    register: result
+    failed_when: not result.changed
+
+  - name: Verify keytab
+    shell: ipa service-find "mysvc1/{{ ansible_fqdn }}"
+    register: result
+    failed_when: result.failed or result.stdout | regex_search(" Keytab. true")
+
+  - name: Ensure service is absent
+    ipaservice:
+      ipaadmin_password: SomeADMINpassword
+      name: "mysvc1/{{ ansible_fqdn }}"


### PR DESCRIPTION
Services without certificates, but with keytabs were not being
disabled. This change allows execution of service_disable if
there is a certificate or if has_keytab is true.

A new test was added to verify the issue:

    tests/service/test_service_disable.yml