### PR TITLE
Modified return value for ipavault module.

### DIFF
--- a/README-vault.md
+++ b/README-vault.md
@@ -248,6 +248,11 @@ Variable | Description | Returned When
 -------- | ----------- | -------------
 `data` | The data stored in the vault. | If `state` is `retrieved`.
 
+Variable | Description | Returned When
+-------- | ----------- | -------------
+`vault` | Vault dict with archived data. (dict) <br>Options: | If `state` is `retrieved`.
+&nbsp; | `data` - The vault data. | Always
+
 
 Notes
 =====

--- a/playbooks/vault/retrive-data-asymmetric-vault.yml
+++ b/playbooks/vault/retrive-data-asymmetric-vault.yml
@@ -14,4 +14,4 @@
         state: retrieved
       register: result
     - debug:
-       msg: "Data: {{ result.data }}"
+       msg: "Data: {{ result.vault.data }}"

--- a/playbooks/vault/retrive-data-symmetric-vault.yml
+++ b/playbooks/vault/retrive-data-symmetric-vault.yml
@@ -14,4 +14,4 @@
         state: retrieved
       register: result
     - debug:
-        msg: "{{ result.data | b64decode }}"
+        msg: "{{ result.vault.data }}"

--- a/plugins/modules/ipavault.py
+++ b/plugins/modules/ipavault.py
@@ -303,10 +303,15 @@ EXAMPLES = """
 """
 
 RETURN = """
-data:
-  description: The vault data.
-  returned: If state is retrieved.
-  type: string
+vault:
+  description: Vault dict with archived data.
+  returned: If state is `retrieved`.
+  type: dict
+  options:
+    data:
+      description: The vault data.
+      returned: always
+      type: string
 """
 
 import os
@@ -910,9 +915,11 @@ def main():
                     if 'result' not in result:
                         raise Exception("No result obtained.")
                     if 'data' in result['result']:
-                        exit_args['data'] = result['result']['data']
+                        data_return = exit_args.setdefault('vault', {})
+                        data_return['data'] = result['result']['data']
                     elif 'vault_data' in result['result']:
-                        exit_args['data'] = result['result']['vault_data']
+                        data_return = exit_args.setdefault('vault', {})
+                        data_return['data'] = result['result']['vault_data']
                     else:
                         raise Exception("No data retrieved.")
                     changed = False

--- a/tests/vault/test_vault_asymmetric.yml
+++ b/tests/vault/test_vault_asymmetric.yml
@@ -42,7 +42,7 @@
       private_key: "{{ lookup('file', 'private.pem') | b64encode }}"
       state: retrieved
     register: result
-    failed_when: result.data != 'Hello World.' or result.changed
+    failed_when: result.vault.data != 'Hello World.' or result.changed
 
   - name: Retrieve data from asymmetric vault into file {{ ansible_env.HOME }}/data.txt.
     ipavault:
@@ -75,7 +75,7 @@
       private_key: "{{ lookup('file', 'private.pem') | b64encode }}"
       state: retrieved
     register: result
-    failed_when: result.data != 'The world of π is half rounded.' or result.changed
+    failed_when: result.vault.data != 'The world of π is half rounded.' or result.changed
 
   - name: Archive data in asymmetric vault, from file.
     ipavault:
@@ -93,7 +93,7 @@
       private_key: "{{ lookup('file', 'private.pem') | b64encode }}"
       state: retrieved
     register: result
-    failed_when: result.data != 'Another World.' or result.changed
+    failed_when: result.vault.data != 'Another World.' or result.changed
 
   - name: Archive data with single character to asymmetric vault
     ipavault:
@@ -110,7 +110,7 @@
       private_key: "{{ lookup('file', 'private.pem') | b64encode }}"
       state: retrieved
     register: result
-    failed_when: result.data != 'c' or result.changed
+    failed_when: result.vault.data != 'c' or result.changed
 
   - name: Ensure asymmetric vault is absent
     ipavault:
@@ -161,7 +161,7 @@
       private_key: "{{ lookup('file', 'private.pem') | b64encode }}"
       state: retrieved
     register: result
-    failed_when: result.data != 'Hello World.' or result.changed
+    failed_when: result.vault.data != 'Hello World.' or result.changed
 
   - name: Retrieve data from asymmetric vault, with password file.
     ipavault:
@@ -170,7 +170,7 @@
       private_key_file: "{{ ansible_env.HOME }}/private.pem"
       state: retrieved
     register: result
-    failed_when: result.data != 'Hello World.' or result.changed
+    failed_when: result.vault.data != 'Hello World.' or result.changed
 
   - name: Ensure asymmetric vault is absent
     ipavault:

--- a/tests/vault/test_vault_standard.yml
+++ b/tests/vault/test_vault_standard.yml
@@ -39,7 +39,7 @@
       name: stdvault
       state: retrieved
     register: result
-    failed_when: result.data != 'Hello World.' or result.changed
+    failed_when: result.vault.data != 'Hello World.' or result.changed
 
   - name: Retrieve data from standard vault into file {{ ansible_env.HOME }}/data.txt.
     ipavault:
@@ -70,7 +70,7 @@
       name: stdvault
       state: retrieved
     register: result
-    failed_when: result.data != 'The world of π is half rounded.' or result.changed
+    failed_when: result.vault.data != 'The world of π is half rounded.' or result.changed
 
   - name: Archive data in standard vault, from file.
     ipavault:
@@ -87,7 +87,7 @@
       name: stdvault
       state: retrieved
     register: result
-    failed_when: result.data != 'Another World.' or result.changed
+    failed_when: result.vault.data != 'Another World.' or result.changed
 
   - name: Archive data with single character to standard vault
     ipavault:
@@ -103,7 +103,7 @@
       name: stdvault
       state: retrieved
     register: result
-    failed_when: result.data != 'c' or result.changed
+    failed_when: result.vault.data != 'c' or result.changed
 
   - name: Ensure standard vault is absent
     ipavault:

--- a/tests/vault/test_vault_symmetric.yml
+++ b/tests/vault/test_vault_symmetric.yml
@@ -43,7 +43,7 @@
       password: SomeVAULTpassword
       state: retrieved
     register: result
-    failed_when: result.data != 'Hello World.' or result.changed
+    failed_when: result.vault.data != 'Hello World.' or result.changed
 
   - name: Retrieve data from symmetric vault into file {{ ansible_env.HOME }}/data.txt.
     ipavault:
@@ -77,7 +77,7 @@
       password: SomeVAULTpassword
       state: retrieved
     register: result
-    failed_when: result.data != 'The world of π is half rounded.' or result.changed
+    failed_when: result.vault.data != 'The world of π is half rounded.' or result.changed
 
   - name: Archive data in symmetric vault, from file.
     ipavault:
@@ -95,7 +95,7 @@
       password: SomeVAULTpassword
       state: retrieved
     register: result
-    failed_when: result.data != 'Another World.' or result.changed
+    failed_when: result.vault.data != 'Another World.' or result.changed
 
   - name: Archive data with single character to symmetric vault
     ipavault:
@@ -113,7 +113,7 @@
       password: SomeVAULTpassword
       state: retrieved
     register: result
-    failed_when: result.data != 'c' or result.changed
+    failed_when: result.vault.data != 'c' or result.changed
 
   - name: Ensure symmetric vault is absent
     ipavault:
@@ -167,7 +167,7 @@
       password: SomeVAULTpassword
       state: retrieved
     register: result
-    failed_when: result.data != 'Hello World.' or result.changed
+    failed_when: result.vault.data != 'Hello World.' or result.changed
 
   - name: Retrieve data from symmetric vault, with password file.
     ipavault:
@@ -176,7 +176,7 @@
       password_file: "{{ ansible_env.HOME }}/password.txt"
       state: retrieved
     register: result
-    failed_when: result.data != 'Hello World.' or result.changed
+    failed_when: result.vault.data != 'Hello World.' or result.changed
 
   - name: Change vault password.
     ipavault:
@@ -212,7 +212,7 @@
       password: SomeNEWpassword
       state: retrieved
     register: result
-    failed_when: result.data != 'Hello World.' or result.changed
+    failed_when: result.vault.data != 'Hello World.' or result.changed
 
   - name: Try to add vault with multiple passwords.
     ipavault:


### PR DESCRIPTION
The ipavault module was returning a single string value when retrieving
data. To keep consistency with other modules, it should return a dict
with the `data` variable in it.

This change modifies the result of ipavault to be a dict and also fixes
relevant tests, examples and documentation.