### PR TITLE
Fix symmetric vault password change when using password_files.

### DIFF
--- a/plugins/modules/ipavault.py
+++ b/plugins/modules/ipavault.py
@@ -565,17 +565,16 @@ def change_password(module, res_find, password, password_file, new_password,
     if password:
         args["password"] = password
     if password_file:
-        args["password"] = password_file
+        args["password_file"] = password_file
     # retrieve current stored data
     result = api_command(module, 'vault_retrieve', name, args)
-    args['data'] = result['result']['data']
 
     # modify arguments to store data with new password.
-    if password:
+    args = {"override_password": True, "data": result['result']['data']}
+    if new_password:
         args["password"] = new_password
-    if password_file:
-        args["password"] = new_password_file
-    args["override_password"] = True
+    if new_password_file:
+        args["password_file"] = new_password_file
     # return the command to store data with the new password.
     return [(name, "vault_archive", args)]
 

--- a/tests/vault/test_vault_symmetric.yml
+++ b/tests/vault/test_vault_symmetric.yml
@@ -295,5 +295,42 @@
     register: result
     failed_when: not result.failed or "Cannot modify password of inexistent vault" not in result.msg
 
+  - name: Ensure symmetric vault is present
+    ipavault:
+      ipaadmin_password: SomeADMINpassword
+      name: symvault
+      vault_type: symmetric
+      password: APasswordToChange
+      vault_data: Hello World.
+    register: result
+    failed_when: not result.changed or result.failed
+
+  - name: Change symmetric vault password, using password file.
+    ipavault:
+      ipaadmin_password: SomeADMINpassword
+      name: symvault
+      password: APasswordToChange
+      new_password_file: "{{ ansible_env.HOME }}/password.txt"
+      vault_type: symmetric
+    register: result
+    failed_when: not result.changed or result.failed
+
+  - name: Retrieve data from symmetric vault.
+    ipavault:
+      ipaadmin_password: SomeADMINpassword
+      name: symvault
+      password: SomeVAULTpassword
+      state: retrieved
+    register: result
+    failed_when: result.vault.data != 'Hello World.' or result.changed
+
+  - name: Ensure symmetric vault is absent
+    ipavault:
+      ipaadmin_password: SomeADMINpassword
+      name: symvault
+      state: absent
+    register: result
+    failed_when: not result.changed
+
   - name: Cleanup testing environment.
     import_tasks: env_cleanup.yml


### PR DESCRIPTION
When using changing passwords, using password files, the file name was
being used as the password, and not its content. This patch fixes the
behavior to use the contents of the password file.

Tests have been added to ensure the correct behavior.