### PR TITLE
ipa[server,replica]: New variables to set firewalld zone

### DIFF
--- a/roles/ipareplica/README.md
+++ b/roles/ipareplica/README.md
@@ -250,7 +250,7 @@ Variable | Description | Required
 -------- | ----------- | --------
 `ipareplica_install_packages` | The bool value defines if the needed packages are installed on the node. (bool, default: true) | no
 `ipareplica_setup_firewalld` | The value defines if the needed services will automatically be openen in the firewall managed by firewalld. (bool, default: true) | no
-
+`ipareplica_firewalld_zone` | The value defines the firewall zone that will be used. This needs to be an existing runtime and permanent zone. (string) | no
 
 Authors
 =======

--- a/roles/ipareplica/tasks/install.yml
+++ b/roles/ipareplica/tasks/install.yml
@@ -26,14 +26,31 @@
       state: present
     when: ipareplica_setup_firewalld | bool
 
+  when: ipareplica_install_packages | bool
+
+- block:
   - name: Firewalld service - Ensure that firewalld is running
     systemd:
       name: firewalld
       enabled: yes
       state: started
-    when: ipareplica_setup_firewalld | bool
 
-  when: ipareplica_install_packages | bool
+  - name: Firewalld - Verify runtime zone "{{ ipareplica_firewalld_zone }}"
+    shell: >
+      firewall-cmd
+      --info-zone="{{ ipareplica_firewalld_zone }}"
+      >/dev/null
+    when: ipareplica_firewalld_zone is defined
+
+  - name: Firewalld - Verify permanent zone "{{ ipareplica_firewalld_zone }}"
+    shell: >
+      firewall-cmd
+      --permanent
+      --info-zone="{{ ipareplica_firewalld_zone }}"
+      >/dev/null
+    when: ipareplica_firewalld_zone is defined
+
+  when: ipareplica_setup_firewalld | bool
 
 #- name: Install - Include Python2/3 import test
 #  import_tasks: "{{ role_path }}/tasks/python_2_3_test.yml"
@@ -109,6 +126,8 @@
     command: >
       firewall-cmd
       --permanent
+      --zone="{{ ipareplica_firewalld_zone if ipareplica_firewalld_zone is
+         defined else '' }}"
       --add-service=freeipa-ldap
       --add-service=freeipa-ldaps
       {{ "--add-service=freeipa-trust" if result_ipareplica_test.setup_adtrust
@@ -120,6 +139,8 @@
   - name: Install - Configure firewalld runtime
     command: >
       firewall-cmd
+      --zone="{{ ipareplica_firewalld_zone if ipareplica_firewalld_zone is
+         defined else '' }}"
       --add-service=freeipa-ldap
       --add-service=freeipa-ldaps
       {{ "--add-service=freeipa-trust" if result_ipareplica_test.setup_adtrust

--- a/roles/ipaserver/README.md
+++ b/roles/ipaserver/README.md
@@ -299,6 +299,7 @@ Variable | Description | Required
 -------- | ----------- | --------
 `ipaserver_install_packages` | The bool value defines if the needed packages are installed on the node. (bool, default: true) | no
 `ipaserver_setup_firewalld` | The value defines if the needed services will automatically be opened in the firewall managed by firewalld. (bool, default: true) | no
+`ipaserver_firewalld_zone` | The value defines the firewall zone that will be used. This needs to be an existing runtime and permanent zone. (string) | no
 `ipaserver_external_cert_files_from_controller` | Files containing the IPA CA certificates and the external CA certificate chains on the controller that will be copied to the ipaserver host to `/root` folder. (list of string) | no
 `ipaserver_copy_csr_to_controller` | Copy the generated CSR from the ipaserver to the controller as `"{{ inventory_hostname }}-ipa.csr"`. (bool) | no
 

--- a/roles/ipaserver/tasks/install.yml
+++ b/roles/ipaserver/tasks/install.yml
@@ -25,14 +25,31 @@
       state: present
     when: ipaserver_setup_firewalld | bool
 
+  when: ipaserver_install_packages | bool
+
+- block:
   - name: Firewalld service - Ensure that firewalld is running
     systemd:
       name: firewalld
       enabled: yes
       state: started
-    when: ipaserver_setup_firewalld | bool
 
-  when: ipaserver_install_packages | bool
+  - name: Firewalld - Verify runtime zone "{{ ipaserver_firewalld_zone }}"
+    shell: >
+      firewall-cmd
+      --info-zone="{{ ipaserver_firewalld_zone }}"
+      >/dev/null
+    when: ipaserver_firewalld_zone is defined
+
+  - name: Firewalld - Verify permanent zone "{{ ipaserver_firewalld_zone }}"
+    shell: >
+      firewall-cmd
+      --permanent
+      --info-zone="{{ ipaserver_firewalld_zone }}"
+      >/dev/null
+    when: ipaserver_firewalld_zone is defined
+
+  when: ipaserver_setup_firewalld | bool
 
 #- name: Install - Include Python2/3 import test
 #  import_tasks: "{{ role_path }}/tasks/python_2_3_test.yml"
@@ -428,6 +445,8 @@
       command: >
         firewall-cmd
         --permanent
+        --zone="{{ ipaserver_firewalld_zone if ipaserver_firewalld_zone is
+           defined else '' }}"
         --add-service=freeipa-ldap
         --add-service=freeipa-ldaps
         {{ "--add-service=freeipa-trust" if ipaserver_setup_adtrust | bool
@@ -439,6 +458,8 @@
     - name: Install - Configure firewalld runtime
       command: >
         firewall-cmd
+        --zone="{{ ipaserver_firewalld_zone if ipaserver_firewalld_zone is
+           defined else '' }}"
         --add-service=freeipa-ldap
         --add-service=freeipa-ldaps
         {{ "--add-service=freeipa-trust" if ipaserver_setup_adtrust | bool


### PR DESCRIPTION
The new variables ipa[server,replica]_firewalld_zone have been added to
be able to set the zone in which the needed services for IPA are enabled.

New tasks have been added to check if the zone is available in the runtime
and also permamanet environment.

The code to enable firewalld has been moved out of thee
ipa[server,replica]_install_packages blocks to make sure that the firewalld
service is also enabled if the package is already installed.

Fixes: issue #177 (How to set up firewalld zones?)