### PR TITLE
Fix ipavault vault_type under Python 2.7

### DIFF
--- a/plugins/modules/ipavault.py
+++ b/plugins/modules/ipavault.py
@@ -756,7 +756,7 @@ def main():
                     res_vault_type = res_find.get('ipavaulttype')[0]
                     args['ipavaulttype'] = vault_type = res_vault_type
                 else:
-                    args['ipavaulttype'] = vault_type = "symmetric"
+                    args['ipavaulttype'] = vault_type = u"symmetric"
 
             # Create command
             if state == "present":


### PR DESCRIPTION
When running module ipavault with Python 2.7, due to differences in
the handling of unicode string than in Python 3, the vault_type type
was different than the required.

This patch changes the default value to force a unicode string in
the supported versions of Python, fixing the module when Python 2
is used.