### PR TITLE
Add support for option `name_from_ip` in ipadnszone module.

### DIFF
--- a/README-dnszone.md
+++ b/README-dnszone.md
@@ -152,6 +152,46 @@ Example playbook to remove a zone:
 
 ```
 
+Example playbook to create a zone for reverse DNS lookup, from an IP address:
+
+```yaml
+
+---
+- name: dnszone present
+  hosts: ipaserver
+  become: true
+
+  tasks:
+  - name: Ensure zone for reverse DNS lookup is present.
+    ipadnszone:
+      ipaadmin_password: SomeADMINpassword
+      name_from_ip: 192.168.1.2
+      state: present
+```
+
+Note that, on the previous example the zone created with `name_from_ip` might be "1.168.192.in-addr.arpa.", "168.192.in-addr.arpa.", or "192.in-addr.arpa.", depending on the DNS response the system get while querying for zones, and for this reason, when creating a zone using `name_from_ip`, the inferred zone name is returned to the controller, in the attribute `dnszone.name`. Since the zone inferred might not be what a user expects, `name_from_ip` can only be used with `state: present`. To have more control over the zone name, the prefix length for the IP address can be provided.
+
+Example playbook to create a zone for reverse DNS lookup, from an IP address, given the prefix length and displaying the resulting zone name:
+
+```yaml
+
+---
+- name: dnszone present
+  hosts: ipaserver
+  become: true
+
+  tasks:
+      - name: Ensure zone for reverse DNS lookup is present.
+    ipadnszone:
+      ipaadmin_password: SomeADMINpassword
+      name_from_ip: 192.168.1.2/24
+      state: present
+    register: result
+  - name: Display inferred zone name.
+    debug:
+      msg: "Zone name: {{ result.dnszone.name }}"
+```
+
 
 Variables
 =========
@@ -164,7 +204,7 @@ Variable | Description | Required
 `ipaadmin_principal` | The admin principal is a string and defaults to `admin` | no
 `ipaadmin_password` | The admin password is a string and is required if there is no admin ticket available on the node | no
 `name` \| `zone_name` | The zone name string or list of strings. | no
-`name_from_ip` | Derive zone name from reverse of IP (PTR). | no
+`name_from_ip` | Derive zone name from reverse of IP (PTR). Can only be used with `state: present`. | no
 `forwarders` | The list of forwarders dicts. Each `forwarders` dict entry has:| no
 &nbsp; | `ip_address` - The IPv4 or IPv6 address of the DNS server. | yes
 &nbsp; | `port` - The custom port that should be used on this server. | no

--- a/README-dnszone.md
+++ b/README-dnszone.md
@@ -163,7 +163,8 @@ Variable | Description | Required
 -------- | ----------- | --------
 `ipaadmin_principal` | The admin principal is a string and defaults to `admin` | no
 `ipaadmin_password` | The admin password is a string and is required if there is no admin ticket available on the node | no
-`name` \| `zone_name` | The zone name string or list of strings. | yes
+`name` \| `zone_name` | The zone name string or list of strings. | no
+`name_from_ip` | Derive zone name from reverse of IP (PTR). | no
 `forwarders` | The list of forwarders dicts. Each `forwarders` dict entry has:| no
 &nbsp; | `ip_address` - The IPv4 or IPv6 address of the DNS server. | yes
 &nbsp; | `port` - The custom port that should be used on this server. | no

--- a/README-dnszone.md
+++ b/README-dnszone.md
@@ -190,6 +190,17 @@ Variable | Description | Required
 `skip_nameserver_check` | Force DNS zone creation even if nameserver is not resolvable | no
 
 
+Return Values
+=============
+
+ipadnszone
+----------
+
+Variable | Description | Returned When
+-------- | ----------- | -------------
+`dnszone` | DNS Zone dict with zone name infered from `name_from_ip`. <br>Options: |  If `state` is `present`, `name_from_ip` is used, and a zone was created.
+&nbsp; | `name` - The name of the zone created, inferred from `name_from_ip`. | Always
+
 Authors
 =======
 

--- a/playbooks/dnszone/dnszone-reverse-from-ip.yml
+++ b/playbooks/dnszone/dnszone-reverse-from-ip.yml
@@ -1,0 +1,10 @@
+---
+- name: Playbook to ensure DNS zone exist
+  hosts: ipaserver
+  become: true
+
+  tasks:
+  - name: Ensure zone exist, finding zone name from IP address.
+    ipadnszone:
+      ipaadmin_password: SomeADMINpassword
+      name_from_ip: 10.1.2.3

--- a/playbooks/dnszone/dnszone-reverse-from-ip.yml
+++ b/playbooks/dnszone/dnszone-reverse-from-ip.yml
@@ -7,4 +7,9 @@
   - name: Ensure zone exist, finding zone name from IP address.
     ipadnszone:
       ipaadmin_password: SomeADMINpassword
-      name_from_ip: 10.1.2.3
+      name_from_ip: 10.1.2.3/24
+    register: result
+
+  - name: Zone name inferred from `name_from_ip`
+    debug:
+      msg: "Zone created: {{ result.dnszone.name }}"

--- a/plugins/module_utils/ansible_freeipa_module.py
+++ b/plugins/module_utils/ansible_freeipa_module.py
@@ -619,7 +619,7 @@ class FreeIPABaseModule(AnsibleModule):
         if exc_val:
             self.fail_json(msg=str(exc_val))
 
-        self.exit_json(changed=self.changed, user=self.exit_args)
+        self.exit_json(changed=self.changed, **self.exit_args)
 
     def get_command_errors(self, command, result):
         """Look for erros into command results."""
@@ -658,13 +658,21 @@ class FreeIPABaseModule(AnsibleModule):
             except Exception as excpt:
                 self.fail_json(msg="%s: %s: %s" % (command, name, str(excpt)))
             else:
-                if "completed" in result:
-                    if result["completed"] > 0:
-                        self.changed = True
-                else:
-                    self.changed = True
-
+                self.process_command_result(name, command, args, result)
             self.get_command_errors(command, result)
+
+    def process_command_result(self, name, command, args, result):
+        """
+        Process an API command result.
+
+        This method can be overriden in subclasses, and change self.exit_values
+        to return data in the result for the controller.
+        """
+        if "completed" in result:
+            if result["completed"] > 0:
+                self.changed = True
+        else:
+            self.changed = True
 
     def require_ipa_attrs_change(self, command_args, ipa_attrs):
         """

--- a/plugins/modules/ipadnszone.py
+++ b/plugins/modules/ipadnszone.py
@@ -472,6 +472,14 @@ class DNSZoneModule(FreeIPABaseModule):
                 }
                 self.add_ipa_command("dnszone_mod", zone_name, args)
 
+    def process_command_result(self, name, command, args, result):
+        super(DNSZoneModule, self).process_command_result(
+            name, command, args, result
+        )
+        if command == "dnszone_add" and self.ipa_params.name_from_ip:
+            dnszone_exit_args = self.exit_args.setdefault('dnszone', {})
+            dnszone_exit_args['name'] = name
+
 
 def get_argument_spec():
     forwarder_spec = dict(

--- a/plugins/modules/ipadnszone.py
+++ b/plugins/modules/ipadnszone.py
@@ -192,6 +192,14 @@ EXAMPLES = """
 """
 
 RETURN = """
+dnszone:
+  description: DNS Zone dict with zone name infered from `name_from_ip`.
+  returned:
+    If `state` is `present`, `name_from_ip` is used, and a zone was created.
+  options:
+    name:
+      description: The name of the zone created, inferred from `name_from_ip`.
+      returned: always
 """
 
 from ipapython.dnsutil import DNSName  # noqa: E402

--- a/plugins/modules/ipadnszone.py
+++ b/plugins/modules/ipadnszone.py
@@ -44,7 +44,9 @@ options:
     type: list
     alises: ["zone_name"]
   name_from_ip:
-    description: Derive zone name from reverse of IP (PTR).
+    description: |
+      Derive zone name from reverse of IP (PTR).
+      Can only be used with `state: present`.
     required: false
     type: str
   forwarders:

--- a/tests/dnszone/test_dnszone_name_from_ip.yml
+++ b/tests/dnszone/test_dnszone_name_from_ip.yml
@@ -1,0 +1,112 @@
+---
+- name: Test dnszone
+  hosts: ipaserver
+  become: yes
+  gather_facts: yes
+
+  tasks:
+
+  # Setup
+  - name: Ensure zone is absent.
+    ipadnszone:
+      ipaadmin_password: SomeADMINpassword
+      name: "{{ item }}"
+      state: absent
+    with_items:
+      - 2.0.192.in-addr.arpa.
+      - 0.0.0.0.0.0.0.0.0.0.0.0.0.0.d.f.ip6.arpa.
+      - 1.0.0.0.e.f.a.c.8.b.d.0.1.0.0.2.ip6.arpa.
+
+  # tests
+  - name: Ensure zone exists for reverse IP.
+    ipadnszone:
+      ipaadmin_password: SomeADMINpassword
+      name_from_ip: 192.0.2.3/24
+    register: ipv4_zone
+    failed_when: not ipv4_zone.changed or ipv4_zone.failed
+
+  - name: Ensure zone exists for reverse IP, again.
+    ipadnszone:
+      ipaadmin_password: SomeADMINpassword
+      name_from_ip: 192.0.2.3/24
+    register: result
+    failed_when: result.changed or result.failed
+
+  - name: Ensure zone exists for reverse IP, given the zone name.
+    ipadnszone:
+      ipaadmin_password: SomeADMINpassword
+      name: "{{ ipv4_zone.dnszone.name }}"
+    register: result
+    failed_when: result.changed or result.failed
+
+  - name: Modify existing zone, using `name_from_ip`.
+    ipadnszone:
+      ipaadmin_password: SomeADMINpassword
+      name_from_ip: 192.0.2.3/24
+      default_ttl: 1234
+    register: result
+    failed_when: not result.changed
+
+  - name: Modify existing zone, using `name_from_ip`, again.
+    ipadnszone:
+      ipaadmin_password: SomeADMINpassword
+      name_from_ip: 192.0.2.3/24
+      default_ttl: 1234
+    register: result
+    failed_when: result.changed or result.failed
+
+  - name: Ensure ipv6 zone exists for reverse IPv6.
+    ipadnszone:
+      ipaadmin_password: SomeADMINpassword
+      name_from_ip: fd00::0001
+    register: ipv6_zone
+    failed_when: not ipv6_zone.changed or ipv6_zone.failed
+
+  # - debug:
+  #     msg: "{{ipv6_zone}}"
+
+  - name: Ensure ipv6 zone was created.
+    ipadnszone:
+      ipaadmin_password: SomeADMINpassword
+      name: "{{ ipv6_zone.dnszone.name }}"
+    register: result
+    failed_when: result.changed or result.failed
+
+  - name: Ensure ipv6 zone exists for reverse IPv6, again.
+    ipadnszone:
+      ipaadmin_password: SomeADMINpassword
+      name_from_ip: fd00::0001
+    register: result
+    failed_when: result.changed
+
+  - name: Ensure second ipv6 zone exists for reverse IPv6.
+    ipadnszone:
+      ipaadmin_password: SomeADMINpassword
+      name_from_ip: 2001:db8:cafe:1::1
+    register: ipv6_sec_zone
+    failed_when: not ipv6_sec_zone.changed or ipv6_zone.failed
+
+  - name: Ensure second ipv6 zone was created.
+    ipadnszone:
+      ipaadmin_password: SomeADMINpassword
+      name: "{{ ipv6_sec_zone.dnszone.name }}"
+    register: result
+    failed_when: result.changed or result.failed
+
+  - name: Ensure second ipv6 zone exists for reverse IPv6, again.
+    ipadnszone:
+      ipaadmin_password: SomeADMINpassword
+      name_from_ip: 2001:db8:cafe:1::1
+    register: result
+    failed_when: result.changed
+
+  # Cleanup
+  - name: Ensure zone is absent.
+    ipadnszone:
+      ipaadmin_password: SomeADMINpassword
+      name: "{{ item }}"
+      state: absent
+    with_items:
+      - "{{ ipv6_zone.dnszone.name }}"
+      - "{{ ipv6_sec_zone.dnszone.name }}"
+      - "{{ ipv4_zone.dnszone.name }}"


### PR DESCRIPTION
IPA CLI has an option `name_from_ip` that provide a name for a zone
from the reverse IP address, so that it can be used to, for example,
manage PTR DNS records.

This patch adds a similar attribute to ipadnszone module, where it
will try to find the proper zone name, using DNS resolve, or provide
a sane default, if a the zone name cannot be resolved.

The option `name_from_ip` must be used instead of `name` in playbooks,
and it is a string, and not a list.

A new example playbook was added:

    playbooks/dnszone/dnszone-reverse-from-ip.yml

A new test playbook was added:

    tests/dnszone/test_dnszone_name_from_ip.yml