### PR TITLE
Missing admin passwords in location module.

### DIFF
--- a/README-location.md
+++ b/README-location.md
@@ -49,6 +49,7 @@ Example playbook to make sure location "my_location1" is present:
 
   tasks:
   - ipalocation:
+      ipaadmin_password: SomeADMINpassword
       name: my_location1
       description: My Location 1
 ```
@@ -64,6 +65,7 @@ Example playbook to make sure location "my_location1" is absent:
 
   tasks:
   - ipalocation:
+      ipaadmin_password: SomeADMINpassword
       name: my_location1
       state: absent
 ```

--- a/playbooks/location/location-absent.yml
+++ b/playbooks/location/location-absent.yml
@@ -6,5 +6,6 @@
   tasks:
   - name: Ensure location my_location1 is absent
     ipalocation:
-     name: my_location1
-     state: absent
+      ipaadmin_password: SomeADMINpassword
+      name: my_location1
+      state: absent

--- a/playbooks/location/location-present.yml
+++ b/playbooks/location/location-present.yml
@@ -6,4 +6,5 @@
   tasks:
   - name: Ensure location my_location1 is present
     ipalocation:
-     name: my_location1
+      ipaadmin_password: SomeADMINpassword
+      name: my_location1

--- a/plugins/modules/ipalocation.py
+++ b/plugins/modules/ipalocation.py
@@ -55,11 +55,13 @@ options:
 EXAMPLES = """
 # Ensure location my_location1 is present
 - ipalocation:
+    ipaadmin_password: SomeADMINpassword
     name: my_location1
     description: My location 1
 
 # Ensure location my_location1 is absent
 - ipalocation:
+    ipaadmin_password: SomeADMINpassword
     name: my_location1
     state: absent
 """

--- a/tests/location/test_location.yml
+++ b/tests/location/test_location.yml
@@ -9,8 +9,9 @@
 
   - name: Ensure location my_location1 is absent
     ipalocation:
-     name: my_location1
-     state: absent
+      ipaadmin_password: SomeADMINpassword
+      name: my_location1
+      state: absent
 
   # CREATE TEST ITEMS
 
@@ -18,41 +19,47 @@
 
   - name: Ensure location my_location1 is present
     ipalocation:
-     name: my_location1
+      ipaadmin_password: SomeADMINpassword
+      name: my_location1
     register: result
     failed_when: not result.changed or result.failed
 
   - name: Ensure location my_location1 is present again
     ipalocation:
-     name: my_location1
+      ipaadmin_password: SomeADMINpassword
+      name: my_location1
     register: result
     failed_when: result.changed or result.failed
 
   - name: Ensure location my_location1 is present with description
     ipalocation:
-     name: my_location1
-     description: My Location 1
+      ipaadmin_password: SomeADMINpassword
+      name: my_location1
+      description: My Location 1
     register: result
     failed_when: not result.changed or result.failed
 
   - name: Ensure location my_location1 is present again with description
     ipalocation:
-     name: my_location1
-     description: My Location 1
+      ipaadmin_password: SomeADMINpassword
+      name: my_location1
+      description: My Location 1
     register: result
     failed_when: result.changed or result.failed
 
   - name: Ensure location my_location1 is absent
     ipalocation:
-     name: my_location1
-     state: absent
+      ipaadmin_password: SomeADMINpassword
+      name: my_location1
+      state: absent
     register: result
     failed_when: not result.changed or result.failed
 
   - name: Ensure location my_location1 is absent again
     ipalocation:
-     name: my_location1
-     state: absent
+      ipaadmin_password: SomeADMINpassword
+      name: my_location1
+      state: absent
     register: result
     failed_when: result.changed or result.failed
 
@@ -60,5 +67,6 @@
 
   - name: Ensure location my_location1 is absent
     ipalocation:
-     name: my_location1
-     state: absent
+      ipaadmin_password: SomeADMINpassword
+      name: my_location1
+      state: absent


### PR DESCRIPTION
Tests for module ipalocation failed due to missing ipaadmin_password.

Added the variable to the playbooks, and also fixed the examples and
documentation. Some playbooks had identation fixed to two spaces
instead of one for consistency with other modules.