### PR TITLE
tests/user/test_users_present_slice.yml: Fix missing users.json

### DIFF
--- a/tests/user/test_users_present_slice.yml
+++ b/tests/user/test_users_present_slice.yml
@@ -1,4 +1,7 @@
 ---
+- name: Include create_users_json.yml
+  import_playbook: create_users_json.yml
+
 - name: Test users present slice
   hosts: ipaserver
   become: true


### PR DESCRIPTION
users.json is generated for the tests and not part of the repo any more.
This test was lacking the include to generate the file.

Related to: b7e1a99b6eddf348dc854c753b45cecde09deb48
            tests/user/test_users*.yml: Use extended dynamic users.json