### PR TITLE
Fix invalid return value from vault module in README.md.

### DIFF
--- a/README-vault.md
+++ b/README-vault.md
@@ -246,10 +246,6 @@ There is only a return value if `state` is `retrieved`.
 
 Variable | Description | Returned When
 -------- | ----------- | -------------
-`data` | The data stored in the vault. | If `state` is `retrieved`.
-
-Variable | Description | Returned When
--------- | ----------- | -------------
 `vault` | Vault dict with archived data. (dict) <br>Options: | If `state` is `retrieved`.
 &nbsp; | `data` - The vault data. | Always
 


### PR DESCRIPTION
There was a duplicate table for the return values in the vault module, the invalid one was removed.