### PR TITLE
ipa[server,replica]: Fix pkcs12 info regressions introduced with CA-less

### DIFF
--- a/roles/ipareplica/tasks/install.yml
+++ b/roles/ipareplica/tasks/install.yml
@@ -281,7 +281,7 @@
       ccache: "{{ result_ipareplica_prepare.ccache }}"
       installer_ccache: "{{ result_ipareplica_prepare.installer_ccache }}"
       _ca_enabled: "{{ result_ipareplica_prepare._ca_enabled }}"
-      _dirsrv_pkcs12_info: "{{ result_ipareplica_prepare._dirsrv_pkcs12_info }}"
+      _dirsrv_pkcs12_info: "{{ result_ipareplica_prepare._dirsrv_pkcs12_info  if result_ipareplica_prepare._dirsrv_pkcs12_info != None else omit }}"
       subject_base: "{{ result_ipareplica_prepare.subject_base }}"
       _top_dir: "{{ result_ipareplica_prepare._top_dir }}"
       _add_to_ipaservers: "{{ result_ipareplica_prepare._add_to_ipaservers }}"
@@ -345,7 +345,7 @@
       config_master_host_name:
         "{{ result_ipareplica_install_ca_certs.config_master_host_name }}"
       ccache: "{{ result_ipareplica_prepare.ccache }}"
-      _pkinit_pkcs12_info: "{{ result_ipareplica_prepare._pkinit_pkcs12_info }}"
+      _pkinit_pkcs12_info: "{{ result_ipareplica_prepare._pkinit_pkcs12_info  if result_ipareplica_prepare._pkinit_pkcs12_info != None else omit }}"
       _top_dir: "{{ result_ipareplica_prepare._top_dir }}"
 
   # We need to point to the master in ipa default conf when certmonger
@@ -407,8 +407,8 @@
       ccache: "{{ result_ipareplica_prepare.ccache }}"
       _ca_enabled: "{{ result_ipareplica_prepare._ca_enabled }}"
       _ca_file: "{{ result_ipareplica_prepare._ca_file }}"
-      _dirsrv_pkcs12_info: "{{ result_ipareplica_prepare._dirsrv_pkcs12_info }}"
-      _pkinit_pkcs12_info: "{{ result_ipareplica_prepare._pkinit_pkcs12_info }}"
+      _dirsrv_pkcs12_info: "{{ result_ipareplica_prepare._dirsrv_pkcs12_info if result_ipareplica_prepare._dirsrv_pkcs12_info != None else omit }}"
+      _pkinit_pkcs12_info: "{{ result_ipareplica_prepare._pkinit_pkcs12_info if result_ipareplica_prepare._pkinit_pkcs12_info != None else omit }}"
       _top_dir: "{{ result_ipareplica_prepare._top_dir }}"
       dirman_password: "{{ ipareplica_dirman_password }}"
       ds_ca_subject: "{{ result_ipareplica_setup_ds.ds_ca_subject }}"
@@ -429,7 +429,7 @@
       ccache: "{{ result_ipareplica_prepare.ccache }}"
       _ca_enabled: "{{ result_ipareplica_prepare._ca_enabled }}"
       _ca_file: "{{ result_ipareplica_prepare._ca_file }}"
-      _http_pkcs12_info: "{{ result_ipareplica_prepare._http_pkcs12_info }}"
+      _http_pkcs12_info: "{{ result_ipareplica_prepare._http_pkcs12_info if result_ipareplica_prepare._http_pkcs12_info != None else omit }}"
       _top_dir: "{{ result_ipareplica_prepare._top_dir }}"
       dirman_password: "{{ ipareplica_dirman_password }}"
 
@@ -507,7 +507,7 @@
       _kra_enabled: "{{ result_ipareplica_prepare._kra_enabled }}"
       _kra_host_name: "{{ result_ipareplica_prepare.config_kra_host_name }}"
       _ca_file: "{{ result_ipareplica_prepare._ca_file }}"
-      _pkinit_pkcs12_info: "{{ result_ipareplica_prepare._pkinit_pkcs12_info }}"
+      _pkinit_pkcs12_info: "{{ result_ipareplica_prepare._pkinit_pkcs12_info if result_ipareplica_prepare._pkinit_pkcs12_info != None else omit }}"
       _top_dir: "{{ result_ipareplica_prepare._top_dir }}"
       dirman_password: "{{ ipareplica_dirman_password }}"
 
@@ -529,7 +529,7 @@
       _kra_enabled: "{{ result_ipareplica_prepare._kra_enabled }}"
       _kra_host_name: "{{ result_ipareplica_prepare.config_kra_host_name }}"
       _subject_base: "{{ result_ipareplica_prepare._subject_base }}"
-      _pkinit_pkcs12_info: "{{ result_ipareplica_prepare._pkinit_pkcs12_info }}"
+      _pkinit_pkcs12_info: "{{ result_ipareplica_prepare._pkinit_pkcs12_info if result_ipareplica_prepare._pkinit_pkcs12_info != None else omit }}"
       _top_dir: "{{ result_ipareplica_prepare._top_dir }}"
       dirman_password: "{{ ipareplica_dirman_password }}"
       config_setup_ca: "{{ result_ipareplica_prepare.config_setup_ca }}"
@@ -554,7 +554,7 @@
       ccache: "{{ result_ipareplica_prepare.ccache }}"
       _ca_enabled: "{{ result_ipareplica_prepare._ca_enabled }}"
       _ca_file: "{{ result_ipareplica_prepare._ca_file }}"
-      _pkinit_pkcs12_info: "{{ result_ipareplica_prepare._pkinit_pkcs12_info }}"
+      _pkinit_pkcs12_info: "{{ result_ipareplica_prepare._pkinit_pkcs12_info if result_ipareplica_prepare._pkinit_pkcs12_info != None else omit }}"
       _top_dir: "{{ result_ipareplica_prepare._top_dir }}"
       dirman_password: "{{ ipareplica_dirman_password }}"
 
@@ -574,7 +574,7 @@
       ccache: "{{ result_ipareplica_prepare.ccache }}"
       _ca_enabled: "{{ result_ipareplica_prepare._ca_enabled }}"
       _ca_file: "{{ result_ipareplica_prepare._ca_file }}"
-      _pkinit_pkcs12_info: "{{ result_ipareplica_prepare._pkinit_pkcs12_info }}"
+      _pkinit_pkcs12_info: "{{ result_ipareplica_prepare._pkinit_pkcs12_info if result_ipareplica_prepare._pkinit_pkcs12_info != None else omit }}"
       _top_dir: "{{ result_ipareplica_prepare._top_dir }}"
       dirman_password: "{{ ipareplica_dirman_password }}"
       ds_ca_subject: "{{ result_ipareplica_setup_ds.ds_ca_subject }}"

--- a/roles/ipaserver/tasks/install.yml
+++ b/roles/ipaserver/tasks/install.yml
@@ -203,7 +203,7 @@
       # no_host_dns: "{{ result_ipaserver_test.no_host_dns }}"
       dirsrv_config_file: "{{ ipaserver_dirsrv_config_file | default(omit) }}"
       dirsrv_cert_files: "{{ ipaserver_dirsrv_cert_files | default(omit) }}"
-      _dirsrv_pkcs12_info: "{{ result_ipaserver_test._dirsrv_pkcs12_info }}"
+      _dirsrv_pkcs12_info: "{{ result_ipaserver_test._dirsrv_pkcs12_info if result_ipaserver_test._dirsrv_pkcs12_info != None else omit }}"
       external_cert_files:
         "{{ ipaserver_external_cert_files | default(omit) }}"
       subject_base: "{{ result_ipaserver_prepare.subject_base }}"
@@ -240,7 +240,7 @@
       no_hbac_allow: "{{ ipaserver_no_hbac_allow }}"
       idstart: "{{ result_ipaserver_test.idstart }}"
       idmax: "{{ result_ipaserver_test.idmax }}"
-      _pkinit_pkcs12_info: "{{ result_ipaserver_test._pkinit_pkcs12_info }}"
+      _pkinit_pkcs12_info: "{{ result_ipaserver_test._pkinit_pkcs12_info if result_ipaserver_test._pkinit_pkcs12_info != None else omit }}"
 
   - name: Install - Setup custodia
     ipaserver_setup_custodia:
@@ -270,7 +270,7 @@
       no_pkinit: "{{ result_ipaserver_test.no_pkinit }}"
       dirsrv_config_file: "{{ ipaserver_dirsrv_config_file | default(omit) }}"
       dirsrv_cert_files: "{{ ipaserver_dirsrv_cert_files | default([]) }}"
-      _dirsrv_pkcs12_info: "{{ result_ipaserver_test._dirsrv_pkcs12_info }}"
+      _dirsrv_pkcs12_info: "{{ result_ipaserver_test._dirsrv_pkcs12_info if result_ipaserver_test._dirsrv_pkcs12_info != None else omit }}"
       external_ca: "{{ ipaserver_external_ca }}"
       external_ca_type: "{{ ipaserver_external_ca_type | default(omit) }}"
       external_ca_profile:
@@ -334,7 +334,7 @@
         idmax: "{{ result_ipaserver_test.idmax }}"
         http_cert_files: "{{ ipaserver_http_cert_files | default([]) }}"
         no_ui_redirect: "{{ ipaserver_no_ui_redirect }}"
-        _http_pkcs12_info: "{{ result_ipaserver_test._http_pkcs12_info }}"
+        _http_pkcs12_info: "{{ result_ipaserver_test._http_pkcs12_info if result_ipaserver_test._http_pkcs12_info != None else omit }}"
 
     - name: Install - Setup KRA
       ipaserver_setup_kra:
@@ -394,7 +394,7 @@
         idstart: "{{ result_ipaserver_test.idstart }}"
         idmax: "{{ result_ipaserver_test.idmax }}"
         dirsrv_config_file: "{{ ipaserver_dirsrv_config_file | default(omit) }}"
-        _dirsrv_pkcs12_info: "{{ result_ipaserver_test._dirsrv_pkcs12_info }}"
+        _dirsrv_pkcs12_info: "{{ result_ipaserver_test._dirsrv_pkcs12_info if result_ipaserver_test._dirsrv_pkcs12_info != None else omit }}"
 
     - name: Install - Setup client
       include_role:


### PR DESCRIPTION
With the CA-less patches the types for the pkcs12 infos have been changed
to lists in the modules. This is resulting in a bad conversion from None
to [''] for the parameters. Because of this a normal replica deployment is
failing as [''] is not a valid value.

The install.yml files for ipareplica and also ipaserver have been changed
in the way that the pkcs12 values are checked if they are None. The
parameter will simply be omitted in this case and the parameter in the
module will become None by default.