### PR TITLE
Fix module documentation

### DIFF
--- a/plugins/modules/ipadelegation.py
+++ b/plugins/modules/ipadelegation.py
@@ -50,7 +50,7 @@ options:
     description: Attribute list to which the delegation applies
     required: false
     aliases: ["attrs"]
-  membergroup
+  membergroup:
     description: User group to apply delegation to
     required: false
     aliases: ["memberof"]

--- a/plugins/modules/ipadnsrecord.py
+++ b/plugins/modules/ipadnsrecord.py
@@ -49,9 +49,11 @@ options:
         aliases: ["record_name"]
         required: true
       zone_name:
-        description: The DNS zone name to which DNS record needs to be managed.
+        description: |
+          The DNS zone name to which DNS record needs to be managed.
+          Required if not provided globally.
         aliases: ["dnszone"]
-        required: true (if not provided globally)
+        required: false
       record_type:
         description: The type of DNS record.
         choices: ["A", "AAAA", "A6", "AFSDB", "CERT", "CNAME", "DLV", "DNAME",
@@ -159,7 +161,7 @@ options:
         required: false
         type: string
       a_create_reverse:
-        description:
+        description: |
           Create reverse record for A records.
           There is no equivalent to remove reverse records.
         type: bool
@@ -169,13 +171,13 @@ options:
         required: false
         type: string
       aaaa_create_reverse:
-        description:
+        description: |
           Create reverse record for AAAA records.
           There is no equivalent to remove reverse records.
         type: bool
         required: false
       create_reverse:
-        description:
+        description: |
           Create reverse record for A or AAAA record types.
           There is no equivalent to remove reverse records.
         type: bool
@@ -189,11 +191,11 @@ options:
         required: false
         type: int
       afsdb_hostname:
-        discription: AFSDB Hostname
+        description: AFSDB Hostname
         required: false
         type: string
       cert_type:
-        descriptioon: CERT Certificate Type
+        description: CERT Certificate Type
         required: false
         type: int
       cert_key_tag:
@@ -225,7 +227,7 @@ options:
         required: false
         type: int
       dlv_digest:
-        descriptinion: DLV Digest
+        description: DLV Digest
         required: false
         type: string
       dname_target:
@@ -245,11 +247,11 @@ options:
         required: false
         type: int
       ds_digest:
-        descriptinion: DS Digest
+        description: DS Digest
         required: false
         type: string
       kx_preference:
-        description:
+        description: |
           Preference given to this exchanger. Lower values are more preferred.
         required: false
         type: int
@@ -306,7 +308,7 @@ options:
         required: false
         type: float
       mx_preference:
-        description:
+        description: |
           Preference given to this exchanger. Lower values are more preferred.
         required: false
         type: int
@@ -347,7 +349,7 @@ options:
         required: false
         type: string
       srv_priority:
-        description:
+        description: |
           Lower number means higher priority. Clients will attempt to contact
           the server with the lowest-numbered priority they can reach.
         required: false
@@ -361,13 +363,15 @@ options:
         required: false
         type: int
       srv_target:
-        description:
+        description: |
           The domain name of the target host or '.' if the service is decidedly
           not available at this domain.
         required: false
         type: string
       sshfp_algorithm:
         description: SSHFP Algorithm
+        required: False
+        type: int
       sshfp_fp_type:
         description: SSHFP Fingerprint Type
         required: False
@@ -385,15 +389,15 @@ options:
         required: false
         type: int
       tlsa_selector:
-        descrpition: TLSA Selector
+        description: TLSA Selector
         required: false
         type: int
       tlsa_matching_type:
-        descrpition: TLSA Matching Type
+        description: TLSA Matching Type
         required: false
         type: int
       tlsa_cert_association_data:
-        descrpition: TLSA Certificate Association Data
+        description: TLSA Certificate Association Data
         required: false
         type: string
       uri_target:
@@ -401,7 +405,7 @@ options:
         required: false
         type: string
       uri_priority:
-        description:
+        description: |
           Lower number means higher priority. Clients will attempt to contact
           the URI with the lowest-numbered priority they can reach.
         required: false
@@ -411,9 +415,11 @@ options:
         required: false
         type: int
   zone_name:
-    description: The DNS zone name to which DNS record needs to be managed.
+    description: |
+      The DNS zone name to which DNS record needs to be managed.
+      Required if not provided globally.
     aliases: ["dnszone"]
-    required: true (if not provided on each record)
+    required: false
   name:
     description: The DNS record name to manage.
     aliases: ["record_name"]
@@ -523,7 +529,7 @@ options:
     required: false
     type: string
   create_reverse:
-    description:
+    description: |
       Create reverse record for A or AAAA record types.
       There is no equivalent to remove reverse records.
     type: bool
@@ -534,7 +540,7 @@ options:
     required: false
     type: string
   a_create_reverse:
-    description:
+    description: |
       Create reverse record for A records.
       There is no equivalent to remove reverse records.
     type: bool
@@ -544,7 +550,7 @@ options:
     required: false
     type: string
   aaaa_create_reverse:
-    description:
+    description: |
       Create reverse record for AAAA records.
       There is no equivalent to remove reverse records.
     type: bool
@@ -554,11 +560,11 @@ options:
     required: false
     type: int
   afsdb_hostname:
-    discription: AFSDB Hostname
+    description: AFSDB Hostname
     required: false
     type: string
   cert_type:
-    descriptioon: CERT Certificate Type
+    description: CERT Certificate Type
     required: false
     type: int
   cert_key_tag:
@@ -590,7 +596,7 @@ options:
     required: false
     type: int
   dlv_digest:
-    descriptinion: DLV Digest
+    description: DLV Digest
     required: false
     type: string
   dname_target:
@@ -610,11 +616,11 @@ options:
     required: false
     type: int
   ds_digest:
-    descriptinion: DS Digest
+    description: DS Digest
     required: false
     type: string
   kx_preference:
-    description:
+    description: |
       Preference given to this exchanger. Lower values are more preferred.
     required: false
     type: int
@@ -671,7 +677,7 @@ options:
     required: false
     type: float
   mx_preference:
-    description:
+    description: |
       Preference given to this exchanger. Lower values are more preferred.
     required: false
     type: int
@@ -712,7 +718,7 @@ options:
     required: false
     type: string
   srv_priority:
-    description:
+    description: |
       Lower number means higher priority. Clients will attempt to contact the
       server with the lowest-numbered priority they can reach.
     required: false
@@ -726,20 +732,22 @@ options:
     required: false
     type: int
   srv_target:
-    description:
+    description: |
       The domain name of the target host or '.' if the service is decidedly not
       available at this domain.
     required: false
     type: string
   sshfp_algorithm:
     description: SSHFP Algorithm
+    required: false
+    type: int
   sshfp_fp_type:
     description: SSHFP Fingerprint Type
-    required: False
+    required: false
     type: int
   sshfp_fingerprint:
     description: SSHFP Fingerprint
-    required: False
+    required: false
     type: string
   txt_data:
     description: TXT Text Data
@@ -750,15 +758,15 @@ options:
     required: false
     type: int
   tlsa_selector:
-    descrpition: TLSA Selector
+    description: TLSA Selector
     required: false
     type: int
   tlsa_matching_type:
-    descrpition: TLSA Matching Type
+    description: TLSA Matching Type
     required: false
     type: int
   tlsa_cert_association_data:
-    descrpition: TLSA Certificate Association Data
+    description: TLSA Certificate Association Data
     required: false
     type: string
   uri_target:
@@ -766,7 +774,7 @@ options:
     required: false
     type: string
   uri_priority:
-    description:
+    description: |
       Lower number means higher priority. Clients will attempt to contact the
       URI with the lowest-numbered priority they can reach.
     required: false

--- a/plugins/modules/ipadnszone.py
+++ b/plugins/modules/ipadnszone.py
@@ -27,6 +27,7 @@ ANSIBLE_METADATA = {
 }
 
 DOCUMENTATION = """
+---
 module: ipadnszone
 short description: Manage FreeIPA dnszone
 description: Manage FreeIPA dnszone
@@ -37,7 +38,6 @@ options:
   ipaadmin_password:
     description: The admin password
     required: false
-
   name:
     description: The zone name string.
     required: true
@@ -132,11 +132,14 @@ options:
     required: false
     type: int
   nsec3param_rec:
-    description: NSEC3PARAM record for zone in format: hash_algorithm flags iterations salt.
+    description: |
+      NSEC3PARAM record for zone in format: hash_algorithm flags iterations
+       salt.
     required: false
     type: str
   skip_overlap_check:
-    description: Force DNS zone creation even if it will overlap with an existing zone
+    description: |
+      Force DNS zone creation even if it will overlap with an existing zone
     required: false
     type: bool
   skip_nameserver_check:

--- a/plugins/modules/iparole.py
+++ b/plugins/modules/iparole.py
@@ -45,10 +45,10 @@ options:
     required: true
     aliases: ["cn"]
   description:
-    descrpition: A description for the role.
+    description: A description for the role.
     required: false
   rename:
-    descrpition: Rename the role object.
+    description: Rename the role object.
     required: false
   user:
     description: List of users.

--- a/plugins/modules/ipaservice.py
+++ b/plugins/modules/ipaservice.py
@@ -47,7 +47,7 @@ options:
     description: Base-64 encoded service certificate.
     required: false
     type: list
-    aliases=['usercertificate']
+    aliases: ["usercertificate"]
   pac_type:
     description: Supported PAC type.
     required: false
@@ -79,12 +79,12 @@ options:
     type: bool
     default: False
     aliases: ["ipakrbokasdelegate"]
-  ok_to_auth_as_delegate: Allow service to authenticate on behalf of a client.
-    description: .
+  ok_to_auth_as_delegate:
+    description: Allow service to authenticate on behalf of a client.
     required: false
     type: bool
     default: False
-    aliases:["ipakrboktoauthasdelegate"]
+    aliases: ["ipakrboktoauthasdelegate"]
   principal:
     description: List of principal aliases for the service.
     required: false
@@ -104,42 +104,42 @@ options:
     type: list
     aliases: ["managedby_host"]
   allow_create_keytab_user:
-    descrption: Users allowed to create a keytab of this host.
+    description: Users allowed to create a keytab of this host.
     required: false
     type: list
     aliases: ["ipaallowedtoperform_write_keys_user"]
   allow_create_keytab_group:
-    descrption: Groups allowed to create a keytab of this host.
+    description: Groups allowed to create a keytab of this host.
     required: false
     type: list
     aliases: ["ipaallowedtoperform_write_keys_group"]
   allow_create_keytab_host:
-    descrption: Hosts allowed to create a keytab of this host.
+    description: Hosts allowed to create a keytab of this host.
     required: false
     type: list
     aliases: ["ipaallowedtoperform_write_keys_host"]
   allow_create_keytab_hostgroup:
-    descrption: Host group allowed to create a keytab of this host.
+    description: Host group allowed to create a keytab of this host.
     required: false
     type: list
     aliases: ["ipaallowedtoperform_write_keys_hostgroup"]
   allow_retrieve_keytab_user:
-    descrption: User allowed to retrieve a keytab of this host.
+    description: User allowed to retrieve a keytab of this host.
     required: false
     type: list
     aliases: ["ipaallowedtoperform_read_keys_user"]
   allow_retrieve_keytab_group:
-    descrption: Groups allowed to retrieve a keytab of this host.
+    description: Groups allowed to retrieve a keytab of this host.
     required: false
     type: list
     aliases: ["ipaallowedtoperform_read_keys_group"]
   allow_retrieve_keytab_host:
-    descrption: Hosts allowed to retrieve a keytab of this host.
+    description: Hosts allowed to retrieve a keytab of this host.
     required: false
     type: list
     aliases: ["ipaallowedtoperform_read_keys_host"]
   allow_retrieve_keytab_hostgroup:
-    descrption: Host groups allowed to retrieve a keytab of this host.
+    description: Host groups allowed to retrieve a keytab of this host.
     required: false
     type: list
     aliases: ["ipaallowedtoperform_read_keys_hostgroup"]

--- a/plugins/modules/ipasudorule.py
+++ b/plugins/modules/ipasudorule.py
@@ -109,7 +109,7 @@ options:
     required: false
     type: int
   sudooption:
-    description:
+    description: List of sudo options.
     required: false
     type: list
     aliases: ["options"]

--- a/plugins/modules/ipatopologysegment.py
+++ b/plugins/modules/ipatopologysegment.py
@@ -59,7 +59,7 @@ options:
   state:
     description: State to ensure
     default: present
-    choices: ["present", "absent", "enabled", "disabled", "reinitialized"
+    choices: ["present", "absent", "enabled", "disabled", "reinitialized",
               "checked" ]
 author:
     - Thomas Woerner

--- a/plugins/modules/ipauser.py
+++ b/plugins/modules/ipauser.py
@@ -80,20 +80,20 @@ options:
         required: false
         aliases: ["principalname", "krbprincipalname"]
       principalexpiration:
-        description:
-        - The kerberos principal expiration date
-        - (possible formats: YYYYMMddHHmmssZ, YYYY-MM-ddTHH:mm:ssZ,
-        - YYYY-MM-ddTHH:mmZ, YYYY-MM-ddZ, YYYY-MM-dd HH:mm:ssZ,
-        - YYYY-MM-dd HH:mmZ) The trailing 'Z' can be skipped.
+        description: |
+          The kerberos principal expiration date
+          (possible formats: YYYYMMddHHmmssZ, YYYY-MM-ddTHH:mm:ssZ,
+          YYYY-MM-ddTHH:mmZ, YYYY-MM-ddZ, YYYY-MM-dd HH:mm:ssZ,
+          YYYY-MM-dd HH:mmZ) The trailing 'Z' can be skipped.
         required: false
         aliases: ["krbprincipalexpiration"]
       passwordexpiration:
-        description:
-        - The kerberos password expiration date (FreeIPA-4.7+)
-        - (possible formats: YYYYMMddHHmmssZ, YYYY-MM-ddTHH:mm:ssZ,
-        - YYYY-MM-ddTHH:mmZ, YYYY-MM-ddZ, YYYY-MM-dd HH:mm:ssZ,
-        - YYYY-MM-dd HH:mmZ) The trailing 'Z' can be skipped.
-        - Only usable with IPA versions 4.7 and up.
+        description: |
+          The kerberos password expiration date (FreeIPA-4.7+)
+          (possible formats: YYYYMMddHHmmssZ, YYYY-MM-ddTHH:mm:ssZ,
+          YYYY-MM-ddTHH:mmZ, YYYY-MM-ddZ, YYYY-MM-dd HH:mm:ssZ,
+          YYYY-MM-dd HH:mmZ) The trailing 'Z' can be skipped.
+          Only usable with IPA versions 4.7 and up.
         required: false
         aliases: ["krbpasswordexpiration"]
       password:
@@ -156,7 +156,7 @@ options:
         description:
           List of supported user authentication types
           Use empty string to reset userauthtype to the initial value.
-        choices=['password', 'radius', 'otp', '']
+        choices: ['password', 'radius', 'otp', '']
         required: false
         aliases: ["ipauserauthtype"]
       userclass:
@@ -245,20 +245,20 @@ options:
     required: false
     aliases: ["principalname", "krbprincipalname"]
   principalexpiration:
-    description:
-    - The kerberos principal expiration date
-    - (possible formats: YYYYMMddHHmmssZ, YYYY-MM-ddTHH:mm:ssZ,
-    - YYYY-MM-ddTHH:mmZ, YYYY-MM-ddZ, YYYY-MM-dd HH:mm:ssZ,
-    - YYYY-MM-dd HH:mmZ) The trailing 'Z' can be skipped.
+    description: |
+      The kerberos principal expiration date
+      (possible formats: YYYYMMddHHmmssZ, YYYY-MM-ddTHH:mm:ssZ,
+      YYYY-MM-ddTHH:mmZ, YYYY-MM-ddZ, YYYY-MM-dd HH:mm:ssZ,
+      YYYY-MM-dd HH:mmZ) The trailing 'Z' can be skipped.
     required: false
     aliases: ["krbprincipalexpiration"]
   passwordexpiration:
-    description:
-    - The kerberos password expiration date (FreeIPA-4.7+)
-    - (possible formats: YYYYMMddHHmmssZ, YYYY-MM-ddTHH:mm:ssZ,
-    - YYYY-MM-ddTHH:mmZ, YYYY-MM-ddZ, YYYY-MM-dd HH:mm:ssZ,
-    - YYYY-MM-dd HH:mmZ) The trailing 'Z' can be skipped.
-    - Only usable with IPA versions 4.7 and up.
+    description: |
+      The kerberos password expiration date (FreeIPA-4.7+)
+      (possible formats: YYYYMMddHHmmssZ, YYYY-MM-ddTHH:mm:ssZ,
+      YYYY-MM-ddTHH:mmZ, YYYY-MM-ddZ, YYYY-MM-dd HH:mm:ssZ,
+      YYYY-MM-dd HH:mmZ) The trailing 'Z' can be skipped.
+      Only usable with IPA versions 4.7 and up.
     required: false
     aliases: ["krbpasswordexpiration"]
   password:
@@ -321,7 +321,7 @@ options:
     description:
       List of supported user authentication types
       Use empty string to reset userauthtype to the initial value.
-    choices=['password', 'radius', 'otp', '']
+    choices: ['password', 'radius', 'otp', '']
     required: false
     aliases: ["ipauserauthtype"]
   userclass:

--- a/roles/ipaclient/library/ipaclient_fix_ca.py
+++ b/roles/ipaclient/library/ipaclient_fix_ca.py
@@ -30,8 +30,7 @@ DOCUMENTATION = '''
 ---
 module: ipaclient_fix_ca
 short description: Fix IPA ca certificate
-description:
-Repair Fix IPA ca certificate
+description: Repair Fix IPA ca certificate
 options:
   servers:
     description: Fully qualified name of IPA servers to enroll to
@@ -43,7 +42,7 @@ options:
     description: The basedn of the IPA server (of the form dc=example,dc=com)
     required: no
   allow_repair:
-    description:
+    description: |
       Allow repair of already joined hosts. Contrary to ipaclient_force_join
       the host entry will not be changed on the server
     required: no

--- a/roles/ipaclient/library/ipaclient_fstore.py
+++ b/roles/ipaclient/library/ipaclient_fstore.py
@@ -32,8 +32,7 @@ DOCUMENTATION = '''
 ---
 module: ipaclient_fstore
 short description: Backup files using IPA client sysrestore
-description:
-Backup files using IPA client sysrestore
+description: Backup files using IPA client sysrestore
 options:
   backup:
     description: File to backup

--- a/roles/ipaclient/library/ipaclient_setup_nss.py
+++ b/roles/ipaclient/library/ipaclient_setup_nss.py
@@ -32,8 +32,7 @@ DOCUMENTATION = '''
 ---
 module: ipaclient_setup_nss
 short description: Create IPA client NSS database
-description:
-Create IPA NSS database
+description: Create IPA NSS database
 options:
   servers:
     description: Fully qualified name of IPA servers to enroll to
@@ -55,7 +54,7 @@ options:
       User Principal allowed to promote replicas and join IPA realm
     required: yes
   subject_base:
-    description:
+    description: |
       The certificate subject base (default O=<realm-name>).
       RDNs are in LDAP order (most specific RDN first).
     required: no
@@ -72,12 +71,12 @@ options:
     description: The installer dnsok setting
     required: yes
   enable_dns_updates:
-    description:
+    description: |
       Configures the machine to attempt dns updates when the ip address
       changes
     required: yes
   all_ip_addresses:
-    description:
+    description: |
       All routable IP addresses configured on any interface will be added
       to DNS
     required: yes

--- a/roles/ipareplica/library/ipareplica_prepare.py
+++ b/roles/ipareplica/library/ipareplica_prepare.py
@@ -34,7 +34,7 @@ DOCUMENTATION = '''
 ---
 module: ipareplica_prepare
 short description: Prepare ipa replica installation
-description:
+description: |
   Prepare ipa replica installation: Create IPA configuration file, run install
   checks again and also update the host name and the hosts file if needed.
   The tests and also the results from ipareplica_test are needed.


### PR DESCRIPTION
ansible-doc is reporting several issues in modules. Most of them have benn
due to misspelled description key word or due to use of multi line text
without the | in the description line.