### PR TITLE
Fixed ipahost test that did not have ipaadmin_password set.

### DIFF
--- a/tests/host/test_host_no_zone.yml
+++ b/tests/host/test_host_no_zone.yml
@@ -6,6 +6,7 @@
   tasks:
   - name: Ensure host with inexistent zone is absent.
     ipahost:
+      ipaadmin_password: SomeADMINpassword
       name: host01.absentzone.test
       state: absent
     register: result


### PR DESCRIPTION
A test for ipahost lacks the ipaadmin_password, so it failed to run without a valid TGT.