### PR TITLE
Add support for ansible-lint and yamllint as Github actions.

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,0 +1,23 @@
+exclude_paths:
+  - roles
+  - .tox
+  - .venv
+
+parseable: true
+
+quiet: false
+
+skip_list:
+  - '201'  # Trailing whitespace
+  - '204'  # Lines should be no longer than 160 chars
+  - '206'  # Variables should have spaces before and after: {{ var_name }}'
+  - '208'  # File permissions not mentioned
+  - '301'  # Commands should not change things if nothing needs doing'
+  - '305'  # Use shell only when shell functionality is required'
+  - '306'  # Shells that use pipes should set the pipefail option'
+  - '502'  # All tasks should be named
+  - '505'  # Referenced missing file
+
+use_default_rules: true
+
+verbosity: 1

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -25,3 +25,7 @@ jobs:
         env:
           ANSIBLE_MODULE_UTILS: plugins/module_utils
           ANSIBLE_LIBRARY: plugins/modules
+
+      - name: Run yaml-lint
+        uses: ibiqlik/action-yamllint@v1
+

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,27 @@
+---
+name: Run Linters
+on:
+  - push
+  - pull_request
+jobs:
+  linters:
+    name: Run Linters
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: "3.6"
+
+      - name: Run ansible-lint
+        uses: ansible/ansible-lint-action@master
+        with:
+          targets: |
+            tests/*.yml
+            tests/*/*.yml
+            tests/*/*/*.yml
+            playbooks/*.yml
+            playbooks/*/*.yml
+        env:
+          ANSIBLE_MODULE_UTILS: plugins/module_utils
+          ANSIBLE_LIBRARY: plugins/modules

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -29,3 +29,5 @@ jobs:
       - name: Run yaml-lint
         uses: ibiqlik/action-yamllint@v1
 
+      - name: Run Python linters
+        uses: rjeffman/python-lint-action@master

--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,28 @@
+---
+ignore: |
+  /.tox/
+  /.venv/
+  /.github/
+
+extends: default
+
+rules:
+  braces:
+    max-spaces-inside: 1
+    level: error
+  brackets:
+    max-spaces-inside: 1
+    level: error
+  truthy:
+    allowed-values: ["yes", "no", "true", "false", "True", "False"]
+    level: error
+  # Disabled rules
+  document-start: disable
+  indentation: disable
+  line-length: disable
+  colons: disable
+  empty-lines: disable
+  comments: disable
+  comments-indentation: disable
+  trailing-spaces: disable
+  new-line-at-end-of-file: disable

--- a/README-dnszone.md
+++ b/README-dnszone.md
@@ -181,7 +181,7 @@ Example playbook to create a zone for reverse DNS lookup, from an IP address, gi
   become: true
 
   tasks:
-      - name: Ensure zone for reverse DNS lookup is present.
+  - name: Ensure zone for reverse DNS lookup is present.
     ipadnszone:
       ipaadmin_password: SomeADMINpassword
       name_from_ip: 192.168.1.2/24

--- a/molecule/resources/playbooks/prepare-build.yml
+++ b/molecule/resources/playbooks/prepare-build.yml
@@ -11,7 +11,7 @@
   - name: Ensure nss package is updated
     package:
       name: nss
-      state: latest
+      state: latest  # noqa 403
 
   - include_role:
       name: ipaserver

--- a/playbooks/host/host-member-managedby_host-absent.yml
+++ b/playbooks/host/host-member-managedby_host-absent.yml
@@ -4,7 +4,7 @@
   become: true
 
   tasks:
-    ipahost:
+  - ipahost:
       ipaadmin_password: SomeADMINpassword
       name: host01.exmaple.com
       managedby_host: server.exmaple.com

--- a/playbooks/host/host-member-managedby_host-present.yml
+++ b/playbooks/host/host-member-managedby_host-present.yml
@@ -4,7 +4,7 @@
   become: true
 
   tasks:
-    ipahost:
+  - ipahost:
       ipaadmin_password: SomeADMINpassword
       name: host01.exmaple.com
       managedby_host: server.exmaple.com

--- a/playbooks/host/host-present-with-managedby_host.yml
+++ b/playbooks/host/host-present-with-managedby_host.yml
@@ -4,7 +4,7 @@
   become: true
 
   tasks:
-    ipahost:
+  - ipahost:
       ipaadmin_password: SomeADMINpassword
       name: host01.exmaple.com
       managedby_host: server.exmaple.com

--- a/playbooks/host/hosts-member-managedby_host-absent.yml
+++ b/playbooks/host/hosts-member-managedby_host-absent.yml
@@ -4,6 +4,7 @@
   become: true
 
   tasks:
+  - name: Ensure hosts manadegby_host is absent.
     ipahost:
       ipaadmin_password: SomeADMINpassword
       hosts:

--- a/playbooks/host/hosts-member-managedby_host-present.yml
+++ b/playbooks/host/hosts-member-managedby_host-present.yml
@@ -4,6 +4,7 @@
   become: true
 
   tasks:
+  - name: Ensure hosts manadegby_host is absent.
     ipahost:
       ipaadmin_password: SomeADMINpassword
       hosts:

--- a/playbooks/host/hosts-present-with-managedby_host.yml
+++ b/playbooks/host/hosts-present-with-managedby_host.yml
@@ -4,7 +4,7 @@
   become: true
 
   tasks:
-    ipahost:
+  - ipahost:
       ipaadmin_password: SomeADMINpassword
       hosts:
       - name: host01.exmaple.com

--- a/playbooks/host/hosts-present-with-randompasswords.yml
+++ b/playbooks/host/hosts-present-with-randompasswords.yml
@@ -23,4 +23,3 @@
   - name: Print generated random password for host02.example.com
     debug:
       var: ipahost.host["host02.example.com"].randompassword
-

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,7 +22,8 @@ data_files =
     /usr/share/ansible/roles/ipareplica = roles/ipareplica/*
 
 [flake8]
-extend-ignore = E203
+extend-ignore = E203, D1, D212, D203, D400, D401
+exclude = .git,__pycache__,.tox,.venv
 per-file-ignores =
     plugins/*:E402
     roles/*:E402

--- a/tests/azure/azure-pipelines.yml
+++ b/tests/azure/azure-pipelines.yml
@@ -18,27 +18,6 @@ pool:
   vmImage: 'ubuntu-18.04'
 
 stages:
-- stage: Linters
-  jobs:
-  - job: RunLinters
-    displayName: Run Linters
-    steps:
-    - task: UsePythonVersion@0
-      inputs:
-        versionSpec: '3.6'
-
-    - script: python -m pip install --upgrade pip setuptools wheel
-      displayName: Install tools
-
-    - script: pip install pydocstyle flake8
-      displayName: Install dependencies
-
-    - script: flake8 .
-      displayName: Run flake8 checks
-
-    - script: pydocstyle .
-      displayName: Verify docstings
-
 - stage: Centos7
   dependsOn: []
   jobs:

--- a/utils/lint_check.sh
+++ b/utils/lint_check.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+topdir=`dirname $(dirname $0)`
+
+flake8 .
+pydocstyle .
+
+ANSIBLE_LIBRARY=${ANSIBLE_LIBRARY:-"${topdir}/plugins/modules"}
+ANSIBLE_MODULE_UTILS=${ANSIBLE_MODULE_UTILS:-"${topdir}/plugins/module_utils"}
+
+export ANSIBLE_LIBRARY ANSIBLE_MODULE_UTILS
+
+yaml_dirs=(
+    "${topdir}/tests/*.yml"
+    "${topdir}/tests/*/*.yml"
+    "${topdir}/tests/*/*/*.yml"
+    "${topdir}/playbooks/*.yml"
+    "${topdir}/playbooks/*/*.yml"
+    "${topdir}/molecule/*/*.yml"
+    "${topdir}/molecule/*/*/*.yml"
+)
+
+ansible-lint --force-color ${yaml_dirs[@]}
+
+yamllint -f colored ${yaml_dirs[@]}


### PR DESCRIPTION
This PR add support for running Yamllint, Ansible-lint and Flake8 as Github actions that will run on every push. It also adds yamllint and ansible-lint to Azure pipelines to be executed for every pull request.

A few existing playbooks needed to be fixed due to an ansible-lint issue.

This PR does not fixes any issues found in the existing playbooks, instead, it disables all found in playbooks during development. The issues should be fixed by other patches.

More details can be found on the individual commits.