### PR TITLE
tests/external-signed-ca-../external-ca.sh: Password too weak in FIPS…

### DIFF
--- a/tests/external-signed-ca-with-automatic-copy/external-ca.sh
+++ b/tests/external-signed-ca-with-automatic-copy/external-ca.sh
@@ -8,7 +8,7 @@ if [ -z "$master" ]; then
     exit 0;
 fi
 
-PASSWORD="SomeCApassword"
+PASSWORD="SomeCApassword.123"
 DBDIR="${master}-nssdb"
 PWDFILE="$DBDIR/pwdfile.txt"
 NOISE="$DBDIR/noise.txt"


### PR DESCRIPTION
… mode

The password that is used in the script to generate the CA and also sign
the CSR is not strong enough in FIPS mode. In normal mode the password was
ok, though.

In FIPS mode the password needs to have at least one upper, lower, digit
and a special char.