### PR TITLE
Adding auto COPR builds

### DIFF
--- a/.copr/Makefile
+++ b/.copr/Makefile
@@ -1,0 +1,9 @@
+srpm:
+	# Setup development environment
+	echo "Installing base development environment"
+	dnf install -y dnf-plugins-core git-all
+	echo "Call SRPM build Script"
+	./utils/build-srpm.sh
+	if [[ "${outdir}" != "" ]]; then \
+		mv /builddir/build/SRPMS/* ${outdir}; \
+	fi


### PR DESCRIPTION
This commit adds .copr/Makefile that calls the executable script (build-srpm.sh)
to be used for COPR SRPM generation.