### PR TITLE
Fix ipapermission documentation issue with ansible-doc.

### DIFF
--- a/plugins/modules/ipapermission.py
+++ b/plugins/modules/ipapermission.py
@@ -66,7 +66,7 @@ options:
     required: false
     type: list
     aliases: ["extratargetfilter"]
-  rawfilter
+  rawfilter:
     description: All target filters
     required: false
     type: list


### PR DESCRIPTION
There was a colon (`:`) missing in the documentation part of ipapermission module.