### PR TITLE
ipa[server,replica,client]: Fix moved sysrestore and is_ipa_configured

### DIFF
--- a/roles/ipaclient/module_utils/ansible_ipa_client.py
+++ b/roles/ipaclient/module_utils/ansible_ipa_client.py
@@ -107,9 +107,12 @@ if NUM_VERSION >= 40400:
     from ipalib import api, errors, x509
     from ipalib import constants
     try:
-        from ipalib.install import sysrestore
+        from ipalib import sysrestore
     except ImportError:
-        from ipapython import sysrestore
+        try:
+            from ipalib.install import sysrestore
+        except ImportError:
+            from ipapython import sysrestore
     try:
         from ipalib.install import certmonger
     except ImportError:

--- a/roles/ipareplica/module_utils/ansible_ipa_replica.py
+++ b/roles/ipareplica/module_utils/ansible_ipa_replica.py
@@ -101,7 +101,11 @@ if NUM_VERSION >= 40600:
         from ipaserver.install.service import (
             find_providing_servers, find_providing_server)
     from ipaserver.install.installutils import (
-        ReplicaConfig, load_pkcs12, is_ipa_configured)
+        ReplicaConfig, load_pkcs12)
+    try:
+        from ipalib.facts import is_ipa_configured
+    except ImportError:
+        from ipaserver.install.installutils import is_ipa_configured
     from ipaserver.install.replication import (
         ReplicationManager, replica_conn_check)
     from ipaserver.install.server.replicainstall import (

--- a/roles/ipaserver/module_utils/ansible_ipa_server.py
+++ b/roles/ipaserver/module_utils/ansible_ipa_server.py
@@ -60,7 +60,11 @@ if NUM_VERSION >= 40500:
     # IPA version >= 4.5
 
     from ipaclient.install.ipachangeconf import IPAChangeConf
-    from ipalib.install import certmonger, sysrestore
+    from ipalib.install import certmonger
+    try:
+        from ipalib import sysrestore
+    except ImportError:
+        from ipalib.install import sysrestore
     from ipapython import ipautil
     from ipapython.ipa_log_manager import standard_logging_setup
     try:
@@ -108,8 +112,12 @@ if NUM_VERSION >= 40500:
     kra_imported = True
     from ipaserver.install.installutils import (
         BadHostError, get_fqdn, get_server_ip_address,
-        is_ipa_configured, load_pkcs12, read_password, verify_fqdn,
+        load_pkcs12, read_password, verify_fqdn,
         update_hosts_file)
+    try:
+        from ipalib.facts import is_ipa_configured
+    except ImportError:
+        from ipaserver.install.installutils import is_ipa_configured
     from ipaserver.install.server.install import (
         check_dirsrv, validate_admin_password, validate_dm_password,
         read_cache, write_cache)


### PR DESCRIPTION
https://pagure.io/freeipa/issue/8458 moved more things to the ipalib and
ipalib.facts:

- sysrestore has been moved from ipalib.install to ipalib
- is_ipa_configured has been moved from ipaserver.install.installutils to
  ipalib.facts

Fixes: #394 (TASK [ipaclient : Install - IPA client test] Error: module
                  'ipalib.install.sysrestore' has no attribute
                  'SYSRESTORE_STATEFILE')