### PR TITLE
Fix ipahost module when adding hosts to a server without DNS support.

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -9,11 +9,10 @@ You will also need to have a remote host with freeipa server installed and confi
 Some other requirements:
 
  * The `controller` must be able to connect to `ipaserver` through ssh using keys.
- * `ipaserver` must be configured with DNS and KRA support.
-   See [ipaserver role](../roles/ipaserver/README.md).
  * IPA admin password must be `SomeADMINpassword`.
  * Directory Server admin password must be `SomeDMpassword`.
 
+To provide broader test coverage, `ipaserver` should be configured with DNS and KRA support, and playbook tests are written based on this configuration. Without such support, some tests are expected to fail. Use a different configuration to evaluate those scenarios. See also [ipaserver role](../roles/ipaserver/README.md).
 
 ## Running the tests
 


### PR DESCRIPTION
When using ipahost module with servers where DNS was not configured it failed to add hosts due to an exception raised on `dnsrecord_show` that was not being correctly handled.
    
As the exception was being handled twice, the This patch simply removes one of the handlers, allowing the exception to propagate to the caller, where it is handled.

This PR also modify host and dns module test playbooks, and adds a variable `SKIP_DNS` that can be used when running tests, to skip tests that require DNS to be configured on the server.
    
Fixes issue #434.
