### PR TITLE
Prevent Azure pipelines to build containers on PRs

### DIFF
--- a/tests/azure/build-containers.yml
+++ b/tests/azure/build-containers.yml
@@ -6,6 +6,9 @@ schedules:
   branches:
     include:
     - master
+  always: true
+
+trigger: none
 
 pool:
   vmImage: 'ubuntu-18.04'


### PR DESCRIPTION
Azure is building CentOS and Fedora containers in every PR. We only need to have containers builds on a nightly build so we are disabling the default triggers from Azure.