### PR TITLE
Fixed log of vault data return when retrieving to a file.

### DIFF
--- a/README-vault.md
+++ b/README-vault.md
@@ -246,7 +246,7 @@ There is only a return value if `state` is `retrieved`.
 
 Variable | Description | Returned When
 -------- | ----------- | -------------
-`vault` | Vault dict with archived data. (dict) <br>Options: | If `state` is `retrieved`.
+`vault` | Vault dict with archived data. (dict) <br>Options: | If `state` is `retrieved` and `out` is not defined.
 &nbsp; | `data` - The vault data. | Always
 
 

--- a/plugins/modules/ipavault.py
+++ b/plugins/modules/ipavault.py
@@ -923,14 +923,12 @@ def main():
                 elif command == 'vault_retrieve':
                     if 'result' not in result:
                         raise Exception("No result obtained.")
-                    if 'data' in result['result']:
-                        data_return = exit_args.setdefault('vault', {})
-                        data_return['data'] = result['result']['data']
-                    elif 'vault_data' in result['result']:
-                        data_return = exit_args.setdefault('vault', {})
-                        data_return['data'] = result['result']['vault_data']
+                    if "data" in result["result"]:
+                        data_return = exit_args.setdefault("vault", {})
+                        data_return["data"] = result["result"]["data"]
                     else:
-                        raise Exception("No data retrieved.")
+                        if not datafile_out:
+                            raise Exception("No data retrieved.")
                     changed = False
                 else:
                     if "completed" in result:

--- a/tests/vault/test_vault_asymmetric.yml
+++ b/tests/vault/test_vault_asymmetric.yml
@@ -52,7 +52,7 @@
       private_key: "{{ lookup('file', 'private.pem') | b64encode }}"
       state: retrieved
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed or (result.vault.data | default(false))
 
   - name: Verify retrieved data.
     slurp:

--- a/tests/vault/test_vault_standard.yml
+++ b/tests/vault/test_vault_standard.yml
@@ -48,7 +48,7 @@
       out: "{{ ansible_env.HOME }}/data.txt"
       state: retrieved
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed or (result.vault.data | default(false))
 
   - name: Verify retrieved data.
     slurp:

--- a/tests/vault/test_vault_symmetric.yml
+++ b/tests/vault/test_vault_symmetric.yml
@@ -53,7 +53,7 @@
       out: "{{ ansible_env.HOME }}/data.txt"
       state: retrieved
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed or (result.vault.data | default(false))
 
   - name: Verify retrieved data.
     slurp:


### PR DESCRIPTION
When retrieving data from a vault using `out` to store the data in a
file resulted is random characters being returned and logged. These
characters could generate a traceback print from Ansible's logger,
without breaking the script.

This patch fixes this behavior by supressing any return value when data
is retrieved to a file.