### PR TITLE
ipa[user,host]: Fail on duplucate names in the users and hosts lists

### DIFF
--- a/plugins/modules/ipahost.py
+++ b/plugins/modules/ipahost.py
@@ -799,10 +799,15 @@ def main():
         server_realm = api_get_realm()
 
         commands = []
+        host_set = set()
 
         for host in names:
             if isinstance(host, dict):
                 name = host.get("name")
+                if name in host_set:
+                    ansible_module.fail_json(
+                        msg="host '%s' is used more than once" % name)
+                host_set.add(name)
                 description = host.get("description")
                 locality = host.get("locality")
                 location = host.get("location")
@@ -1336,6 +1341,8 @@ def main():
 
             else:
                 ansible_module.fail_json(msg="Unkown state '%s'" % state)
+
+        del host_set
 
         # Execute commands
 

--- a/plugins/modules/ipauser.py
+++ b/plugins/modules/ipauser.py
@@ -958,10 +958,15 @@ def main():
         # commands
 
         commands = []
+        user_set = set()
 
         for user in names:
             if isinstance(user, dict):
                 name = user.get("name")
+                if name in user_set:
+                    ansible_module.fail_json(
+                        msg="user '%s' is used more than once" % name)
+                user_set.add(name)
                 # present
                 first = user.get("first")
                 last = user.get("last")
@@ -1369,6 +1374,8 @@ def main():
 
             else:
                 ansible_module.fail_json(msg="Unkown state '%s'" % state)
+
+        del user_set
 
         # Execute commands
 

--- a/tests/host/test_hosts.yml
+++ b/tests/host/test_hosts.yml
@@ -96,3 +96,18 @@
       state: absent
     register: result
     failed_when: result.changed
+
+  - name: Duplicate names in hosts failure test
+    ipahost:
+      ipaadmin_password: SomeADMINpassword
+      hosts:
+      - name: "{{ host1_fqdn }}"
+        force: yes
+      - name: "{{ host2_fqdn }}"
+        force: yes
+      - name: "{{ host3_fqdn }}"
+        force: yes
+      - name: "{{ host3_fqdn }}"
+        force: yes
+    register: result
+    failed_when: result.changed or "is used more than once" not in result.msg

--- a/tests/user/test_users.yml
+++ b/tests/user/test_users.yml
@@ -85,6 +85,25 @@
     register: result
     failed_when: result.changed
 
+  - name: Duplicate names in users failure test
+    ipauser:
+      ipaadmin_password: SomeADMINpassword
+      users:
+      - name: user1
+        givenname: user1
+        last: Last
+      - name: user2
+        first: user2
+        last: Last
+      - name: user3
+        first: user3
+        last: Last
+      - name: user3
+        first: user3
+        last: Last
+    register: result
+    failed_when: result.changed or "is used more than once" not in result.msg
+
   - name: Remove test users
     ipauser:
       ipaadmin_password: SomeADMINpassword


### PR DESCRIPTION
It was possible to have several entries for names with the hosts and users
lists. This resulted sometimes in errors but also unexpected changes. A new
check has been added to make sure that the names in the users and hosts
lists are unique.

New tests have been added to verify this in the existing files:
- tests/host/test_hosts.yml
- tests/user/test_users.yml