### PR TITLE
ipa[host]group: Fix membermanager unknow user issue

### DIFF
--- a/plugins/modules/ipagroup.py
+++ b/plugins/modules/ipagroup.py
@@ -507,16 +507,15 @@ def main():
             # All "already a member" and "not a member" failures in the
             # result are ignored. All others are reported.
             errors = []
-            if "failed" in result and len(result["failed"]) > 0:
-                for item in result["failed"]:
-                    failed_item = result["failed"][item]
-                    for member_type in failed_item:
-                        for member, failure in failed_item[member_type]:
-                            if "already a member" in failure \
-                               or "not a member" in failure:
-                                continue
-                            errors.append("%s: %s %s: %s" % (
-                                command, member_type, member, failure))
+            for failed_item in result.get("failed", []):
+                failed = result["failed"][failed_item]
+                for member_type in failed:
+                    for member, failure in failed[member_type]:
+                        if "already a member" in failure \
+                           or "not a member" in failure:
+                            continue
+                        errors.append("%s: %s %s: %s" % (
+                            command, member_type, member, failure))
             if len(errors) > 0:
                 ansible_module.fail_json(msg=", ".join(errors))
 

--- a/plugins/modules/ipahostgroup.py
+++ b/plugins/modules/ipahostgroup.py
@@ -423,14 +423,15 @@ def main():
             # All "already a member" and "not a member" failures in the
             # result are ignored. All others are reported.
             errors = []
-            if "failed" in result and "member" in result["failed"]:
-                failed = result["failed"]["member"]
+            for failed_item in result.get("failed", []):
+                failed = result["failed"][failed_item]
                 for member_type in failed:
                     for member, failure in failed[member_type]:
-                        if "already a member" not in failure \
-                           and "not a member" not in failure:
-                            errors.append("%s: %s %s: %s" % (
-                                command, member_type, member, failure))
+                        if "already a member" in failure \
+                           or "not a member" in failure:
+                            continue
+                        errors.append("%s: %s %s: %s" % (
+                            command, member_type, member, failure))
             if len(errors) > 0:
                 ansible_module.fail_json(msg=", ".join(errors))
 

--- a/tests/group/test_group_membermanager.yml
+++ b/tests/group/test_group_membermanager.yml
@@ -8,7 +8,7 @@
   - name: Ensure user manangeruser1 and manageruser2 is absent
     ipauser:
       ipaadmin_password: SomeADMINpassword
-      name: manageruser1,manageruser2
+      name: manageruser1,manageruser2,unknown_user
       state: absent
 
   - name: Ensure group testgroup, managergroup1 and managergroup2 are absent
@@ -184,6 +184,15 @@
       state: absent
     register: result
     failed_when: not result.changed
+
+  - name: Ensure unknown membermanager_user member failure
+    ipagroup:
+      ipaadmin_password: SomeADMINpassword
+      name: testgroup
+      membermanager_user: unknown_user
+      action: member
+    register: result
+    failed_when: result.changed or "no such entry" not in result.msg
 
   - name: Ensure group testgroup, managergroup1 and managergroup2 are absent
     ipagroup:

--- a/tests/hostgroup/test_hostgroup_membermanager.yml
+++ b/tests/hostgroup/test_hostgroup_membermanager.yml
@@ -15,7 +15,7 @@
   - name: Ensure user manangeruser1 and manageruser2 is absent
     ipauser:
       ipaadmin_password: SomeADMINpassword
-      name: manageruser1,manageruser2
+      name: manageruser1,manageruser2,unknown_user
       state: absent
 
   - name: Ensure group managergroup1 and managergroup2 are absent
@@ -199,6 +199,15 @@
       state: absent
     register: result
     failed_when: not result.changed
+
+  - name: Ensure unknown membermanager_user member failure
+    ipahostgroup:
+      ipaadmin_password: SomeADMINpassword
+      name: testhostgroup
+      membermanager_user: unknown_user
+      action: member
+    register: result
+    failed_when: result.changed or "no such entry" not in result.msg
 
   - name: Ensure host-group testhostgroup is absent
     ipahostgroup:


### PR DESCRIPTION
If a unknown membermanager user presence will be ensured, the unknown user
error was ignored. This has been fixed in ipagroup. The code for the error
handling in ipagroup and ipahostgroup has been adapted because of this.

New tests for tests/[host]group/test_[host]group_membermnager.yml have been
added.