### PR TITLE
Add commonly used virtual environment paths to gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 *.pyc
 *.retry
+
+# ignore virtual environments
+/.tox/
+/.venv/


### PR DESCRIPTION
When using virtual environment for development, Git reports that the
virtual environment itself in untracked. This change add commonly found
virtual environment directories to the list of ignored files/directories.