### PR TITLE
ipareplica: Fix missing parameters for several modules

### DIFF
--- a/roles/ipareplica/library/ipareplica_create_ipa_conf.py
+++ b/roles/ipareplica/library/ipareplica_create_ipa_conf.py
@@ -262,6 +262,7 @@ def main():
     config.subject_base = options.subject_base
     config.dirman_password = dirman_password
     config.ca_host_name = ca_host_name
+    config.setup_ca = options.setup_ca
 
     remote_api = gen_remote_api(master_host_name, paths.ETC_IPA)
     installer._remote_api = remote_api

--- a/roles/ipareplica/library/ipareplica_ds_apply_updates.py
+++ b/roles/ipareplica/library/ipareplica_ds_apply_updates.py
@@ -177,6 +177,7 @@ def main():
     config = gen_ReplicaConfig()
     config.dirman_password = dirman_password
     config.subject_base = options.subject_base
+    config.master_host_name = master_host_name
 
     remote_api = gen_remote_api(master_host_name, paths.ETC_IPA)
 

--- a/roles/ipareplica/library/ipareplica_ds_enable_ssl.py
+++ b/roles/ipareplica/library/ipareplica_ds_enable_ssl.py
@@ -173,6 +173,7 @@ def main():
     config = gen_ReplicaConfig()
     config.dirman_password = dirman_password
     config.subject_base = options.subject_base
+    config.master_host_name = master_host_name
 
     remote_api = gen_remote_api(master_host_name, paths.ETC_IPA)
     # installer._remote_api = remote_api

--- a/roles/ipareplica/library/ipareplica_setup_adtrust.py
+++ b/roles/ipareplica/library/ipareplica_setup_adtrust.py
@@ -110,7 +110,7 @@ def main():
             # additional
             ccache=dict(required=True),
             _top_dir=dict(required=True),
-            setup_ca=dict(required=True),
+            setup_ca=dict(required=True, type='bool'),
             config_master_host_name=dict(required=True),
         ),
         supports_check_mode=True,

--- a/roles/ipareplica/library/ipareplica_setup_custodia.py
+++ b/roles/ipareplica/library/ipareplica_setup_custodia.py
@@ -169,6 +169,7 @@ def main():
     config.promote = installer.promote
     config.kra_enabled = kra_enabled
     config.kra_host_name = kra_host_name
+    config.setup_ca = options.setup_ca
 
     remote_api = gen_remote_api(master_host_name, paths.ETC_IPA)
 

--- a/roles/ipareplica/library/ipareplica_setup_http.py
+++ b/roles/ipareplica/library/ipareplica_setup_http.py
@@ -164,7 +164,7 @@ def main():
     config.subject_base = options.subject_base
     config.dirman_password = dirman_password
     config.setup_ca = options.setup_ca
-    # config.master_host_name = master_host_name
+    config.master_host_name = master_host_name
     config.ca_host_name = ca_host_name
     config.promote = installer.promote
 

--- a/roles/ipareplica/library/ipareplica_setup_krb.py
+++ b/roles/ipareplica/library/ipareplica_setup_krb.py
@@ -63,6 +63,9 @@ options:
   _top_dir:
     description: The installer _top_dir setting
     required: no
+  dirman_password:
+    description: Directory Manager (master) password
+    required: no
 author:
     - Thomas Woerner
 '''
@@ -98,6 +101,7 @@ def main():
             ccache=dict(required=True),
             _pkinit_pkcs12_info=dict(required=False, type='list'),
             _top_dir=dict(required=True),
+            dirman_password=dict(required=True, no_log=True),
         ),
         supports_check_mode=True,
     )
@@ -126,6 +130,7 @@ def main():
         '_pkinit_pkcs12_info')
 
     options._top_dir = ansible_module.params.get('_top_dir')
+    dirman_password = ansible_module.params.get('dirman_password')
 
     # init #
 
@@ -141,8 +146,10 @@ def main():
                                          constants.DEFAULT_CONFIG)
     api_bootstrap_finalize(env)
     config = gen_ReplicaConfig()
+    config.dirman_password = dirman_password
     config.master_host_name = config_master_host_name
     config.subject_base = options.subject_base
+    config.setup_ca = options.setup_ca
 
     ccache = os.environ['KRB5CCNAME']
 

--- a/roles/ipareplica/tasks/install.yml
+++ b/roles/ipareplica/tasks/install.yml
@@ -226,6 +226,8 @@
       setup_adtrust: "{{ result_ipareplica_test.setup_adtrust }}"
       setup_kra: "{{ result_ipareplica_test.setup_kra }}"
       setup_dns: "{{ ipareplica_setup_dns }}"
+      ### server ###
+      setup_ca: "{{ ipareplica_setup_ca }}"
       ### ssl certificate ###
       dirsrv_cert_files: "{{ ipareplica_dirsrv_cert_files | default([]) }}"
       ### client ###
@@ -332,6 +334,7 @@
       _ca_subject: "{{ result_ipareplica_prepare._ca_subject }}"
       _subject_base: "{{ result_ipareplica_prepare._subject_base }}"
       dirman_password: "{{ ipareplica_dirman_password }}"
+      setup_ca: "{{ result_ipareplica_prepare.config_setup_ca }}"
 
   - name: Install - Setup KRB
     ipareplica_setup_krb:
@@ -347,6 +350,7 @@
       ccache: "{{ result_ipareplica_prepare.ccache }}"
       _pkinit_pkcs12_info: "{{ result_ipareplica_prepare._pkinit_pkcs12_info  if result_ipareplica_prepare._pkinit_pkcs12_info != None else omit }}"
       _top_dir: "{{ result_ipareplica_prepare._top_dir }}"
+      dirman_password: "{{ ipareplica_dirman_password }}"
 
   # We need to point to the master in ipa default conf when certmonger
   # asks for HTTP certificate in newer ipa versions. In these versions
@@ -388,6 +392,7 @@
       _ca_subject: "{{ result_ipareplica_prepare._ca_subject }}"
       _subject_base: "{{ result_ipareplica_prepare._subject_base }}"
       dirman_password: "{{ ipareplica_dirman_password }}"
+      setup_ca: "{{ result_ipareplica_prepare.config_setup_ca }}"
       master:
         "{{ result_ipareplica_install_ca_certs.config_master_host_name }}"
     when: result_ipareplica_test.change_master_for_certmonger
@@ -471,6 +476,7 @@
       _ca_subject: "{{ result_ipareplica_prepare._ca_subject }}"
       _subject_base: "{{ result_ipareplica_prepare._subject_base }}"
       dirman_password: "{{ ipareplica_dirman_password }}"
+      setup_ca: "{{ result_ipareplica_prepare.config_setup_ca }}"
     when: result_ipareplica_test.change_master_for_certmonger
 
   - name: Install - Setup otpd
@@ -611,10 +617,12 @@
       _ca_enabled: "{{ result_ipareplica_prepare._ca_enabled }}"
       _kra_enabled: "{{ result_ipareplica_prepare._kra_enabled }}"
       _kra_host_name: "{{ result_ipareplica_prepare.config_kra_host_name }}"
+      _ca_host_name: "{{ result_ipareplica_prepare.config_ca_host_name }}"
       _top_dir: "{{ result_ipareplica_prepare._top_dir }}"
       _add_to_ipaservers: "{{ result_ipareplica_prepare._add_to_ipaservers }}"
       _ca_subject: "{{ result_ipareplica_prepare._ca_subject }}"
       _subject_base: "{{ result_ipareplica_prepare._subject_base }}"
+      dirman_password: "{{ ipareplica_dirman_password }}"
     when: result_ipareplica_test.setup_kra
 
   - name: Install - Restart KDC


### PR DESCRIPTION
The parameters master_host_name, config_setup_ca, dirman_password have not
been set for some modules. Also there was no ldap2 connection within
ipareplica_setup_kra. All this resulted in improper configuration where
for example KRA deployment failed in the end.

A conversion warning in ipareplica_setup_adtrust has also been fixed for
the setup_ca parameter.

Fixes #314 (IPA replica installation failure - DS enabled SSL - second part)