### PR TITLE
ipaserver: copy_external_cert should use basename on server only

### DIFF
--- a/roles/ipaserver/tasks/copy_external_cert.yml
+++ b/roles/ipaserver/tasks/copy_external_cert.yml
@@ -2,11 +2,11 @@
   set_fact:
      ipaserver_external_cert_files: []
   when: ipaserver_external_cert_files is undefined
-- name: Install - Copy "{{ item }}" "{{ inventory_hostname }}':/root/'{{ item }}"
+- name: Install - Copy "{{ item }}" "{{ inventory_hostname }}':/root/'{{ item | basename }}"
   copy:
     src: "{{ item }}"
-    dest: "/root/{{ item }}"
+    dest: "/root/{{ item | basename }}"
     force: yes
-- name: Install - Extend ipaserver_external_cert_files with "/root/{{ item }}"
+- name: Install - Extend ipaserver_external_cert_files with "/root/{{ item | basename }}"
   set_fact:
-    ipaserver_external_cert_files: "{{ ipaserver_external_cert_files }} + [ '/root/{{ item }}' ]"
+    ipaserver_external_cert_files: "{{ ipaserver_external_cert_files }} + [ '/root/{{ item | basename }}' ]"


### PR DESCRIPTION
Currently the certifaictes are copied ot the server with the complete
path that is provided within the playbook. This could result in
unexpected file placements. Certificates should be placed in the /root
folder for the deployment.

Fixes #405 (copy_external_cert does not handle pathed items)