### PR TITLE
Fix host's module managedby_host playbooks.

### DIFF
--- a/playbooks/host/host-member-managedby_host-absent.yml
+++ b/playbooks/host/host-member-managedby_host-absent.yml
@@ -4,7 +4,7 @@
   become: true
 
   tasks:
-    ipahost:
+  - ipahost:
       ipaadmin_password: SomeADMINpassword
       name: host01.exmaple.com
       managedby_host: server.exmaple.com

--- a/playbooks/host/host-member-managedby_host-present.yml
+++ b/playbooks/host/host-member-managedby_host-present.yml
@@ -4,7 +4,7 @@
   become: true
 
   tasks:
-    ipahost:
+  - ipahost:
       ipaadmin_password: SomeADMINpassword
       name: host01.exmaple.com
       managedby_host: server.exmaple.com

--- a/playbooks/host/host-present-with-managedby_host.yml
+++ b/playbooks/host/host-present-with-managedby_host.yml
@@ -4,7 +4,7 @@
   become: true
 
   tasks:
-    ipahost:
+  - ipahost:
       ipaadmin_password: SomeADMINpassword
       name: host01.exmaple.com
       managedby_host: server.exmaple.com

--- a/playbooks/host/hosts-member-managedby_host-absent.yml
+++ b/playbooks/host/hosts-member-managedby_host-absent.yml
@@ -4,6 +4,7 @@
   become: true
 
   tasks:
+  - name: Ensure hosts manadegby_host is absent.
     ipahost:
       ipaadmin_password: SomeADMINpassword
       hosts:

--- a/playbooks/host/hosts-member-managedby_host-present.yml
+++ b/playbooks/host/hosts-member-managedby_host-present.yml
@@ -4,6 +4,7 @@
   become: true
 
   tasks:
+  - name: Ensure hosts manadegby_host is absent.
     ipahost:
       ipaadmin_password: SomeADMINpassword
       hosts:

--- a/playbooks/host/hosts-present-with-managedby_host.yml
+++ b/playbooks/host/hosts-present-with-managedby_host.yml
@@ -4,7 +4,7 @@
   become: true
 
   tasks:
-    ipahost:
+  - ipahost:
       ipaadmin_password: SomeADMINpassword
       hosts:
       - name: host01.exmaple.com

--- a/playbooks/host/hosts-present-with-randompasswords.yml
+++ b/playbooks/host/hosts-present-with-randompasswords.yml
@@ -23,4 +23,3 @@
   - name: Print generated random password for host02.example.com
     debug:
       var: ipahost.host["host02.example.com"].randompassword
-


### PR DESCRIPTION
The host's module example playbooks had syntax errors that prevented
its execution. The tasks were described as dicts rather than lists.