### PR TITLE
Add missing example playbooks for dnsforwardzone module.

### DIFF
--- a/playbooks/dnsforwardzone/ensure-dnsforwardzone-is-absent.yml
+++ b/playbooks/dnsforwardzone/ensure-dnsforwardzone-is-absent.yml
@@ -1,0 +1,11 @@
+---
+- name: Playbook to manage DNS forward zone
+  hosts: ipaserver
+  become: true
+  gather_facts: false
+
+  tasks:
+  # Ensure DNS zone is present
+  - ipadnsforwardzone:
+      ipaadmin_password: SomeADMINpassword
+      state: absent

--- a/playbooks/dnsforwardzone/ensure-dnsforwardzone-is-present.yml
+++ b/playbooks/dnsforwardzone/ensure-dnsforwardzone-is-present.yml
@@ -1,0 +1,16 @@
+---
+- name: Playbook to manage DNS forward zone
+  hosts: ipaserver
+  become: true
+  gather_facts: false
+
+  tasks:
+  # Ensure DNS zone is present
+  - ipadnsforwardzone:
+      ipaadmin_password: SomeADMINpassword
+      name: example.com
+      forwarders:
+        - ip_address: 8.8.8.8
+      forwardpolicy: first
+      skip_overlap_check: true
+      permission: yes

--- a/playbooks/dnsforwardzone/ensure-dnsforwardzone-with-forwarder-port.yml
+++ b/playbooks/dnsforwardzone/ensure-dnsforwardzone-with-forwarder-port.yml
@@ -1,0 +1,14 @@
+---
+- name: Playbook to manage DNS forward zone
+  hosts: ipaserver
+  become: true
+  gather_facts: false
+
+  tasks:
+  # Ensure DNS zone is present
+  - ipadnsforwardzone:
+      ipaadmin_password: SomeADMINpassword
+      name: example.com
+      forwarders:
+        - ip_address: 192.168.100.123
+          port: 8063


### PR DESCRIPTION
Module dnsforwardzone had no example playbooks, which are added by this patch.