### PR TITLE
Fixed error msgs on FreeIPABaseModule subclasses

### DIFF
--- a/plugins/module_utils/ansible_freeipa_module.py
+++ b/plugins/module_utils/ansible_freeipa_module.py
@@ -610,11 +610,14 @@ class FreeIPABaseModule(AnsibleModule):
         exit the module with proper arguments.
 
         """
-        if exc_val:
-            self.fail_json(msg=str(exc_val))
-
         # TODO: shouldn't we also disconnect from api backend?
         temp_kdestroy(self.ccache_dir, self.ccache_name)
+
+        if exc_type == SystemExit:
+            raise
+
+        if exc_val:
+            self.fail_json(msg=str(exc_val))
 
         self.exit_json(changed=self.changed, user=self.exit_args)
 


### PR DESCRIPTION
When a fail_json is called a SystemExit exeception is raised.
Since the FreeIPABaseModule has an internal context manager to deal with exceptions this ContextManager captures the SystemExit. After dealing destroying the kinit session the SystemExit must be raised again to allow the fail_json to work properly.