### PR TITLE
Add FreeIPA version check to module_utils.ansible_freeipa_module.

### DIFF
--- a/README-permission.md
+++ b/README-permission.md
@@ -141,7 +141,7 @@ Variable | Description | Required
 `name` \| `cn` | The permission name string. | yes
 `right` \| `ipapermright` | Rights to grant. It can be a list of one or more of `read`, `search`, `compare`, `write`, `add`, `delete`, and `all` default: `all` | no
 `attrs` | All attributes to which the permission applies | no
-`bindtype` \| `ipapermbindruletype` | Bind rule type. It can be one of `permission`, `all`, `self`, or `anonymous` defaults to `permission` for new permissions.| no
+`bindtype` \| `ipapermbindruletype` | Bind rule type. It can be one of `permission`, `all`, `self`, or `anonymous` defaults to `permission` for new permissions. Bind rule type `self` can only be used on IPA versions 4.8.7 or up.| no
 `subtree` \| `ipapermlocation` | Subtree to apply permissions to | no
 `filter` \| `extratargetfilter` | Extra target filter | no
 `rawfilter` \| `ipapermtargetfilter` | All target filters | no

--- a/plugins/modules/ipapermission.py
+++ b/plugins/modules/ipapermission.py
@@ -152,7 +152,8 @@ RETURN = """
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.ansible_freeipa_module import \
     temp_kinit, temp_kdestroy, valid_creds, api_connect, api_command, \
-    compare_args_ipa, module_params_get, gen_add_del_lists
+    compare_args_ipa, module_params_get, gen_add_del_lists, \
+    api_check_ipa_version
 import six
 
 if six.PY3:
@@ -335,6 +336,10 @@ def main():
             ansible_module.fail_json(
                 msg="Argument '%s' can not be used with action "
                 "'%s' and state '%s'" % (x, action, state))
+
+    if bindtype == "self" and api_check_ipa_version("<", "4.8.7"):
+        ansible_module.fail_json(
+            msg="Bindtype 'self' is not supported by your IPA version.")
 
     # Init
 

--- a/tests/permission/test_permission.yml
+++ b/tests/permission/test_permission.yml
@@ -4,15 +4,19 @@
   become: true
 
   tasks:
+  - include_tasks: ../env_freeipa_facts.yml
 
   # CLEANUP TEST ITEMS
 
   - name: Ensure permission perm-test-1 is absent
     ipapermission:
       ipaadmin_password: SomeADMINpassword
-      name: perm-test-1
+      name:
+      - perm-test-1
+      - perm-test-bindtype-test
+      - perm-test-renamed
       state: absent
-   
+
   # TESTS
 
   - name: Ensure permission perm-test-1 is present
@@ -38,7 +42,7 @@
       ipaadmin_password: SomeADMINpassword
       name: perm-test-1
       privilege: "User Administrators"
-      action: member      
+      action: member
     register: result
     failed_when: not result.changed or result.failed
 
@@ -89,7 +93,7 @@
       state: absent
     register: result
     failed_when: result.changed or result.failed
-    
+
   - name: Ensure permission perm-test-renamed is present
     ipapermission:
       ipaadmin_password: SomeADMINpassword
@@ -99,16 +103,35 @@
     register: result
     failed_when: result.changed or result.failed
 
+  - name: Ensure permission with bindtype 'self' is present, if IPA version >= 4.8.7
+    ipapermission:
+      ipaadmin_password: SomeADMINpassword
+      name: perm-test-bindtype-test
+      bindtype: self
+      object_type: host
+      right: all
+    when: ipa_version is version('4.8.7', '>=')
+    register: result
+    failed_when: not result.changed or result.failed
+
+  - name: Fail to set permission perm-test-renamed bindtype to 'self', if IPA version < 4.8.7
+    ipapermission:
+      ipaadmin_password: SomeADMINpassword
+      name: perm-test-bindtype-test
+      bindtype: self
+      object_type: host
+      right: all
+    when: ipa_version is version('4.8.7', '<')
+    register: result
+    failed_when: not result.failed or "Bindtype 'self' is not supported by your IPA version." not in result.msg
+
   # CLEANUP TEST ITEMS
 
   - name: Ensure permission perm-test-1 is absent
     ipapermission:
       ipaadmin_password: SomeADMINpassword
-      name: perm-test-1
-      state: absent
-
-  - name: Ensure permission perm-test-renamed is absent
-    ipapermission:
-      ipaadmin_password: SomeADMINpassword
-      name: perm-test-renamed
+      name:
+      - perm-test-1
+      - perm-test-bindtype-test
+      - perm-test-renamed
       state: absent


### PR DESCRIPTION
Some attribute values are only accepted for specific FreeIPA versions,
for example `self` for permission's `bindtype`. Although there are
options to check for command and parameter availability, there is no
check for verifying if a value should be accepted.

This patch add a function to check if the target FreeIPA host has, at
least a specific version. For example, calling `api_check_version(4.8)`
would return `True` for every 4.8-series release.

The version evaluation uses Python packaging's version comparision,
which is compatible with PEP 440.