### PR TITLE
Fixed note about specific IPA version for attributes.

### DIFF
--- a/README-config.md
+++ b/README-config.md
@@ -19,6 +19,7 @@ Supported FreeIPA Versions
 
 FreeIPA versions 4.4.0 and up are supported by the ipaconfig module.
 
+Some variables are only supported on newer versions of FreeIPA. Check `Variables` section for details.
 
 Requirements
 ------------
@@ -91,7 +92,7 @@ Variable | Description | Required
 `ipaadmin_principal` | The admin principal is a string and defaults to `admin` | no
 `ipaadmin_password` | The admin password is a string and is required if there is no admin ticket available on the node | no
 `maxusername` \| `ipamaxusernamelength` |  Set the maximum username length (1 to 255) | no
-`maxhostname` \| `ipamaxhostnamelength` |  Set the maximum hostname length between 64-255 | no
+`maxhostname` \| `ipamaxhostnamelength` |  Set the maximum hostname length between 64-255. Only usable with IPA versions 4.8.0 and up. | no
 `homedirectory` \| `ipahomesrootdir` |  Set the default location of home directories | no
 `defaultshell` \| `ipadefaultloginshell` |  Set the default shell for new users | no
 `defaultgroup` \| `ipadefaultprimarygroup` |  Set the default group for new users | no

--- a/README-group.md
+++ b/README-group.md
@@ -19,6 +19,8 @@ Supported FreeIPA Versions
 
 FreeIPA versions 4.4.0 and up are supported by the ipagroup module.
 
+Some variables are only supported on newer versions of FreeIPA. Check `Variables` section for details.
+
 
 Requirements
 ------------

--- a/README-service.md
+++ b/README-service.md
@@ -18,7 +18,7 @@ Supported FreeIPA Versions
 
 FreeIPA versions 4.4.0 and up are supported by the ipaservice module.
 
-Option `skip_host_check` requires FreeIPA version 4.7.0 or later.
+Some variables are only supported on newer versions of FreeIPA. Check `Variables` section for details.
 
 
 Requirements
@@ -298,7 +298,7 @@ Variable | Description | Required
 `requires_pre_auth` \| `ipakrbrequirespreauth` | Pre-authentication is required for the service. Default to true. (bool) | no
 `ok_as_delegate` \|  `ipakrbokasdelegate` | Client credentials may be delegated to the service. Default to false. (bool) | no
 `ok_to_auth_as_delegate` \|  `ipakrboktoauthasdelegate` | The service is allowed to authenticate on behalf of a client. Default to false. (bool) | no
-`skip_host_check` | Force service to be created even when host object does not exist to manage it. Default to false. (bool)| no
+`skip_host_check` | Force service to be created even when host object does not exist to manage it. Only usable with IPA versions 4.7.0 and up. Default to false. (bool)| no
 `force` | Force principal name even if host not in DNS. Default to false. (bool) | no
 `host` \| `managedby_host`| Hosts that can manage the service. | no
 `principal` \| `krbprincipalname` | List of principal aliases for the service. | no


### PR DESCRIPTION
Some attributes require a specific IPA version to be used, some were
not documented, some had different text.

This change standardize the text to show that some attributes require
a specific IPA version to be used, and add the versions where they
were not yet documented.