### PR TITLE
Fix problem when defining `description` with "pipe" operator.

### DIFF
--- a/plugins/modules/iparole.py
+++ b/plugins/modules/iparole.py
@@ -135,7 +135,7 @@ def gen_args(module):
     for param, arg in arg_map.items():
         value = module_params_get(module, param)
         if value is not None:
-            args[arg] = value
+            args[arg] = value.strip()
 
     return args
 


### PR DESCRIPTION
When using the pipe operator in Ansible, to define a string, a newline
character is added to the attribute, and it breaks role_* functions.
It is fixed by stripping white space from `description` and `rename`
attributes.