### PR TITLE
Add support for adding external members to ipagroup.

### DIFF
--- a/README-group.md
+++ b/README-group.md
@@ -109,6 +109,24 @@ Example playbook to add group members to a group:
       - appops
 ```
 
+Example playbook to add members from a trusted realm to an external group:
+
+```yaml
+--
+- name: Playbook to handle groups.
+  hosts: ipaserver
+  became: true
+
+  - name: Create an external group and add members from a trust to it.
+    ipagroup:
+      ipaadmin_password: SomeADMINpassword
+      name: extgroup
+      external: yes
+      externalmember:
+      - WINIPA\\Web Users
+      - WINIPA\\Developers
+```
+
 Example playbook to remove groups:
 
 ```yaml
@@ -148,6 +166,7 @@ Variable | Description | Required
 `service` | List of service name strings assigned to this group. Only usable with IPA versions 4.7 and up. | no
 `membermanager_user` | List of member manager users assigned to this group. Only usable with IPA versions 4.8.4 and up. | no
 `membermanager_group` | List of member manager groups assigned to this group. Only usable with IPA versions 4.8.4 and up. | no
+`externalmember` \| `ipaexternalmember`  \| `external_member`| List of members of a trusted domain in DOM\\name or name@domain form. | no
 `action` | Work on group or member level. It can be on of `member` or `group` and defaults to `group`. | no
 `state` | The state to ensure. It can be one of `present` or `absent`, default: `present`. | yes
 

--- a/tests/env_freeipa_facts.yml
+++ b/tests/env_freeipa_facts.yml
@@ -16,3 +16,4 @@
   set_fact:
     ipa_version: "{{ ipa_cmd_version.stdout_lines[0] }}"
     ipa_api_version: "{{ ipa_cmd_version.stdout_lines[1] }}"
+    trust_test_is_supported: no

--- a/tests/group/test_group_external_members.yml
+++ b/tests/group/test_group_external_members.yml
@@ -1,0 +1,113 @@
+---
+- name: find trust
+  hosts: ipaserver
+  become: true
+  gather_facts: false
+
+  tasks:
+
+  - include_tasks: ../env_freeipa_facts.yml
+
+  - block:
+
+    - name: Add nonposix group.
+      ipagroup:
+        ipaadmin_password: SomeADMINpassword
+        name: extgroup
+        nonposix: yes
+      register: result
+      failed_when: result.failed or not result.changed
+
+    - name: Set group to be external
+      ipagroup:
+        ipaadmin_password: SomeADMINpassword
+        name: extgroup
+        external: yes
+      register: result
+      failed_when: result.failed or not result.changed
+
+    - name: Add AD users to group
+      ipagroup:
+        ipaadmin_password: SomeADMINpassword
+        name: extgroup
+        external_member: "AD\\Domain Users"
+      register: result
+      failed_when: result.failed or not result.changed
+
+    - name: Add AD users to group, again
+      ipagroup:
+        ipaadmin_password: SomeADMINpassword
+        name: extgroup
+        external_member: "AD\\Domain Users"
+      register: result
+      failed_when: result.failed or result.changed
+
+    - name: Remove external group
+      ipagroup:
+        ipaadmin_password: SomeADMINpassword
+        name: extgroup
+        state: absent
+      register: result
+      failed_when: result.failed or not result.changed
+
+    - name: Add nonposix, external group, with AD users.
+      ipagroup:
+        ipaadmin_password: SomeADMINpassword
+        name: extgroup
+        nonposix: yes
+        external: yes
+        external_member: "AD\\Domain Users"
+      register: result
+      failed_when: result.failed or not result.changed
+
+    - name: Add nonposix, external group, with AD users, again.
+      ipagroup:
+        ipaadmin_password: SomeADMINpassword
+        name: extgroup
+        nonposix: yes
+        external: yes
+        external_member: "AD\\Domain Users"
+      register: result
+      failed_when: result.failed or result.changed
+
+    - name: Remove group
+      ipagroup:
+        ipaadmin_password: SomeADMINpassword
+        name: extgroup
+        state: absent
+      register: result
+      failed_when: result.failed or not result.changed
+
+    - name: Add nonposix group.
+      ipagroup:
+        ipaadmin_password: SomeADMINpassword
+        name: extgroup
+        nonposix: yes
+      register: result
+      failed_when: result.failed or not result.changed
+
+    - name: Set group to be external, and add users.
+      ipagroup:
+        ipaadmin_password: SomeADMINpassword
+        name: extgroup
+        external: yes
+        external_member: "AD\\Domain Users"
+      register: result
+      failed_when: result.failed or not result.changed
+
+    - name: Set group to be external, and add users, again.
+      ipagroup:
+        ipaadmin_password: SomeADMINpassword
+        name: extgroup
+        external: yes
+        external_member: "AD\\Domain Users"
+      register: result
+      failed_when: result.failed or result.changed
+
+    - name: Cleanup environment.
+      ipagroup:
+        ipaadmin_password: SomeADMINpassword
+        name: extgroup
+        state: absent
+
+    when: trust_test_is_supported | default(false)


### PR DESCRIPTION
This patch add support for adding external members to ipagroup which
have the `external` attribute set. It adds another attribute to the
module, `external_members`, which is a list of users or groups from
an external trust, to be added to the group.

This patch requires server-trust-ad to be tested, as such, the tests
have been guarded by a test block, for when such tests are available
in ansible-freeipa CI.

Fixes issue #418