### PR TITLE
 Add support to define which playbook tests to execute with pytest.

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -63,6 +63,24 @@ IPA_SERVER_HOST=<ipaserver_host_or_ip> pytest -rs
 
 For a complete list of options check `pytest --help`.
 
+### Disabling and enabling playbook tests
+
+Sometimes it is useful to enable or disable specific playbook tests. To only run a subset of modules or tests, use the variables IPA_ENABLED_MODULES and IPA ENABLED_TESTS, to define a comma-separated list of modules or tests to be enabled. Any test or module not in the list will not be executed. For example, to run only `sudorule` and `sudocmd` tests:
+
+```
+IPA_ENABLE_MODULES="sudorule,sudocmd" IPA_SERVER_HOST=<ipaserver_host_or_ip> pytest
+```
+
+If all but a few selected tests are to be executed, use the IPA_DISABLED_MODULES or IPA_DISABLED_TESTS. For example, to run all, but "test_service_certificate" test:
+
+```
+IPA_DISABLED_TESTS=test_service_certificate IPA_SERVER_HOST=<ipaserver_host_or_ip> pytest
+```
+
+If none of this variables are defined, all tests will be executed.
+
+To configure the tests that will run for your pull request, add a TEMP commit, with the configuration defined in the file `tests/azure/templates/variables.yml`. Set the variables `ipa_enable_modules`, `ipa_enable_tests`, `ipa_disable_modules`, and `ipa_disable_tests`, in the same way as the equivalent environment variables.
+
 ### Types of tests
 
 #### Playbook tests
@@ -118,6 +136,7 @@ molecule destroy -s c8s
 ```
 
 See [Running the tests](#running-the-tests) section for more information on available options.
+
 
 ## Upcoming/desired improvements:
 

--- a/tests/azure/templates/playbook_tests.yml
+++ b/tests/azure/templates/playbook_tests.yml
@@ -18,11 +18,12 @@ parameters:
   - name: build_number
     type: string
 
-
 jobs:
 - job: Test_Group${{ parameters.group_number }}
   displayName: Run playbook tests ${{ parameters.scenario }} (${{ parameters.group_number }}/${{ parameters.number_of_groups }})
   timeoutInMinutes: 120
+  variables:
+  - template: variables.yaml
   steps:
   - task: UsePythonVersion@0
     inputs:
@@ -63,6 +64,10 @@ jobs:
     env:
       IPA_SERVER_HOST: ${{ parameters.scenario }}
       RUN_TESTS_IN_DOCKER: true
+      IPA_DISABLED_MODULES: ${{ variables.disabled_modules }}
+      IPA_DISABLED_TESTS: ${{ variables.disabled_tests }}
+      IPA_ENABLED_MODULES: ${{ variables.enabled_modules }}
+      IPA_ENABLED_TESTS: ${{ variables.enabled_tests }}
 
   - task: PublishTestResults@2
     inputs:

--- a/tests/azure/templates/playbook_tests.yml
+++ b/tests/azure/templates/playbook_tests.yml
@@ -64,10 +64,10 @@ jobs:
     env:
       IPA_SERVER_HOST: ${{ parameters.scenario }}
       RUN_TESTS_IN_DOCKER: true
-      IPA_DISABLED_MODULES: ${{ variables.disabled_modules }}
-      IPA_DISABLED_TESTS: ${{ variables.disabled_tests }}
-      IPA_ENABLED_MODULES: ${{ variables.enabled_modules }}
-      IPA_ENABLED_TESTS: ${{ variables.enabled_tests }}
+      IPA_DISABLED_MODULES: ${{ variables.ipa_disabled_modules }}
+      IPA_DISABLED_TESTS: ${{ variables.ipa_disabled_tests }}
+      IPA_ENABLED_MODULES: ${{ variables.ipa_enabled_modules }}
+      IPA_ENABLED_TESTS: ${{ variables.ipa_enabled_tests }}
 
   - task: PublishTestResults@2
     inputs:

--- a/tests/azure/templates/pytest_tests.yml
+++ b/tests/azure/templates/pytest_tests.yml
@@ -16,6 +16,8 @@ jobs:
 - job: Test_PyTests
   displayName: Run pytests on ${{ parameters.scenario }}
   timeoutInMinutes: 120
+  variables:
+  - template: variables.yaml
   steps:
   - task: UsePythonVersion@0
     inputs:
@@ -53,10 +55,10 @@ jobs:
     env:
       IPA_SERVER_HOST: ${{ parameters.scenario }}
       RUN_TESTS_IN_DOCKER: true
-      IPA_DISABLED_MODULES: ${{ variables.disabled_modules }}
-      IPA_DISABLED_TESTS: ${{ variables.disabled_tests }}
-      IPA_ENABLED_MODULES: ${{ variables.enabled_modules }}
-      IPA_ENABLED_TESTS: ${{ variables.enabled_tests }}
+      IPA_DISABLED_MODULES: ${{ variables.ipa_disabled_modules }}
+      IPA_DISABLED_TESTS: ${{ variables.ipa_disabled_tests }}
+      IPA_ENABLED_MODULES: ${{ variables.ipa_enabled_modules }}
+      IPA_ENABLED_TESTS: ${{ variables.ipa_enabled_tests }}
 
   - task: PublishTestResults@2
     inputs:

--- a/tests/azure/templates/pytest_tests.yml
+++ b/tests/azure/templates/pytest_tests.yml
@@ -53,6 +53,10 @@ jobs:
     env:
       IPA_SERVER_HOST: ${{ parameters.scenario }}
       RUN_TESTS_IN_DOCKER: true
+      IPA_DISABLED_MODULES: ${{ variables.disabled_modules }}
+      IPA_DISABLED_TESTS: ${{ variables.disabled_tests }}
+      IPA_ENABLED_MODULES: ${{ variables.enabled_modules }}
+      IPA_ENABLED_TESTS: ${{ variables.enabled_tests }}
 
   - task: PublishTestResults@2
     inputs:

--- a/tests/azure/templates/variables.yaml
+++ b/tests/azure/templates/variables.yaml
@@ -1,0 +1,18 @@
+#
+# Variables must be defined as comma separated lists.
+# For easier management of items to enable/disable,
+# use one test/module on each line, followed by a comma.
+#
+# Example:
+#
+# disabled_modules: >-
+#   dnsconfig,
+#   group,
+#   hostgroup
+#
+---
+variables:
+  # ipa_enabled_modules: >-
+  # ipa_enabled_tests: >-
+  # ipa_disabled_modules: >-
+  # ipa_disabled_tests: >-

--- a/tests/azure/templates/variables.yaml
+++ b/tests/azure/templates/variables.yaml
@@ -14,5 +14,7 @@
 variables:
   # ipa_enabled_modules: >-
   # ipa_enabled_tests: >-
-  # ipa_disabled_modules: >-
+  ipa_disabled_modules: >-
+    dnsconfig,
+    dnsforwardzone,
   # ipa_disabled_tests: >-

--- a/tests/sanity/ignore-2.12.txt
+++ b/tests/sanity/ignore-2.12.txt
@@ -43,7 +43,6 @@ tests/sanity/sanity.sh shebang!skip
 tests/user/users.sh shebang!skip
 tests/user/users_absent.sh shebang!skip
 tests/utils.py pylint:ansible-format-automatic-specification
-tests/utils.py pylint:subprocess-run-check
 utils/ansible-doc-test shebang!skip
 utils/ansible-ipa-client-install shebang!skip
 utils/ansible-ipa-replica-install shebang!skip

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -174,6 +174,7 @@ def _run_playbook(playbook):
             inventory_file.name,
             playbook,
         ]
+        # pylint: disable=subprocess-run-check
         process = subprocess.run(
             cmd, cwd=SCRIPT_DIR, stdout=subprocess.PIPE, stderr=subprocess.PIPE
         )
@@ -300,11 +301,13 @@ class AnsibleFreeIPATestCase(TestCase):
             host_connection_info, ssh_identity_file=ssh_identity_file,
         )
 
-    def run_playbook(self, playbook, allow_failures=False):
+    @staticmethod
+    def run_playbook(playbook, allow_failures=False):
         return run_playbook(playbook, allow_failures)
 
-    def run_playbook_with_exp_msg(self, playbook, expected_msg):
-        result = self.run_playbook(playbook, allow_failures=True)
+    @staticmethod
+    def run_playbook_with_exp_msg(playbook, expected_msg):
+        result = run_playbook(playbook, allow_failures=True)
         assert (
             expected_msg in result.stdout.decode("utf8")
             or


### PR DESCRIPTION
pytest provide the means to skip tests based on patterns, but writing
these patterns for ansible-freeipa might not be feasible.

This PR allows the selection of playbook tests and modules that will
be executed with pytest using the environmentt variables IPA_ENABLED_TESTS
IPA_ENABLED_MODULES, IPA_DISABLED_TESTS or IPA_DISABLED_MODULES.

When using IPA_ENABLED_MODULES, all modules will be disabled, and only
the modules in the enabled list will be tested. If using the test
filter, IPA_ENABLED_TESTS, all tests are disabled, unless they are in
the enabled test lists.

If the IPA_DISABLED_* version is used, tests and modules are enabled by
default, and the list is used to disable the module or specific test.

To disable a test or module in Azure CI, edit the file
`tests/azure/variables` and add the desired tests or modules to the
parameter variables `enabled_modules`, 'enabled_tests`, `disabled_tests`
or `disable_modules`.

Note that, if added to the `master` branch, this will affect the tests
for every pipeline that it is include (including 'nightly'), so it should
be used with care.

It can be used with TEMP commits to enable only the desired tests,
speeding up upstream tests.