### PR TITLE
build-galaxy-release: Galaxyfy READMEs, module EXAMPLES and tests

### DIFF
--- a/utils/build-galaxy-release.sh
+++ b/utils/build-galaxy-release.sh
@@ -29,11 +29,27 @@ cd plugins/action_plugins && {
     cd ../..
 }
 
+for x in $(find plugins/modules -name "*.py" -print); do
+    python utils/galaxyfy-module-EXAMPLES.py "$x" "ipa" "$collection_prefix"
+done
+
+for x in $(find roles/*/library -name "*.py" -print); do
+    python utils/galaxyfy-module-EXAMPLES.py "$x" "ipa" "$collection_prefix"
+done
+
 for x in roles/*/tasks/*.yml; do
     python utils/galaxyfy-playbook.py "$x" "ipa" "$collection_prefix"
 done
 
 for x in $(find playbooks -name "*.yml" -print); do
+    python utils/galaxyfy-playbook.py "$x" "ipa" "$collection_prefix"
+done
+
+for x in $(find . -name "README*.md" -print); do
+    python utils/galaxyfy-README.py "$x" "ipa" "$collection_prefix"
+done
+
+for x in $(find tests -name "*.yml" -print); do
     python utils/galaxyfy-playbook.py "$x" "ipa" "$collection_prefix"
 done
 

--- a/utils/galaxyfy-README.py
+++ b/utils/galaxyfy-README.py
@@ -1,0 +1,61 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Authors:
+#   Thomas Woerner <twoerner@redhat.com>
+#
+# Copyright (C) 2020 Red Hat
+# see file 'COPYING' for use and warranty information
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import sys
+from galaxyfy import galaxyfy_playbook
+
+
+def readme(readme_in, project_prefix, collection_prefix):
+    out_lines = []
+
+    with open(readme_in) as in_f:
+        changed = False
+        code = False
+        code_lines = []
+        for line in in_f:
+            stripped = line.strip()
+            if stripped.startswith("```"):
+                if code:
+                    _out_lines, _changed = \
+                        galaxyfy_playbook(project_prefix, collection_prefix,
+                                          code_lines)
+                    out_lines.extend(_out_lines)
+                    code_lines = []
+                    if _changed:
+                        changed = True
+                    code = False
+                else:
+                    code = True
+                    out_lines.append(line)
+                    continue
+            if code:
+                code_lines.append(line)
+            else:
+                out_lines.append(line)
+
+    if changed:
+        with open(readme_in, "w") as out_f:
+            for line in out_lines:
+                out_f.write(line)
+
+
+readme(sys.argv[1], sys.argv[2], sys.argv[3])

--- a/utils/galaxyfy-module-EXAMPLES.py
+++ b/utils/galaxyfy-module-EXAMPLES.py
@@ -1,0 +1,63 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Authors:
+#   Thomas Woerner <twoerner@redhat.com>
+#
+# Copyright (C) 2020 Red Hat
+# see file 'COPYING' for use and warranty information
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import sys
+from galaxyfy import galaxyfy_playbook
+
+
+def module_EXAMPLES(module_in, project_prefix, collection_prefix):
+    out_lines = []
+
+    with open(module_in) as in_f:
+        changed = False
+        example = False
+        example_lines = []
+        for line in in_f:
+            stripped = line.strip()
+            if stripped in ['EXAMPLES = """', "EXAMPLES = '''"]:
+                example = True
+                out_lines.append(line)
+                continue
+            elif example and stripped in ["'''", '"""']:
+                _out_lines, _changed = \
+                    galaxyfy_playbook(project_prefix, collection_prefix,
+                                      example_lines)
+                for _line in _out_lines:
+                    out_lines.append(_line)
+                example_lines = []
+                if _changed:
+                    changed = True
+                example = False
+                out_lines.append(line)
+                continue
+            if example:
+                example_lines.append(line)
+            else:
+                out_lines.append(line)
+
+    if changed:
+        with open(module_in, "w") as out_f:
+            for line in out_lines:
+                out_f.write(line)
+
+
+module_EXAMPLES(sys.argv[1], sys.argv[2], sys.argv[3])

--- a/utils/galaxyfy-playbook.py
+++ b/utils/galaxyfy-playbook.py
@@ -1,45 +1,40 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Authors:
+#   Thomas Woerner <twoerner@redhat.com>
+#
+# Copyright (C) 2019,2020 Red Hat
+# see file 'COPYING' for use and warranty information
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 import sys
-import re
+from galaxyfy import galaxyfy_playbook
 
 
-def galaxify_playbook(playbook_in, project_prefix, collection_prefix):
-    p1 = re.compile('(%s.*:)$' % project_prefix)
-    p2 = re.compile('(.*:) (%s.*)$' % project_prefix)
-    lines = []
-
-    pattern1 = r'%s.\1' % collection_prefix
-    pattern2 = r'\1 %s.\2' % collection_prefix
-
+def playbook(playbook_in, project_prefix, collection_prefix):
+    changed = False
     with open(playbook_in) as in_f:
-        changed = False
-        changeable = False
-        include_role = False
-        for line in in_f:
-            stripped = line.strip()
-            if stripped.startswith("- name:") or \
-               stripped.startswith("- block:"):
-                changeable = True
-            elif stripped in ["set_fact:", "vars:"]:
-                changeable = False
-                include_role = False
-            elif stripped.startswith("include_role:"):
-                include_role = True
-            elif include_role and stripped.startswith("name:"):
-                line = p2.sub(pattern2, line)
-                changed = True
-            elif changeable and stripped.startswith("- role:"):
-                line = p2.sub(pattern2, line)
-                changed = True
-            elif changeable and not stripped.startswith(collection_prefix):
-                line = p1.sub(pattern1, line)
-                changed = True
-
-            lines.append(line)
+        lines = in_f.readlines()
+        out_lines, changed = \
+            galaxyfy_playbook(project_prefix, collection_prefix, lines)
 
     if changed:
         with open(playbook_in, "w") as out_f:
-            for line in lines:
+            for line in out_lines:
                 out_f.write(line)
 
 
-galaxify_playbook(sys.argv[1], sys.argv[2], sys.argv[3])
+playbook(sys.argv[1], sys.argv[2], sys.argv[3])

--- a/utils/galaxyfy.py
+++ b/utils/galaxyfy.py
@@ -1,0 +1,66 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Authors:
+#   Thomas Woerner <twoerner@redhat.com>
+#
+# Copyright (C) 2019,2020 Red Hat
+# see file 'COPYING' for use and warranty information
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import re
+
+
+def galaxyfy_playbook(project_prefix, collection_prefix, lines):
+    p1 = re.compile('(%s.*:)$' % project_prefix)
+    p2 = re.compile('(.*:) (%s.*)$' % project_prefix)
+    out_lines = []
+
+    pattern1 = r'%s.\1' % collection_prefix
+    pattern2 = r'\1 %s.\2' % collection_prefix
+
+    changed = False
+    changeable = False
+    include_role = False
+    for line in lines:
+        stripped = line.strip()
+        if stripped.startswith("- name:") or \
+           stripped.startswith("- block:"):
+            changeable = True
+        elif stripped in ["set_fact:", "vars:"]:
+            changeable = False
+            include_role = False
+        elif stripped.startswith("include_role:"):
+            include_role = True
+        elif include_role and stripped.startswith("name:"):
+            line = p2.sub(pattern2, line)
+            changed = True
+        elif changeable and stripped.startswith("- role:"):
+            line = p2.sub(pattern2, line)
+            changed = True
+        elif (changeable and stripped.startswith(project_prefix) and
+              not stripped.startswith(collection_prefix) and
+              stripped.endswith(":")):
+            line = p1.sub(pattern1, line)
+            changed = True
+            changeable = False  # Only change first line in task
+        elif (stripped.startswith("- %s" % project_prefix) and
+              stripped.endswith(":")):
+            line = p1.sub(pattern1, line)
+            changed = True
+
+        out_lines.append(line)
+
+    return (out_lines, changed)


### PR DESCRIPTION
Up to now the snippets in the README files, the EXAMPLES in the modules
and also the tests playbooks have not been adapted while building the
collection.

These are the invoved python files:

    utils/galaxyfy-README.py
    utils/galaxyfy-module-EXAMPLES.py
    utils/galaxyfy-playbook.py
    utils/galaxyfy.py

utils/galaxyfy.py provides the function galaxyfy_playbook, which has been
extended and is used in galaxyfy-playbook.py, galaxyfy-README.py and
galaxyfy-module-EXAMPLES.py.
