### PR TITLE
Add new module to support adding and deleting Auto Membership Rules

### DIFF
--- a/README-automember.md
+++ b/README-automember.md
@@ -1,0 +1,111 @@
+Automember module
+===========
+
+Description
+-----------
+
+The automember module allows to ensure presence or absence of automember rules
+    and manage automember rule conditions.
+
+Features
+--------
+
+* Automember management
+
+
+Supported FreeIPA Versions
+--------------------------
+
+FreeIPA versions 4.4.0 and up are supported by the ipaautomember module.
+
+
+Requirements
+------------
+
+**Controller**
+* Ansible version: 2.8+
+
+**Node**
+* Supported FreeIPA version (see above)
+
+
+Usage
+=====
+
+Example inventory file
+
+```ini
+[ipaserver]
+ipaserver.test.local
+```
+
+
+Example playbook to make sure group automember rule is present with conditions:
+
+```yaml
+---
+- name: Playbook to add a group automember rule with two conditions
+  hosts: ipaserver
+  become: yes
+  gather_facts: no
+
+  tasks:
+  - ipaautomember:
+      ipaadmin_password: SomeADMINpassword
+      name: admins
+      description: "my automember rule"
+      type: group
+      inclusive:
+        - key: mail
+          expression: '@example.com$'
+      exclusive:
+        - key: uid
+          expression: "1234"
+```
+
+Example playbook to make sure group automember rule is present with no conditions.
+
+```yaml
+---
+- ipaautomember:
+    ipaadmin_password: SomeADMINpassword
+    name: admins
+    description: "my automember rule"
+    type: group
+```
+
+Example playbook to delete a group automember rule:
+
+```yaml
+- ipaautomember:
+    ipaadmin_password: SomeADMINpassword
+    name: admins
+    description: "my automember rule"
+    type: group
+    state: absent
+```
+
+
+
+Variables
+---------
+
+ipaautomember
+-------
+
+Variable | Description | Required
+-------- | ----------- | --------
+`ipaadmin_principal` | The admin principal is a string and defaults to `admin` | no
+`ipaadmin_password` | The admin password is a string and is required if there is no admin ticket available on the node | no
+`name` \| `cn` | Automember rule. | yes
+`description` | A description of this auto member rule. | no
+`type` | Grouping to which the rule applies. It can be one of `group`, `hostgroup`. | yes
+`inclusive` | List of dictionaries in the format of `{'key': attribute, 'expression': inclusive_regex}` | no
+`exclusive` | List of dictionaries in the format of `{'key': attribute, 'expression': exclusive_regex}` | no
+`state` | The state to ensure. It can be one of `present`, `absent`, default: `present`. | no
+
+
+Authors
+=======
+
+Mark Hahl

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Features
 * Cluster deployments: Server, replicas and clients in one playbook
 * One-time-password (OTP) support for client installation
 * Repair mode for clients
+* modules for automembership rule management
 * Modules for dns forwarder management
 * Modules for dns record management
 * Modules for dns zone management

--- a/playbooks/automember/automember-absent.yml
+++ b/playbooks/automember/automember-absent.yml
@@ -5,12 +5,14 @@
   tasks:
   - name: Ensure group automember rule admins is absent
     ipaautomember:
+      ipaadmin_password: SomeADMINpassword
       name: admins
       type: group
       state: absent
 
   - name: Ensure hostgroup automember rule ipaservers is absent
     ipaautomember:
+      ipaadmin_password: SomeADMINpassword
       name: ipaservers
       type: hostgroup
       state: absent

--- a/playbooks/automember/automember-absent.yml
+++ b/playbooks/automember/automember-absent.yml
@@ -1,0 +1,16 @@
+---
+- name: Automember absent example
+  hosts: ipaserver
+  become: true
+  tasks:
+  - name: Ensure group automember rule admins is absent
+    ipaautomember:
+      name: admins
+      type: group
+      state: absent
+
+  - name: Ensure hostgroup automember rule ipaservers is absent
+    ipaautomember:
+      name: ipaservers
+      type: hostgroup
+      state: absent

--- a/playbooks/automember/automember-present.yml
+++ b/playbooks/automember/automember-present.yml
@@ -5,12 +5,14 @@
   tasks:
   - name: Ensure group automember rule admins is present
     ipaautomember:
+      ipaadmin_password: SomeADMINpassword
       name: admins
       type: group
       state: present
 
   - name: Ensure hostgroup automember rule ipaservers is absent
     ipaautomember:
+      ipaadmin_password: SomeADMINpassword
       name: ipaservers
       type: hostgroup
       state: present

--- a/playbooks/automember/automember-present.yml
+++ b/playbooks/automember/automember-present.yml
@@ -1,0 +1,16 @@
+---
+- name: Automember absent example
+  hosts: ipaserver
+  become: true
+  tasks:
+  - name: Ensure group automember rule admins is present
+    ipaautomember:
+      name: admins
+      type: group
+      state: present
+
+  - name: Ensure hostgroup automember rule ipaservers is absent
+    ipaautomember:
+      name: ipaservers
+      type: hostgroup
+      state: present

--- a/playbooks/automember/automember-present.yml
+++ b/playbooks/automember/automember-present.yml
@@ -1,5 +1,5 @@
 ---
-- name: Automember absent example
+- name: Automember present example
   hosts: ipaserver
   become: true
   tasks:

--- a/plugins/module_utils/ansible_freeipa_module.py
+++ b/plugins/module_utils/ansible_freeipa_module.py
@@ -225,7 +225,7 @@ def date_format(value):
     raise ValueError("Invalid date '%s'" % value)
 
 
-def compare_args_ipa(module, args, ipa):  # noqa
+def compare_args_ipa(module, args, ipa, ignore=[]):  # noqa
     """Compare IPA obj attrs with the command args.
 
     This function compares IPA objects attributes with the args the
@@ -239,6 +239,8 @@ def compare_args_ipa(module, args, ipa):  # noqa
     base_debug_msg = "Ansible arguments and IPA commands differed. "
 
     for key in args.keys():
+        if key in ignore:
+            continue
         if key not in ipa:
             module.debug(
                 base_debug_msg + "Command key not present in IPA: %s" % key

--- a/plugins/module_utils/ansible_freeipa_module.py
+++ b/plugins/module_utils/ansible_freeipa_module.py
@@ -225,7 +225,7 @@ def date_format(value):
     raise ValueError("Invalid date '%s'" % value)
 
 
-def compare_args_ipa(module, args, ipa, ignore=[]):  # noqa
+def compare_args_ipa(module, args, ipa, ignore=None):  # noqa
     """Compare IPA obj attrs with the command args.
 
     This function compares IPA objects attributes with the args the
@@ -238,9 +238,13 @@ def compare_args_ipa(module, args, ipa, ignore=[]):  # noqa
     """
     base_debug_msg = "Ansible arguments and IPA commands differed. "
 
-    for key in args.keys():
-        if key in ignore:
-            continue
+    if ignore is None:
+        ignore = []
+
+    filtered_args = [k for k in args.keys() if k not in ignore]
+
+    for key in filtered_args:
+
         if key not in ipa:
             module.debug(
                 base_debug_msg + "Command key not present in IPA: %s" % key

--- a/plugins/modules/ipaautomember.py
+++ b/plugins/modules/ipaautomember.py
@@ -80,7 +80,7 @@ EXAMPLES = """
     ipaadmin_password: SomeADMINpassword
     name: admins
     description: "example description"
-    grouping: group
+    type: group
     state: present
     inclusive:
     - key: "mail"

--- a/plugins/modules/ipaautomember.py
+++ b/plugins/modules/ipaautomember.py
@@ -141,7 +141,7 @@ def gen_args(description, grouping):
 
 
 def transform_conditions(conditions):
-    """ Transforms a list of dicts into a list with the format of key=value. """
+    """Transform a list of dicts into a list with the format of key=value."""
     transformed = []
     for condition in conditions:
         transformed.append('='.join(str(x) for x in condition.values()))
@@ -149,7 +149,7 @@ def transform_conditions(conditions):
 
 
 def gen_condition_commands(name, grouping, module_conditions, current_conditions):
-    """ Returns a list of commands to add/remove automember rule conditions. """
+    """Return a list of commands to add/remove automember rule conditions."""
     commands = []
     add_diff = set(module_conditions) - set(current_conditions)
     remove_diff = set(current_conditions) - set(module_conditions)
@@ -256,7 +256,7 @@ def main():
                 if exclusive is not None and False:
 
                     # Get the conditions from the module
-                    module_conditions = transform_conditions(inclusive)
+                    module_conditions = transform_conditions(exclusive)
 
                     # Get the conditions from the existing automember rule.
                     current_conditions = res_find.get(

--- a/plugins/modules/ipaautomember.py
+++ b/plugins/modules/ipaautomember.py
@@ -79,12 +79,12 @@ EXAMPLES = """
 - ipaautomember:
     ipaadmin_password: SomeADMINpassword
     name: admins
-    description: "t"
+    description: "example description"
     grouping: group
     state: present
     inclusive:
-    - key: "audio"
-        expression: "test"
+    - key: "mail"
+      expression: "example.com$
 
 """
 

--- a/plugins/modules/ipaautomember.py
+++ b/plugins/modules/ipaautomember.py
@@ -104,7 +104,7 @@ RETURN = """
 def find_automember(module, name, grouping):
     _args = {
         "all": True,
-        "type": grouping
+        "type": to_text(grouping)
     }
 
     _result = api_command(module, "automember_find", to_text(name), _args)
@@ -124,13 +124,13 @@ def gen_condition_args(grouping,
                        exclusiveregex):
     _args = {}
     if grouping is not None:
-        _args['type'] = grouping
+        _args['type'] = to_text(grouping)
     if key is not None:
-        _args['key'] = key
+        _args['key'] = to_text(key)
     if inclusiveregex is not None:
-        _args['automemberinclusiveregex'] = inclusiveregex
+        _args['automemberinclusiveregex'] = to_text(inclusiveregex)
     if exclusiveregex is not None:
-        _args['automemberexclusiveregex'] = exclusiveregex
+        _args['automemberexclusiveregex'] = to_text(exclusiveregex)
 
     return _args
 
@@ -140,7 +140,7 @@ def gen_args(description, grouping):
     if description is not None:
         _args["description"] = to_text(description)
     if grouping is not None:
-        _args['type'] = grouping
+        _args['type'] = to_text(grouping)
 
     return _args
 
@@ -278,7 +278,7 @@ def main():
             elif state == 'absent':
                 if res_find is not None:
                     commands.append(
-                        [name, 'automember_del', {'type': grouping}])
+                        [name, 'automember_del', {'type': to_text(grouping)}])
 
         for name, command, args in commands:
             try:
@@ -296,10 +296,6 @@ def main():
 
                 elif command == 'automember_mod':
                     changed |= "Modified" in result['summary']
-
-                ansible_module.warn(str(result))
-
-                res_find = find_automember(ansible_module, name, grouping)
 
             except Exception as e:
                 ansible_module.fail_json(msg=str(e))

--- a/plugins/modules/ipaautomember.py
+++ b/plugins/modules/ipaautomember.py
@@ -1,0 +1,306 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Authors:
+#   Mark Hahl <mhahl@redhat.com>
+#
+# Copyright (C) 2019 Red Hat
+# see file 'COPYING' for use and warranty information
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+
+ANSIBLE_METADATA = {
+    "metadata_version": "1.0",
+    "supported_by": "community",
+    "status": ["preview"],
+}
+
+
+DOCUMENTATION = """
+---
+module: ipaautomember
+short description: Add and delete FreeIPA Auto Membership Rules.
+description:
+- Add, modify and delete an IPA Auto Membership Rules.
+options:
+  ipaadmin_principal:
+    description: The admin principal
+    default: admin
+  ipaadmin_password:
+    description: The admin password
+    required: false
+  name:
+    description: The automember rule
+    required: true
+    aliases: ["cn"]
+  description:
+    description: A description of this auto member rule
+    required: false
+  type:
+    description:
+    - Grouping to which the rule applies
+    required: true
+    type: str
+    choices: ["group", "hostgroup"]
+  exclusive:
+    description:
+    - List of dictionaries containing the attribute and expression.
+    type: list
+    elements: dict
+    aliases: ["automemberexclusiveregex"]
+  inclusive:
+    description:
+    - List of dictionaries containing the attribute and expression.
+    type: list
+    elements: dict
+    aliases: ["automemberinclusiveregex"]
+  state:
+    description: State to ensure
+    default: present
+    choices: ["present", "absent"]
+author:
+    - Mark Hahl
+"""
+
+EXAMPLES = """
+# Ensure an automember rule exists
+- ipaautomember:
+    ipaadmin_password: SomeADMINpassword
+    name: admins
+    description: "t"
+    grouping: group
+    state: present
+    inclusive:
+    - key: "audio"
+        expression: "test"
+
+"""
+
+RETURN = """
+"""
+
+from ansible_collections.freeipa.ansible_freeipa.plugins.module_utils.ansible_freeipa_module import temp_kinit, \
+    temp_kdestroy, valid_creds, api_connect, api_command, compare_args_ipa
+from ansible.module_utils._text import to_text
+from ansible.module_utils.basic import AnsibleModule
+
+def find_automember(module, name, grouping):
+    _args = {
+        "all": True,
+        "type": grouping
+    }
+
+    _result = api_command(module, "automember_find", to_text(name), _args)
+
+    if len(_result["result"]) > 1:
+        module.fail_json(
+            msg="There is more than one automember '%s'" % (name))
+    elif len(_result["result"]) == 1:
+        return _result["result"][0]
+    else:
+        return None
+
+
+def gen_condition_args(grouping,
+                       key,
+                       inclusiveregex,
+                       exclusiveregex):
+    _args = {}
+    if grouping is not None:
+        _args['type'] = grouping
+    if key is not None:
+        _args['key'] = key
+    if inclusiveregex is not None:
+        _args['automemberinclusiveregex'] = inclusiveregex
+    if exclusiveregex is not None:
+        _args['automemberexclusiveregex'] = exclusiveregex
+
+    return _args
+
+
+def gen_args(description, grouping):
+    _args = {}
+    if description is not None:
+        _args["description"] = to_text(description)
+    if grouping is not None:
+        _args['type'] = grouping
+
+    return _args
+
+
+def transform_conditions(conditions):
+    """ Transforms a list of dicts into a list with the format of key=value. """
+    transformed = []
+    for condition in conditions:
+        transformed.append('='.join(str(x) for x in condition.values()))
+    return transformed
+
+
+def gen_condition_commands(name, grouping, module_conditions, current_conditions):
+    """ Returns a list of commands to add/remove automember rule conditions. """
+    commands = []
+    add_diff = set(module_conditions) - set(current_conditions)
+    remove_diff = set(current_conditions) - set(module_conditions)
+
+    for item in add_diff:
+        key, condition = item.split("=")
+        condition_args = gen_condition_args(grouping, key, condition, None)
+        commands.append([name, 'automember_add_condition', condition_args])
+
+    for item in remove_diff:
+        key, condition = item.split("=")
+        condition_args = gen_condition_args(grouping, key, condition, None)
+        commands.append([name, 'automember_remove_condition', condition_args])
+
+    return commands
+
+
+def main():
+    ansible_module = AnsibleModule(
+        argument_spec=dict(
+            # general
+            ipaadmin_principal=dict(type="str", default="admin"),
+            ipaadmin_password=dict(type="str", required=False, no_log=True),
+
+            inclusive=dict(type="list", aliases=[
+                           "automemberinclusiveregex"], default=None),
+            exclusive=dict(type="list", aliases=[
+                           "automemberexclusiveregex"], default=None),
+            name=dict(type="list", aliases=["cn"],
+                      default=None, required=True),
+            description=dict(type="str", default=None),
+            type=dict(type='str', required=True, choices=['group', 'hostgroup']),
+            state=dict(type="str", default="present",
+                       choices=["present", "absent"]),
+        ),
+        supports_check_mode=True,
+    )
+
+    ansible_module._ansible_debug = True
+
+    # Get parameters
+
+    # general
+    ipaadmin_principal = ansible_module.params.get("ipaadmin_principal")
+    ipaadmin_password = ansible_module.params.get("ipaadmin_password")
+    names = ansible_module.params.get("name")
+
+    # present
+    description = ansible_module.params.get("description")
+
+    # conditions
+    inclusive = ansible_module.params.get("inclusive")
+    exclusive = ansible_module.params.get("exclusive")
+
+    # state
+    state = ansible_module.params.get("state")
+
+    # grouping/type
+    grouping = ansible_module.params.get("type")
+
+    # Init
+    changed = False
+    exit_args = {}
+    ccache_dir = None
+    ccache_name = None
+    res_find = None
+
+    try:
+        if not valid_creds(ansible_module, ipaadmin_principal):
+            ccache_dir, ccache_name = temp_kinit(ipaadmin_principal,
+                                                 ipaadmin_password)
+        api_connect()
+
+        commands = []
+
+        for name in names:
+            # Make sure automember rule exists
+            res_find = find_automember(ansible_module, name, grouping)
+
+            # Create command
+            if state == 'present':
+                args = gen_args(description, grouping)
+
+                if res_find is not None:
+                    if not compare_args_ipa(ansible_module, args, res_find, ['type']):
+                        commands.append([name, 'automember_mod', args])
+                else:
+                    commands.append([name, 'automember_add', args])
+                    res_find = {}
+
+                if inclusive is not None:
+
+                    # Get the conditions from the module
+                    module_conditions = transform_conditions(inclusive)
+
+                    # Get the conditions from the existing automember rule.
+                    current_conditions = res_find.get(
+                        'automemberinclusiveregex', [])
+
+                    # Append the commands to the list
+                    commands.extend(gen_condition_commands(
+                        name, grouping, module_conditions, current_conditions))
+
+                if exclusive is not None and False:
+
+                    # Get the conditions from the module
+                    module_conditions = transform_conditions(inclusive)
+
+                    # Get the conditions from the existing automember rule.
+                    current_conditions = res_find.get(
+                        'automemberexclusiveregex', [])
+
+                    # Append the commands to the list
+                    commands.extend(gen_condition_commands(
+                        name, grouping, module_conditions, current_conditions))
+            elif state == 'absent':
+                if res_find is not None:
+                    commands.append([name, 'automember_del', {'type': grouping}])
+
+        for name, command, args in commands:
+            try:
+                result = api_command(
+                    ansible_module, command, to_text(name), args)
+
+                # Check if any changes were made by any command
+                if command in ('automember_del', 'automember_remove_condition'):
+                    changed |= "Deleted" in result['summary']
+                    
+                elif command in ('automember_add', 'automember_add_condition'):
+                    changed |= "Added" in result['summary']
+
+                elif command == 'automember_mod':
+                    changed |= "Modified" in result['summary']
+
+                ansible_module.warn(str(result))
+
+                res_find = find_automember(ansible_module, name, grouping)
+
+            
+            except Exception as e:
+                ansible_module.fail_json(msg=str(e))
+
+    except Exception as e:
+        ansible_module.fail_json(msg=str(e))
+
+    finally:
+        temp_kdestroy(ccache_dir, ccache_name)
+
+    # Done
+    ansible_module.exit_json(changed=changed, **exit_args)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/automember/test_automember.yml
+++ b/tests/automember/test_automember.yml
@@ -1,0 +1,164 @@
+---
+- name: Test automember
+  hosts: ipaserver
+  become: true
+
+  tasks:
+
+  # CLEANUP TEST ITEMS
+
+  - name: Ensure group automember rule admins is absent
+    ipaautomember:
+      ipaadmin_password: SomeADMINpassword
+      name: admins
+      state: absent
+      type: group
+
+  - name: Ensure hostgroup automember rule ipaservers is absent
+    ipaautomember:
+      ipaadmin_password: SomeADMINpassword
+      name: ipaservers
+      state: absent
+      type: hostgroup
+
+  # CREATE TEST ITEMS
+
+  # TESTS
+
+  - name: Ensure admins group automember rule is present
+    ipaautomember:
+      ipaadmin_password: SomeADMINpassword
+      name: admins
+      description: Admins automember rule.
+      type: group
+    register: result
+    failed_when: not result.changed or result.failed
+
+  - name: Ensure admins group automember rule is present again
+    ipaautomember:
+      ipaadmin_password: SomeADMINpassword
+      name: admins
+      description: Admins automember rule.
+      type: group
+    register: result
+    failed_when: result.changed or result.failed
+
+  - name: Change admins group automember rule description
+    ipaautomember:
+      ipaadmin_password: SomeADMINpassword
+      name: admins
+      description: Admins automember rule description.
+      type: group
+    register: result
+    failed_when: not result.changed or result.failed
+
+  - name: Ensure admins group automember rule has conditions
+    ipaautomember:
+      ipaadmin_password: SomeADMINpassword
+      name: admins
+      type: group
+      inclusive:
+        - key: 'mail'
+          expression: 'example.com$'
+        - key: 'uid'
+          expression: '1234'
+      exclusive:
+        - key: 'givenname'
+          expression: 'example'
+    register: result
+    failed_when: not result.changed or result.failed
+
+  - name: Ensure admins group automember rule has conditions again
+    ipaautomember:
+      ipaadmin_password: SomeADMINpassword
+      name: admins
+      type: group
+      inclusive:
+        - key: 'mail'
+          expression: 'example.com$'
+        - key: 'uid'
+          expression: '1234'
+      exclusive:
+        - key: 'givenname'
+          expression: 'example'
+    register: result
+    failed_when: result.changed or result.failed
+
+######
+
+  - name: Ensure ipaservers hostgroup automember rule is present
+    ipaautomember:
+      ipaadmin_password: SomeADMINpassword
+      name: ipaservers
+      description: ipaservers automember rule
+      type: hostgroup
+    register: result
+    failed_when: not result.changed or result.failed
+
+  - name: Ensure ipaservers hostgroup automember rule is present again
+    ipaautomember:
+      ipaadmin_password: SomeADMINpassword
+      name: ipaservers
+      description: ipaservers automember rule
+      type: hostgroup
+    register: result
+    failed_when: result.changed or result.failed
+
+  - name: Change ipaservers hostgroup automember rule description
+    ipaautomember:
+      ipaadmin_password: SomeADMINpassword
+      name: ipaservers
+      description: ipaservers test automember rule
+      type: hostgroup
+    register: result
+    failed_when: not result.changed or result.failed
+
+  - name: Ensure ipaservers hostgroup automember rule has conditions
+    ipaautomember:
+      ipaadmin_password: SomeADMINpassword
+      name: admins
+      type: group
+      inclusive:
+        - key: 'description'
+          expression: 'example'
+        - key: 'fqdn'
+          expression: 'example'
+      exclusive:
+        - key: 'serverhostname'
+          expression: 'example'
+    register: result
+    failed_when: not result.changed or result.failed
+
+  - name: Ensure ipaservers hostgroup automember rule has conditions again
+    ipaautomember:
+      ipaadmin_password: SomeADMINpassword
+      name: admins
+      type: group
+      inclusive:
+        - key: 'description'
+          expression: 'example'
+        - key: 'fqdn'
+          expression: 'example'
+      exclusive:
+        - key: 'serverhostname'
+          expression: 'example'
+    register: result
+    failed_when: result.changed or result.failed
+
+  # CLEANUP TEST ITEMS
+
+  - name: Ensure group automember rule admins is absent
+    ipaautomember:
+      ipaadmin_password: SomeADMINpassword
+      type: group
+      name:
+      - admins
+      state: absent
+
+  - name: Ensure hostgroup automember rule ipaservers is absent
+    ipaautomember:
+      ipaadmin_password: SomeADMINpassword
+      type: hostgroup
+      name:
+      - ipaservers
+      state: absent

--- a/tests/automember/test_automember.yml
+++ b/tests/automember/test_automember.yml
@@ -58,13 +58,13 @@
       name: admins
       type: group
       inclusive:
-        - key: 'mail'
-          expression: 'example.com$'
         - key: 'uid'
-          expression: '1234'
+          expression: 'uid'
+        - key: 'uidnumber'
+          expression: 'uidnumber'
       exclusive:
-        - key: 'givenname'
-          expression: 'example'
+        - key: 'uid'
+          expression: 'uid'
     register: result
     failed_when: not result.changed or result.failed
 
@@ -74,13 +74,13 @@
       name: admins
       type: group
       inclusive:
-        - key: 'mail'
-          expression: 'example.com$'
         - key: 'uid'
-          expression: '1234'
+          expression: 'uid'
+        - key: 'uidnumber'
+          expression: 'uidnumber'
       exclusive:
-        - key: 'givenname'
-          expression: 'example'
+        - key: 'uid'
+          expression: 'uid'
     register: result
     failed_when: result.changed or result.failed
 
@@ -116,32 +116,32 @@
   - name: Ensure ipaservers hostgroup automember rule has conditions
     ipaautomember:
       ipaadmin_password: SomeADMINpassword
-      name: admins
-      type: group
+      name: ipaservers
+      type: hostgroup
       inclusive:
         - key: 'description'
-          expression: 'example'
-        - key: 'fqdn'
-          expression: 'example'
+          expression: 'description'
+        - key: 'description'
+          expression: 'description'
       exclusive:
-        - key: 'serverhostname'
-          expression: 'example'
+        - key: 'cn'
+          expression: 'cn'
     register: result
     failed_when: not result.changed or result.failed
 
   - name: Ensure ipaservers hostgroup automember rule has conditions again
     ipaautomember:
       ipaadmin_password: SomeADMINpassword
-      name: admins
-      type: group
+      name: ipaservers
+      type: hostgroup
       inclusive:
         - key: 'description'
-          expression: 'example'
-        - key: 'fqdn'
-          expression: 'example'
+          expression: 'description'
+        - key: 'description'
+          expression: 'description'
       exclusive:
-        - key: 'serverhostname'
-          expression: 'example'
+        - key: 'cn'
+          expression: 'cn'
     register: result
     failed_when: result.changed or result.failed
 

--- a/tests/automember/test_automember.yml
+++ b/tests/automember/test_automember.yml
@@ -151,14 +151,12 @@
     ipaautomember:
       ipaadmin_password: SomeADMINpassword
       type: group
-      name:
-      - admins
+      name: admins
       state: absent
 
   - name: Ensure hostgroup automember rule ipaservers is absent
     ipaautomember:
       ipaadmin_password: SomeADMINpassword
       type: hostgroup
-      name:
-      - ipaservers
+      name: ipaservers
       state: absent


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Add new module to support adding and deleting Auto Membership Rules.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- New Module Pull Request

##### COMPONENT NAME
ipaautomember.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

Define what you want the automember rule to look like and it will ensure it matches.

<!--- Paste verbatim command output below, e.g. before and after your change -->
```lang=yaml
# Ensure an automember rule exists
- ipaautomember:
    ipaadmin_password: SomeADMINpassword
    name: admins
    description: "example description"
    type: group
    state: present
    inclusive:
    - key: "mail"
      expression: "example.com$"

```