### PR TITLE
Fix lookup for certicates in tests

### DIFF
--- a/tests/dnsrecord/test_dnsrecord.yml
+++ b/tests/dnsrecord/test_dnsrecord.yml
@@ -14,6 +14,7 @@
       cmd: |
         openssl req -x509 -newkey rsa:2048 -days 365 -nodes -keyout "private{{ item }}.key" -out "cert{{ item }}.pem" -subj '/CN=test'
         openssl x509 -outform der -in "cert{{ item }}.pem" -out "cert{{ item }}.der"
+        base64 "cert{{ item }}.der" -w5000 > "cert{{ item }}.b64"
     with_items: [1]
     become: no
     delegate_to: localhost
@@ -686,7 +687,7 @@
       cert_type: 1
       cert_key_tag: 1234
       cert_algorithm: 3
-      cert_certificate_or_crl: "{{ lookup('file', 'cert1.der') | b64encode }}"
+      cert_certificate_or_crl: "{{ lookup('file', 'cert1.b64') }}"
     register: result
     failed_when: not result.changed
 
@@ -698,7 +699,7 @@
       cert_type: 1
       cert_key_tag: 1234
       cert_algorithm: 3
-      cert_certificate_or_crl: "{{ lookup('file', 'cert1.der') | b64encode }}"
+      cert_certificate_or_crl: "{{ lookup('file', 'cert1.b64') }}"
     register: result
     failed_when: result.changed
 
@@ -707,7 +708,7 @@
       ipaadmin_password: SomeADMINpassword
       zone_name: "{{ testzone }}"
       name: host04
-      cert_rec: "1 1234 3 {{ lookup('file', 'cert1.der') | b64encode }}"
+      cert_rec: "1 1234 3 {{ lookup('file', 'cert1.b64') }}"
       state: absent
     register: result
     failed_when: not result.changed
@@ -717,7 +718,7 @@
       ipaadmin_password: SomeADMINpassword
       zone_name: "{{ testzone }}"
       name: host04
-      cert_rec: 1 1234 3 "{{ lookup('file', 'cert1.der') | b64encode }}"
+      cert_rec: 1 1234 3 "{{ lookup('file', 'cert1.b64') }}"
       state: absent
     register: result
     failed_when: result.changed
@@ -1354,7 +1355,7 @@
 
   - name: Remove certificate files.
     shell:
-      cmd: rm -f "private{{ item }}.key" "cert{{ item }}.pem" "cert{{ item }}.der"
+      cmd: rm -f "private{{ item }}.key" "cert{{ item }}.pem" "cert{{ item }}.der" "cert{{ item }}.b64"
     with_items: [1]
     become: no
     delegate_to: localhost

--- a/tests/host/certificate/test_host_certificate.yml
+++ b/tests/host/certificate/test_host_certificate.yml
@@ -14,6 +14,7 @@
       cmd: |
         openssl req -x509 -newkey rsa:2048 -days 365 -nodes -keyout "private{{ item }}.key" -out "cert{{ item }}.pem" -subj '/CN=test'
         openssl x509 -outform der -in "cert{{ item }}.pem" -out "cert{{ item }}.der"
+        base64 "cert{{ item }}.der" -w5000 > "cert{{ item }}.b64"
     with_items: [1, 2, 3]
     become: no
     delegate_to: localhost
@@ -37,9 +38,9 @@
       ipaadmin_password: SomeADMINpassword
       name: "{{ 'test.' + ipaserver_domain }}"
       certificate:
-        - "{{ lookup('file', 'cert1.der') | b64encode }}"
-        - "{{ lookup('file', 'cert2.der') | b64encode }}"
-        - "{{ lookup('file', 'cert3.der') | b64encode }}"
+        - "{{ lookup('file', 'cert1.b64', rstrip=False) }}"
+        - "{{ lookup('file', 'cert2.b64', rstrip=False) }}"
+        - "{{ lookup('file', 'cert3.b64', rstrip=False) }}"
       action: member
     register: result
     failed_when: not result.changed
@@ -49,9 +50,9 @@
       ipaadmin_password: SomeADMINpassword
       name: "{{ 'test.' + ipaserver_domain }}"
       certificate:
-        - "{{ lookup('file', 'cert1.der') | b64encode }}"
-        - "{{ lookup('file', 'cert2.der') | b64encode }}"
-        - "{{ lookup('file', 'cert3.der') | b64encode }}"
+        - "{{ lookup('file', 'cert1.b64', rstrip=False) }}"
+        - "{{ lookup('file', 'cert2.b64', rstrip=False) }}"
+        - "{{ lookup('file', 'cert3.b64', rstrip=False) }}"
       action: member
     register: result
     failed_when: result.changed
@@ -61,9 +62,9 @@
       ipaadmin_password: SomeADMINpassword
       name: "{{ 'test.' + ipaserver_domain }}"
       certificate:
-        - "{{ lookup('file', 'cert1.der') | b64encode }}"
-        - "{{ lookup('file', 'cert2.der') | b64encode }}"
-        - "{{ lookup('file', 'cert3.der') | b64encode }}"
+        - "{{ lookup('file', 'cert1.b64', rstrip=False) }}"
+        - "{{ lookup('file', 'cert2.b64', rstrip=False) }}"
+        - "{{ lookup('file', 'cert3.b64', rstrip=False) }}"
       state: absent
       action: member
     register: result
@@ -74,9 +75,9 @@
       ipaadmin_password: SomeADMINpassword
       name: "{{ 'test.' + ipaserver_domain }}"
       certificate:
-        - "{{ lookup('file', 'cert1.der') | b64encode }}"
-        - "{{ lookup('file', 'cert2.der') | b64encode }}"
-        - "{{ lookup('file', 'cert3.der') | b64encode }}"
+        - "{{ lookup('file', 'cert1.b64', rstrip=False) }}"
+        - "{{ lookup('file', 'cert2.b64', rstrip=False) }}"
+        - "{{ lookup('file', 'cert3.b64', rstrip=False) }}"
       state: absent
       action: member
     register: result
@@ -100,7 +101,7 @@
 
   - name: Remove certificate files.
     shell:
-      cmd: rm -f "private{{ item }}.key" "cert{{ item }}.pem" "cert{{ item }}.der"
+      cmd: rm -f "private{{ item }}.key" "cert{{ item }}.pem" "cert{{ item }}.der" "cert{{ item }}.b64"
     with_items: [1, 2, 3]
     become: no
     delegate_to: localhost

--- a/tests/host/certificate/test_hosts_certificate.yml
+++ b/tests/host/certificate/test_hosts_certificate.yml
@@ -30,6 +30,7 @@
       cmd: |
         openssl req -x509 -newkey rsa:2048 -days 365 -nodes -keyout "private{{ item }}.key" -out "cert{{ item }}.pem" -subj '/CN=test'
         openssl x509 -outform der -in "cert{{ item }}.pem" -out "cert{{ item }}.der"
+        base64 "cert{{ item }}.der" -w5000 > "cert{{ item }}.b64"
     with_items: [1, 2, 3]
     become: no
     delegate_to: localhost
@@ -40,9 +41,9 @@
       hosts:
       - name: "{{ 'test.' + ipaserver_domain }}"
         certificate:
-        - "{{ lookup('file', 'cert1.der') | b64encode }}"
-        - "{{ lookup('file', 'cert2.der') | b64encode }}"
-        - "{{ lookup('file', 'cert3.der') | b64encode }}"
+        - "{{ lookup('file', 'cert1.b64', rstrip=False) }}"
+        - "{{ lookup('file', 'cert2.b64', rstrip=False) }}"
+        - "{{ lookup('file', 'cert3.b64', rstrip=False) }}"
       action: member
     register: result
     failed_when: not result.changed
@@ -53,9 +54,9 @@
       hosts:
       - name: "{{ 'test.' + ipaserver_domain }}"
         certificate:
-        - "{{ lookup('file', 'cert1.der') | b64encode }}"
-        - "{{ lookup('file', 'cert2.der') | b64encode }}"
-        - "{{ lookup('file', 'cert3.der') | b64encode }}"
+        - "{{ lookup('file', 'cert1.b64', rstrip=False) }}"
+        - "{{ lookup('file', 'cert2.b64', rstrip=False) }}"
+        - "{{ lookup('file', 'cert3.b64', rstrip=False) }}"
       action: member
     register: result
     failed_when: result.changed
@@ -66,9 +67,9 @@
       hosts:
       - name: "{{ 'test.' + ipaserver_domain }}"
         certificate:
-        - "{{ lookup('file', 'cert1.der') | b64encode }}"
-        - "{{ lookup('file', 'cert2.der') | b64encode }}"
-        - "{{ lookup('file', 'cert3.der') | b64encode }}"
+        - "{{ lookup('file', 'cert1.b64', rstrip=False) }}"
+        - "{{ lookup('file', 'cert2.b64', rstrip=False) }}"
+        - "{{ lookup('file', 'cert3.b64', rstrip=False) }}"
       state: absent
       action: member
     #register: result
@@ -80,9 +81,9 @@
       hosts:
       - name: "{{ 'test.' + ipaserver_domain }}"
         certificate:
-        - "{{ lookup('file', 'cert1.der') | b64encode }}"
-        - "{{ lookup('file', 'cert2.der') | b64encode }}"
-        - "{{ lookup('file', 'cert3.der') | b64encode }}"
+        - "{{ lookup('file', 'cert1.b64', rstrip=False) }}"
+        - "{{ lookup('file', 'cert2.b64', rstrip=False) }}"
+        - "{{ lookup('file', 'cert3.b64', rstrip=False) }}"
       state: absent
       action: member
     register: result
@@ -99,7 +100,7 @@
 
   - name: Remove certificate files.
     shell:
-      cmd: rm -f "private{{ item }}.key" "cert{{ item }}.pem" "cert{{ item }}.der"
+      cmd: rm -f "private{{ item }}.key" "cert{{ item }}.pem" "cert{{ item }}.der" "cert{{ item }}.b64"
     with_items: [1, 2, 3]
     become: no
     delegate_to: localhost

--- a/tests/user/certificate/test_user_certificate.yml
+++ b/tests/user/certificate/test_user_certificate.yml
@@ -10,6 +10,7 @@
       cmd: |
         openssl req -x509 -newkey rsa:2048 -days 365 -nodes -keyout "private{{ item }}.key" -out "cert{{ item }}.pem" -subj '/CN=test'
         openssl x509 -outform der -in "cert{{ item }}.pem" -out "cert{{ item }}.der"
+        base64 "cert{{ item }}.der" -w5000 > "cert{{ item }}.b64"
     with_items: [1, 2, 3]
     become: no
     delegate_to: localhost
@@ -26,9 +27,9 @@
       ipaadmin_password: SomeADMINpassword
       name: test
       certificate:
-      - "{{ lookup('file', 'cert1.der') | b64encode }}"
-      - "{{ lookup('file', 'cert2.der') | b64encode }}"
-      - "{{ lookup('file', 'cert3.der') | b64encode }}"
+      - "{{ lookup('file', 'cert1.b64', rstrip=False) }}"
+      - "{{ lookup('file', 'cert2.b64', rstrip=False) }}"
+      - "{{ lookup('file', 'cert3.b64', rstrip=False) }}"
       action: member
     register: result
     failed_when: not result.changed
@@ -40,9 +41,9 @@
       first: test
       last: test
       certificate:
-      - "{{ lookup('file', 'cert1.der') | b64encode }}"
-      - "{{ lookup('file', 'cert2.der') | b64encode }}"
-      - "{{ lookup('file', 'cert3.der') | b64encode }}"
+      - "{{ lookup('file', 'cert1.b64', rstrip=False) }}"
+      - "{{ lookup('file', 'cert2.b64', rstrip=False) }}"
+      - "{{ lookup('file', 'cert3.b64', rstrip=False) }}"
       action: member
     register: result
     failed_when: result.changed
@@ -52,9 +53,9 @@
       ipaadmin_password: SomeADMINpassword
       name: test
       certificate:
-      - "{{ lookup('file', 'cert1.der') | b64encode }}"
-      - "{{ lookup('file', 'cert2.der') | b64encode }}"
-      - "{{ lookup('file', 'cert3.der') | b64encode }}"
+      - "{{ lookup('file', 'cert1.b64', rstrip=False) }}"
+      - "{{ lookup('file', 'cert2.b64', rstrip=False) }}"
+      - "{{ lookup('file', 'cert3.b64', rstrip=False) }}"
       state: absent
       action: member
     register: result
@@ -65,9 +66,9 @@
       ipaadmin_password: SomeADMINpassword
       name: test
       certificate:
-      - "{{ lookup('file', 'cert1.der') | b64encode }}"
-      - "{{ lookup('file', 'cert2.der') | b64encode }}"
-      - "{{ lookup('file', 'cert3.der') | b64encode }}"
+      - "{{ lookup('file', 'cert1.b64', rstrip=False) }}"
+      - "{{ lookup('file', 'cert2.b64', rstrip=False) }}"
+      - "{{ lookup('file', 'cert3.b64', rstrip=False) }}"
       state: absent
       action: member
     register: result
@@ -83,7 +84,7 @@
 
   - name: Remove certificate files.
     shell:
-      cmd: rm -f "private{{ item }}.key" "cert{{ item }}.pem" "cert{{ item }}.der"
+      cmd: rm -f "private{{ item }}.key" "cert{{ item }}.pem" "cert{{ item }}.der" "cert{{ item }}.b64"
     with_items: [1, 2, 3]
     become: no
     delegate_to: localhost

--- a/tests/user/certificate/test_users_certificate.yml
+++ b/tests/user/certificate/test_users_certificate.yml
@@ -10,6 +10,7 @@
       cmd: |
         openssl req -x509 -newkey rsa:2048 -days 365 -nodes -keyout "private{{ item }}.key" -out "cert{{ item }}.pem" -subj '/CN=test'
         openssl x509 -outform der -in "cert{{ item }}.pem" -out "cert{{ item }}.der"
+        base64 "cert{{ item }}.der" -w5000 > "cert{{ item }}.b64"
     with_items: [1, 2, 3]
     become: no
     delegate_to: localhost
@@ -35,9 +36,9 @@
       users:
       - name: test
         certificate:
-        - "{{ lookup('file', 'cert1.der') | b64encode }}"
-        - "{{ lookup('file', 'cert2.der') | b64encode }}"
-        - "{{ lookup('file', 'cert3.der') | b64encode }}"
+        - "{{ lookup('file', 'cert1.b64', rstrip=False) }}"
+        - "{{ lookup('file', 'cert2.b64', rstrip=False) }}"
+        - "{{ lookup('file', 'cert3.b64', rstrip=False) }}"
       action: member
     register: result
     failed_when: not result.changed
@@ -48,9 +49,9 @@
       users:
       - name: test
         certificate:
-        - "{{ lookup('file', 'cert1.der') | b64encode }}"
-        - "{{ lookup('file', 'cert2.der') | b64encode }}"
-        - "{{ lookup('file', 'cert3.der') | b64encode }}"
+        - "{{ lookup('file', 'cert1.b64', rstrip=False) }}"
+        - "{{ lookup('file', 'cert2.b64', rstrip=False) }}"
+        - "{{ lookup('file', 'cert3.b64', rstrip=False) }}"
       action: member
     register: result
     failed_when: result.changed
@@ -61,9 +62,9 @@
       users:
       - name: test
         certificate:
-        - "{{ lookup('file', 'cert1.der') | b64encode }}"
-        - "{{ lookup('file', 'cert2.der') | b64encode }}"
-        - "{{ lookup('file', 'cert3.der') | b64encode }}"
+        - "{{ lookup('file', 'cert1.b64', rstrip=False) }}"
+        - "{{ lookup('file', 'cert2.b64', rstrip=False) }}"
+        - "{{ lookup('file', 'cert3.b64', rstrip=False) }}"
       state: absent
       action: member
     #register: result
@@ -75,9 +76,9 @@
       users:
       - name: test
         certificate:
-        - "{{ lookup('file', 'cert1.der') | b64encode }}"
-        - "{{ lookup('file', 'cert2.der') | b64encode }}"
-        - "{{ lookup('file', 'cert3.der') | b64encode }}"
+        - "{{ lookup('file', 'cert1.b64', rstrip=False) }}"
+        - "{{ lookup('file', 'cert2.b64', rstrip=False) }}"
+        - "{{ lookup('file', 'cert3.b64', rstrip=False) }}"
       state: absent
       action: member
     register: result
@@ -94,7 +95,7 @@
 
   - name: Remove certificate files.
     shell:
-      cmd: rm -f "private{{ item }}.key" "cert{{ item }}.pem" "cert{{ item }}.der"
+      cmd: rm -f "private{{ item }}.key" "cert{{ item }}.pem" "cert{{ item }}.der" "cert{{ item }}.b64"
     with_items: [1, 2, 3]
     become: no
     delegate_to: localhost

--- a/tests/user/certmapdata/test_user_certmapdata.yml
+++ b/tests/user/certmapdata/test_user_certmapdata.yml
@@ -10,6 +10,7 @@
       cmd: |
         openssl req -x509 -newkey rsa:2048 -days 365 -nodes -keyout "private{{ item }}.key" -out "cert{{ item }}.pem" -subj '/CN=test'
         openssl x509 -outform der -in "cert{{ item }}.pem" -out "cert{{ item }}.der"
+        base64 "cert{{ item }}.der" -w5000 > "cert{{ item }}.b64"
     with_items: [1, 2, 3]
     become: no
     delegate_to: localhost
@@ -34,9 +35,9 @@
       ipaadmin_password: SomeADMINpassword
       name: test
       certmapdata:
-        - certificate: "{{ lookup('file', 'cert1.der') | b64encode }}"
-        - certificate: "{{ lookup('file', 'cert2.der') | b64encode }}"
-        - certificate: "{{ lookup('file', 'cert3.der') | b64encode }}"
+        - certificate: "{{ lookup('file', 'cert1.b64', rstrip=False) }}"
+        - certificate: "{{ lookup('file', 'cert2.b64', rstrip=False) }}"
+        - certificate: "{{ lookup('file', 'cert3.b64', rstrip=False) }}"
       action: member
     register: result
     failed_when: not result.changed
@@ -46,9 +47,9 @@
       ipaadmin_password: SomeADMINpassword
       name: test
       certmapdata:
-        - certificate: "{{ lookup('file', 'cert1.der') | b64encode }}"
-        - certificate: "{{ lookup('file', 'cert2.der') | b64encode }}"
-        - certificate: "{{ lookup('file', 'cert3.der') | b64encode }}"
+        - certificate: "{{ lookup('file', 'cert1.b64', rstrip=False) }}"
+        - certificate: "{{ lookup('file', 'cert2.b64', rstrip=False) }}"
+        - certificate: "{{ lookup('file', 'cert3.b64', rstrip=False) }}"
       action: member
     register: result
     failed_when: result.changed
@@ -58,9 +59,9 @@
       ipaadmin_password: SomeADMINpassword
       name: test
       certmapdata:
-        - certificate: "{{ lookup('file', 'cert1.der') | b64encode }}"
-        - certificate: "{{ lookup('file', 'cert2.der') | b64encode }}"
-        - certificate: "{{ lookup('file', 'cert3.der') | b64encode }}"
+        - certificate: "{{ lookup('file', 'cert1.b64', rstrip=False) }}"
+        - certificate: "{{ lookup('file', 'cert2.b64', rstrip=False) }}"
+        - certificate: "{{ lookup('file', 'cert3.b64', rstrip=False) }}"
       action: member
       state: absent
     register: result
@@ -71,9 +72,9 @@
       ipaadmin_password: SomeADMINpassword
       name: test
       certmapdata:
-        - certificate: "{{ lookup('file', 'cert1.der') | b64encode }}"
-        - certificate: "{{ lookup('file', 'cert2.der') | b64encode }}"
-        - certificate: "{{ lookup('file', 'cert3.der') | b64encode }}"
+        - certificate: "{{ lookup('file', 'cert1.b64', rstrip=False) }}"
+        - certificate: "{{ lookup('file', 'cert2.b64', rstrip=False) }}"
+        - certificate: "{{ lookup('file', 'cert3.b64', rstrip=False) }}"
       action: member
       state: absent
     register: result
@@ -226,7 +227,7 @@
 
   - name: Remove certificate files.
     shell:
-      cmd: rm -f "private{{ item }}.key" "cert{{ item }}.pem" "cert{{ item }}.der"
+      cmd: rm -f "private{{ item }}.key" "cert{{ item }}.pem" "cert{{ item }}.der" "cert{{ item }}.b64"
     with_items: [1, 2, 3]
     become: no
     delegate_to: localhost

--- a/tests/user/certmapdata/test_users_certmapdata.yml
+++ b/tests/user/certmapdata/test_users_certmapdata.yml
@@ -10,6 +10,7 @@
       cmd: |
         openssl req -x509 -newkey rsa:2048 -days 365 -nodes -keyout "private{{ item }}.key" -out "cert{{ item }}.pem" -subj '/CN=test'
         openssl x509 -outform der -in "cert{{ item }}.pem" -out "cert{{ item }}.der"
+        base64 "cert{{ item }}.der" -w5000 > "cert{{ item }}.b64"
     with_items: [1, 2, 3]
     become: no
     delegate_to: localhost
@@ -37,9 +38,9 @@
       users:
       - name: test
         certmapdata:
-        - certificate: "{{ lookup('file', 'cert1.der') | b64encode }}"
-        - certificate: "{{ lookup('file', 'cert2.der') | b64encode }}"
-        - certificate: "{{ lookup('file', 'cert3.der') | b64encode }}"
+        - certificate: "{{ lookup('file', 'cert1.b64', rstrip=False) }}"
+        - certificate: "{{ lookup('file', 'cert2.b64', rstrip=False) }}"
+        - certificate: "{{ lookup('file', 'cert3.b64', rstrip=False) }}"
       action: member
     register: result
     failed_when: not result.changed
@@ -50,9 +51,9 @@
       users:
       - name: test
         certmapdata:
-        - certificate: "{{ lookup('file', 'cert1.der') | b64encode }}"
-        - certificate: "{{ lookup('file', 'cert2.der') | b64encode }}"
-        - certificate: "{{ lookup('file', 'cert3.der') | b64encode }}"
+        - certificate: "{{ lookup('file', 'cert1.b64', rstrip=False) }}"
+        - certificate: "{{ lookup('file', 'cert2.b64', rstrip=False) }}"
+        - certificate: "{{ lookup('file', 'cert3.b64', rstrip=False) }}"
       action: member
     register: result
     failed_when: result.changed
@@ -63,9 +64,9 @@
       users:
       - name: test
         certmapdata:
-        - certificate: "{{ lookup('file', 'cert1.der') | b64encode }}"
-        - certificate: "{{ lookup('file', 'cert2.der') | b64encode }}"
-        - certificate: "{{ lookup('file', 'cert3.der') | b64encode }}"
+        - certificate: "{{ lookup('file', 'cert1.b64', rstrip=False) }}"
+        - certificate: "{{ lookup('file', 'cert2.b64', rstrip=False) }}"
+        - certificate: "{{ lookup('file', 'cert3.b64', rstrip=False) }}"
       action: member
       state: absent
     register: result
@@ -77,9 +78,9 @@
       users:
       - name: test
         certmapdata:
-        - certificate: "{{ lookup('file', 'cert1.der') | b64encode }}"
-        - certificate: "{{ lookup('file', 'cert2.der') | b64encode }}"
-        - certificate: "{{ lookup('file', 'cert3.der') | b64encode }}"
+        - certificate: "{{ lookup('file', 'cert1.b64', rstrip=False) }}"
+        - certificate: "{{ lookup('file', 'cert2.b64', rstrip=False) }}"
+        - certificate: "{{ lookup('file', 'cert3.b64', rstrip=False) }}"
       action: member
       state: absent
     register: result
@@ -162,7 +163,7 @@
 
   - name: Remove certificate files.
     shell:
-      cmd: rm -f "private{{ item }}.key" "cert{{ item }}.pem" "cert{{ item }}.der"
+      cmd: rm -f "private{{ item }}.key" "cert{{ item }}.pem" "cert{{ item }}.der" "cert{{ item }}.b64"
     with_items: [1, 2, 3]
     become: no
     delegate_to: localhost

--- a/tests/user/test_users_invalid_cert.yml
+++ b/tests/user/test_users_invalid_cert.yml
@@ -10,6 +10,7 @@
       cmd: |
         openssl req -x509 -newkey rsa:2048 -days 365 -nodes -keyout "private{{ item }}.key" -out "cert{{ item }}.pem" -subj '/CN=test'
         openssl x509 -outform der -in "cert{{ item }}.pem" -out "cert{{ item }}.der"
+        base64 "cert{{ item }}.der" -w5000 > "cert{{ item }}.b64"
     with_items: [1, 2]
     become: no
     delegate_to: localhost
@@ -35,7 +36,7 @@
       users:
       - name: test
         certificate:
-        - "{{ lookup('file', 'cert1.der') | b64encode }}"
+        - "{{ lookup('file', 'cert1.b64', rstrip=False) }}"
       action: member
     register: result
     failed_when: not result.changed
@@ -46,8 +47,8 @@
       users:
       - name: test
         certificate:
-        - "{{ lookup('file', 'cert1.der') | b64encode }}"
-        - "{{ lookup('file', 'cert2.der') | b64encode }}"
+        - "{{ lookup('file', 'cert1.b64', rstrip=False) }}"
+        - "{{ lookup('file', 'cert2.b64', rstrip=False) }}"
       state: absent
       action: member
     #register: result
@@ -55,7 +56,7 @@
 
   - name: Remove certificate files.
     shell:
-      cmd: rm -f "private{{ item }}.key" "cert{{ item }}.pem" "cert{{ item }}.der"
+      cmd: rm -f "private{{ item }}.key" "cert{{ item }}.pem" "cert{{ item }}.der" "cert{{ item }}.b64"
     with_items: [1, 2]
     become: no
     delegate_to: localhost

--- a/tests/vault/tasks_vault_members.yml
+++ b/tests/vault/tasks_vault_members.yml
@@ -27,7 +27,7 @@
       ipaadmin_password: SomeADMINpassword
       name: "{{vault.name}}"
       vault_type: "{{vault.vault_type}}"
-      public_key: "{{lookup('file', 'private.pem') | b64encode}}"
+      public_key: "{{lookup('file', 'private.pem', rstrip=False) | b64encode}}"
     register: result
     failed_when: not result.changed
     when: vault.vault_type == 'asymmetric'

--- a/tests/vault/test_vault_asymmetric.yml
+++ b/tests/vault/test_vault_asymmetric.yml
@@ -14,7 +14,7 @@
       ipaadmin_password: SomeADMINpassword
       name: asymvault
       vault_type: asymmetric
-      public_key: "{{ lookup('file', 'public.pem') | b64encode }}"
+      public_key: "{{ lookup('file', 'public.pem', rstrip=False) | b64encode }}"
     register: result
     failed_when: not result.changed
 
@@ -23,7 +23,7 @@
       ipaadmin_password: SomeADMINpassword
       name: asymvault
       vault_type: asymmetric
-      public_key: "{{ lookup('file', 'public.pem') | b64encode }}"
+      public_key: "{{ lookup('file', 'public.pem', rstrip=False) | b64encode }}"
     register: result
     failed_when: result.changed
 
@@ -39,7 +39,7 @@
     ipavault:
       ipaadmin_password: SomeADMINpassword
       name: asymvault
-      private_key: "{{ lookup('file', 'private.pem') | b64encode }}"
+      private_key: "{{ lookup('file', 'private.pem', rstrip=False) | b64encode }}"
       state: retrieved
     register: result
     failed_when: result.vault.data != 'SomeADMINpassword' or result.changed
@@ -56,7 +56,7 @@
     ipavault:
       ipaadmin_password: SomeADMINpassword
       name: asymvault
-      private_key: "{{ lookup('file', 'private.pem') | b64encode }}"
+      private_key: "{{ lookup('file', 'private.pem', rstrip=False) | b64encode }}"
       state: retrieved
     register: result
     failed_when: result.vault.data != 'Hello World.' or result.changed
@@ -66,7 +66,7 @@
       ipaadmin_password: SomeADMINpassword
       name: asymvault
       out: "{{ ansible_env.HOME }}/data.txt"
-      private_key: "{{ lookup('file', 'private.pem') | b64encode }}"
+      private_key: "{{ lookup('file', 'private.pem', rstrip=False) | b64encode }}"
       state: retrieved
     register: result
     failed_when: result.changed or result.failed or (result.vault.data | default(false))
@@ -89,7 +89,7 @@
     ipavault:
       ipaadmin_password: SomeADMINpassword
       name: asymvault
-      private_key: "{{ lookup('file', 'private.pem') | b64encode }}"
+      private_key: "{{ lookup('file', 'private.pem', rstrip=False) | b64encode }}"
       state: retrieved
     register: result
     failed_when: result.vault.data != 'The world of π is half rounded.' or result.changed
@@ -107,7 +107,7 @@
     ipavault:
       ipaadmin_password: SomeADMINpassword
       name: asymvault
-      private_key: "{{ lookup('file', 'private.pem') | b64encode }}"
+      private_key: "{{ lookup('file', 'private.pem', rstrip=False) | b64encode }}"
       state: retrieved
     register: result
     failed_when: result.vault.data != 'Another World.' or result.changed
@@ -124,7 +124,7 @@
     ipavault:
       ipaadmin_password: SomeADMINpassword
       name: asymvault
-      private_key: "{{ lookup('file', 'private.pem') | b64encode }}"
+      private_key: "{{ lookup('file', 'private.pem', rstrip=False) | b64encode }}"
       state: retrieved
     register: result
     failed_when: result.vault.data != 'c' or result.changed
@@ -175,7 +175,7 @@
     ipavault:
       ipaadmin_password: SomeADMINpassword
       name: asymvault
-      private_key: "{{ lookup('file', 'private.pem') | b64encode }}"
+      private_key: "{{ lookup('file', 'private.pem', rstrip=False) | b64encode }}"
       state: retrieved
     register: result
     failed_when: result.vault.data != 'Hello World.' or result.changed


### PR DESCRIPTION
The file lookup is by default setting `rstrip=True` which could lead
into a stripped new line. This is not happening always but resulted in
failed tests sometimes with certificates pasted to the b64encode filter.

For all calls of lookup in the certificae tests `rstrip=False` has been
added to make sure that this is not happening any more. The user and
host tests have also been simplified to create the base64 encoded file
in the beginning and use this file then later on in the tests without
the need to use the b64encode filter.

Ref: https://github.com/ansible/ansible/issues/57521#issuecomment-502238000