### PR TITLE
Add pre-commit configuration for linters.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,31 @@
+---
+repos:
+- repo: https://github.com/ansible/ansible-lint.git
+  rev: v4.3.5
+  hooks:
+  - id: ansible-lint
+    always_run: true
+    pass_filenames: true
+    files: \.(yaml|yml)$
+    entry: env ANSIBLE_LIBRARY=./plugins/modules ANSIBLE_MODULE_UTILS=./plugins/module_utils ansible-lint --force-color
+- repo: https://github.com/adrienverge/yamllint.git
+  rev: v1.25.0
+  hooks:
+  - id: yamllint
+    args: ['.']
+- repo: https://gitlab.com/pycqa/flake8
+  rev: 3.8.4
+  hooks:
+  - id: flake8
+- repo: https://gitlab.com/pycqa/pydocstyle
+  rev: 5.1.1
+  hooks:
+  - id: pydocstyle
+- repo: local
+  hooks:
+  - id: ansible-doc-test
+    name: Verify Ansible roles and module documentation.
+    language: script
+    entry: utils/ansible-doc-test
+    # args: ['-v', 'roles', 'plugins']
+    files: ^.*.py$

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,2 +1,3 @@
 -r requirements-tests.txt
 ipdb
+pre-commit


### PR DESCRIPTION
This patch adds another lever of linter checking for ansible-freeipa
by enabling linters to run on the developer machine, before pushing
changes to be evaluated on the CI, allowing code fixes without
wating for CI to run the linters on the repository.

To enable pre-commit hooks, `pre-commit` is used, and was added to
requirements-dev.txt, and can be installed with pip
(`pip install -r requirements-dev.txt`). Once installed, on every
commit, YAML and python files on the commit will be evaluated.

If one needs to bypass the pre-commit linters, `git commit` can be
issued with `--no-verify`.

The linters will not be removed from the CI, as a commit can be
performed without running the checks.