### PR TITLE
Fix ipavault `salt` update.

### DIFF
--- a/README-vault.md
+++ b/README-vault.md
@@ -197,7 +197,7 @@ Example playbook to make sure vault is absent:
       state: absent
     register: result
   - debug:
-      msg: "{{ result.data }}"
+      msg: "{{ result.vault.data }}"
 ```
 
 Variables

--- a/plugins/modules/ipavault.py
+++ b/plugins/modules/ipavault.py
@@ -517,6 +517,16 @@ def check_encryption_params(module, state, action, vault_type, salt,
             module.fail_json(
                 msg="Cannot modify password of inexistent vault.")
 
+        if (
+            salt is not None
+            and not(
+                any([password, password_file])
+                and any([new_password, new_password_file])
+            )
+        ):
+            module.fail_json(
+                msg="Vault `salt` can only change when changing the password.")
+
     if vault_type == "asymmetric":
         vault_type_invalid = [
             'password', 'password_file', 'new_password', 'new_password_file'

--- a/plugins/modules/ipavault.py
+++ b/plugins/modules/ipavault.py
@@ -494,8 +494,10 @@ def check_encryption_params(module, state, action, vault_type, salt,
                             new_password, new_password_file, res_find):
     vault_type_invalid = []
 
-    if res_find is not None:
+    if vault_type is None and res_find is not None:
         vault_type = res_find['ipavaulttype']
+        if isinstance(vault_type, (tuple, list)):
+            vault_type = vault_type[0]
 
     if vault_type == "standard":
         vault_type_invalid = ['public_key', 'public_key_file', 'password',

--- a/plugins/modules/ipavault.py
+++ b/plugins/modules/ipavault.py
@@ -243,7 +243,7 @@ EXAMPLES = """
     state: retrieved
   register: result
 - debug:
-    msg: "{{ result.data }}"
+    msg: "{{ result.vault.data }}"
 
 # Change password of a symmetric vault
 - ipavault:

--- a/plugins/modules/ipavault.py
+++ b/plugins/modules/ipavault.py
@@ -768,7 +768,12 @@ def main():
                             commands.append([name, "vault_mod_internal", args])
 
                     else:
+                        if vault_type == 'symmetric' \
+                           and 'ipavaultsalt' not in args:
+                            args['ipavaultsalt'] = os.urandom(32)
+
                         commands.append([name, "vault_add_internal", args])
+
                         if vault_type != 'standard' and vault_data is None:
                             vault_data = ''
 
@@ -825,14 +830,6 @@ def main():
                     if owner_del_args is not None:
                         commands.append(
                             [name, 'vault_remove_owner', owner_del_args])
-
-                    if vault_type == 'symmetric' \
-                       and 'ipavaultsalt' not in args:
-                        args['ipavaultsalt'] = os.urandom(32)
-
-                    if vault_type == 'symmetric' \
-                       and 'ipavaultsalt' not in args:
-                        args['ipavaultsalt'] = os.urandom(32)
 
                 elif action in "member":
                     # Add users and groups

--- a/tests/vault/test_vault_symmetric.yml
+++ b/tests/vault/test_vault_symmetric.yml
@@ -203,7 +203,7 @@
       password: SomeNEWpassword
       state: retrieved
     register: result
-    failed_when: result.data != 'Hello World.' or result.changed
+    failed_when: result.vault.data != 'Hello World.' or result.changed
 
   - name: Retrieve data from symmetric vault, with old password.
     ipavault:

--- a/tests/vault/test_vault_symmetric.yml
+++ b/tests/vault/test_vault_symmetric.yml
@@ -234,14 +234,41 @@
     register: result
     failed_when: not result.changed
 
+  - name: Try to change symmetric vault salt, without providing any password
     ipavault:
       ipaadmin_password: SomeADMINpassword
-      name: inexistentvault
-      password: SomeVAULTpassword
-      new_password: SomeVAULTpassword
-      new_password_file: "{{ ansible_env.HOME }}/password.txt"
+      name: symvault
+      salt: MTIzNDU2Nzg5MDEyMzQ1Ngo=
     register: result
-    failed_when: not result.failed or "parameters are mutually exclusive" not in result.msg
+    failed_when: not result.failed and  "Vault `salt` can only change when changing the password." not in result.msg
+
+  - name: Try to change symmetric vault salt, without providing `password`
+    ipavault:
+      ipaadmin_password: SomeADMINpassword
+      name: symvault
+      salt: MTIzNDU2Nzg5MDEyMzQ1Ngo=
+      new_password: SomeVAULTpassword
+    register: result
+    failed_when: not result.failed and  "Vault `salt` can only change when changing the password." not in result.msg
+
+  - name: Try to change symmetric vault salt, without providing `new_password`
+    ipavault:
+      ipaadmin_password: SomeADMINpassword
+      name: symvault
+      salt: MTIzNDU2Nzg5MDEyMzQ1Ngo=
+      password: SomeVAULTpassword
+    register: result
+    failed_when: not result.failed and  "Vault `salt` can only change when changing the password." not in result.msg
+
+  - name: Try to change symmetric vault salt, using wrong password.
+    ipavault:
+      ipaadmin_password: SomeADMINpassword
+      name: symvault
+      password: SomeWRONGpassword
+      new_password: SomeWRONGpassword
+      salt: MDEyMzQ1Njc4OTAxMjM0NQo=
+    register: result
+    failed_when: not result.failed
 
   - name: Ensure symmetric vault is absent
     ipavault:

--- a/tests/vault/test_vault_symmetric.yml
+++ b/tests/vault/test_vault_symmetric.yml
@@ -178,6 +178,15 @@
     register: result
     failed_when: result.vault.data != 'Hello World.' or result.changed
 
+  - name: Retrieve data from symmetric vault, with wrong password.
+    ipavault:
+      ipaadmin_password: SomeADMINpassword
+      name: symvault
+      password: SomeWRONGpassword
+      state: retrieved
+    register: result
+    failed_when: not result.failed or "Invalid credentials" not in result.msg
+
   - name: Change vault password.
     ipavault:
       ipaadmin_password: SomeADMINpassword
@@ -187,24 +196,6 @@
     register: result
     failed_when: not result.changed
 
-  - name: Retrieve data from symmetric vault, with wrong password.
-    ipavault:
-      ipaadmin_password: SomeADMINpassword
-      name: symvault
-      password: SomeVAULTpassword
-      state: retrieved
-    register: result
-    failed_when: not result.failed or "Invalid credentials" not in result.msg
-
-  - name: Change vault password, with wrong `old_password`.
-    ipavault:
-      ipaadmin_password: SomeADMINpassword
-      name: symvault
-      password: SomeVAULTpassword
-      new_password: SomeNEWpassword
-    register: result
-    failed_when: not result.failed or "Invalid credentials" not in result.msg
-
   - name: Retrieve data from symmetric vault, with new password.
     ipavault:
       ipaadmin_password: SomeADMINpassword
@@ -212,18 +203,37 @@
       password: SomeNEWpassword
       state: retrieved
     register: result
-    failed_when: result.vault.data != 'Hello World.' or result.changed
+    failed_when: result.data != 'Hello World.' or result.changed
 
-  - name: Try to add vault with multiple passwords.
+  - name: Retrieve data from symmetric vault, with old password.
     ipavault:
       ipaadmin_password: SomeADMINpassword
-      name: inexistentvault
+      name: symvault
       password: SomeVAULTpassword
-      password_file: "{{ ansible_env.HOME }}/password.txt"
+      state: retrieved
     register: result
-    failed_when: not result.failed or "parameters are mutually exclusive" not in result.msg
+    failed_when: not result.failed or "Invalid credentials" not in result.msg
 
-  - name: Try to add vault with multiple new passwords.
+  - name: Change symmetric vault salt, changing password
+    ipavault:
+      ipaadmin_password: SomeADMINpassword
+      name: symvault
+      password: SomeNEWpassword
+      new_password: SomeVAULTpassword
+      salt: AAAAAAAAAAAAAAAAAAAAAAA=
+    register: result
+    failed_when: not result.changed
+
+  - name: Change symmetric vault salt, without changing password
+    ipavault:
+      ipaadmin_password: SomeADMINpassword
+      name: symvault
+      password: SomeVAULTpassword
+      new_password: SomeVAULTpassword
+      salt: MTIzNDU2Nzg5MDEyMzQ1Ngo=
+    register: result
+    failed_when: not result.changed
+
     ipavault:
       ipaadmin_password: SomeADMINpassword
       name: inexistentvault


### PR DESCRIPTION
While adding some tests to verify ipavault salt attribute manipulation, some errors were found both on the behavior of its update (salt should not be updated, unless symmetric vault password is changed), and in related parts of the code. This PR addresses these problems.

* Fixed an occurence in some scenarios, where the value of the vault type is returned as a tuple, rather than a string, this made some changes to existing vault to fail.
* When modifying an existing vault to change the value of salt, the password must also change. It is fine to "change" the password to the same value, thus only changing the salt value.
* The generation of a random salt, when one was not provided, was duplicated and in the wrong place, being generated too late to be used properly.

New tests have been added to verify this in the existing files:

* tests/vault/test_vault_symmetric.yml
