### PR TITLE
Add support for running pytest tests with ssh password.

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -29,6 +29,14 @@ environment variable. For example:
 ANSIBLE_REMOTE_USER=root IPA_SERVER_HOST=<ipaserver_host_or_ip> pytest
 ```
 
+If you want to use ssh with password, you must set `IPA_SSH_PASSWORD`
+environment variable. For example:
+
+```
+IPA_SSH_PASSWORD=<ipaserver_ssh_password> IPA_SERVER_HOST=<ipaserver_host_or_ip> pytest
+```
+
+
 To run a single test use the full path with the following format:
 
 ```
@@ -99,5 +107,3 @@ See [Running the tests](#running-the-tests) section for more information on avai
 
 * A script to pre-config the complete test environment using virsh.
 * A test matrix to run tests against different distros in parallel (probably using tox).
-* Allow to connect to `ipaserver` using ssh and password.
-

--- a/tests/test_playbook_runs.py
+++ b/tests/test_playbook_runs.py
@@ -19,6 +19,10 @@ def is_docker_env():
     return True
 
 
+def get_ssh_password():
+    return os.getenv("IPA_SSH_PASSWORD")
+
+
 def get_server_host():
     return os.getenv("IPA_SERVER_HOST")
 
@@ -32,6 +36,10 @@ def get_inventory_content():
 
     if is_docker_env():
         ipa_server_host += " ansible_connection=docker"
+
+    sshpass = get_ssh_password()
+    if sshpass:
+        ipa_server_host += " ansible_ssh_pass=%s" % sshpass
 
     lines = [
         "[ipaserver]",


### PR DESCRIPTION
Currently, running pytest requires that ssh uses key exchange. These
change allows the use of ssh with password to connect to the host.