### PR TITLE
Add azure test build matrix

### DIFF
--- a/tests/azure/azure-pipelines.yml
+++ b/tests/azure/azure-pipelines.yml
@@ -17,40 +17,48 @@ trigger:
 pool:
   vmImage: 'ubuntu-18.04'
 
-jobs:
-- job: RunLinters
-  displayName: Run Linters
-  steps:
-  - task: UsePythonVersion@0
-    inputs:
-      versionSpec: '3.6'
+stages:
+- stage: Linters
+  jobs:
+  - job: RunLinters
+    displayName: Run Linters
+    steps:
+    - task: UsePythonVersion@0
+      inputs:
+        versionSpec: '3.6'
 
-  - script: python -m pip install --upgrade pip setuptools wheel
-    displayName: Install tools
+    - script: python -m pip install --upgrade pip setuptools wheel
+      displayName: Install tools
 
-  - script: pip install pydocstyle flake8
-    displayName: Install dependencies
+    - script: pip install pydocstyle flake8
+      displayName: Install dependencies
 
-  - script: flake8 .
-    displayName: Run flake8 checks
+    - script: flake8 .
+      displayName: Run flake8 checks
 
-  - script: pydocstyle .
-    displayName: Verify docstings
+    - script: pydocstyle .
+      displayName: Verify docstings
 
-- template: templates/playbook_tests.yml
-  parameters:
-    group_number: 1
-    number_of_groups: 3
-    build_number: $(Build.BuildNumber)
+- stage: Centos7
+  dependsOn: []
+  jobs:
+  - template: templates/group_tests.yml
+    parameters:
+      build_number: $(Build.BuildNumber)
+      scenario: centos-7
 
-- template: templates/playbook_tests.yml
-  parameters:
-    group_number: 2
-    number_of_groups: 3
-    build_number: $(Build.BuildNumber)
+- stage: Centos8
+  dependsOn: []
+  jobs:
+  - template: templates/group_tests.yml
+    parameters:
+      build_number: $(Build.BuildNumber)
+      scenario: centos-8
 
-- template: templates/playbook_tests.yml
-  parameters:
-    group_number: 3
-    number_of_groups: 3
-    build_number: $(Build.BuildNumber)
+- stage: FedoraLatest
+  dependsOn: []
+  jobs:
+  - template: templates/group_tests.yml
+    parameters:
+      build_number: $(Build.BuildNumber)
+      scenario: fedora-latest

--- a/tests/azure/build-containers.yml
+++ b/tests/azure/build-containers.yml
@@ -6,6 +6,9 @@ schedules:
   branches:
     include:
     - master
+  always: true
+
+trigger: none
 
 pool:
   vmImage: 'ubuntu-18.04'

--- a/tests/azure/templates/group_tests.yml
+++ b/tests/azure/templates/group_tests.yml
@@ -1,0 +1,29 @@
+
+parameters:
+  - name: scenario
+    type: string
+    default: centos-8
+  - name: build_number
+    type: string
+
+jobs:
+- template: playbook_tests.yml
+  parameters:
+    group_number: 1
+    number_of_groups: 3
+    build_number: ${{ parameters.build_number }}
+    scenario: ${{ parameters.scenario }}
+
+- template: playbook_tests.yml
+  parameters:
+    group_number: 2
+    number_of_groups: 3
+    build_number: ${{ parameters.build_number }}
+    scenario: ${{ parameters.scenario }}
+
+- template: playbook_tests.yml
+  parameters:
+    group_number: 3
+    number_of_groups: 3
+    build_number: ${{ parameters.build_number }}
+    scenario: ${{ parameters.scenario }}

--- a/tests/azure/templates/playbook_tests.yml
+++ b/tests/azure/templates/playbook_tests.yml
@@ -16,10 +16,12 @@ parameters:
     type: string
     default: 3.6
   - name: build_number
+    type: string
+
 
 jobs:
-- job: RunTests${{ parameters.group_number }}
-  displayName: Run tests ${{ parameters.group_number }}/${{ parameters.number_of_groups }}
+- job: Test_Group${{ parameters.group_number }}
+  displayName: Run tests ${{ parameters.scenario }} (${{ parameters.group_number }}/${{ parameters.number_of_groups }})
   steps:
   - task: UsePythonVersion@0
     inputs:


### PR DESCRIPTION
Changes azure-pipelines to run PR tests in 3 different stages: fedora-latest, centos-7 and centos-8.
