### PR TITLE
Add action to verify Ansible documentation on each commit or PR.

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,16 @@
+---
+name: Verify Ansible documentation.
+on:
+  - push
+  - pull_request
+jobs:
+  check_docs:
+    name: Check Ansible Documentation.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: '3.x'
+      - name: Run ansible-doc-test
+        run: ANSIBLE_LIBRARY="." python utils/ansible-doc-test roles plugins

--- a/utils/ansible-doc-test
+++ b/utils/ansible-doc-test
@@ -124,7 +124,10 @@ def ansible_doc_test(path, verbose):
                 # All roles and plugins
                 roles = os.listdir("roles/")
                 for _role in roles:
-                    if not os.path.isdir("roles/%s" % _role):
+                    if (
+                        not os.path.isdir("roles/%s" % _role)
+                        or not os.path.isdir("roles/%s/library" % _role)
+                    ):
                         continue
                     modules = os.listdir("roles/%s/library" % _role)
                     for _module in modules:


### PR DESCRIPTION
This change add support for running ansible-doc-test as a Github
action on every commit or PR, ensuring that roles and modules are
able to produce correct documentation with ansible-doc.

> The task failure is expected, as there is an issue with one file, which
is ifxed in #426.