### PR TITLE
ipadnszone: Fix modification o SOA serial with other attributes.

### DIFF
--- a/tests/dnszone/test_dnszone_mod.yml
+++ b/tests/dnszone/test_dnszone_mod.yml
@@ -11,6 +11,80 @@
     include_tasks: env_setup.yml
 
   # Tests
+  - name: Verify if zone can be created with a specific SOA serial.
+    block:
+    - name: Create zone with serial, refresh, retry and expire.
+      ipadnszone:
+        ipaadmin_password: SomeADMINpassword
+        name: testzone.local
+        serial: 4567
+        refresh: 70
+        retry: 89
+        expire: 200
+
+    - name: Verify zone was created with correct values.
+      shell: |
+         echo SomeADMINpassword | kinit -c {{ KRB5CCNAME }} admin
+         KRB5CCNAME={{ KRB5CCNAME }} ipa dnszone-show testzone.local
+         kdestroy -A -q -c {{ KRB5CCNAME }}
+      register: result
+      failed_when: |
+        result.failed or not (
+          "serial: 4567" in result.stdout
+          and "refresh: 70" in result.stdout
+          and "retry: 89" in result.stdout
+          and "expire: 200" in result.stdout
+        )
+
+    - name: Remove test zone.
+      ipadnszone:
+        ipaadmin_password: SomeADMINpassword
+        name: testzone.local
+        state: absent
+
+    vars:
+      KRB5CCNAME: verify_bz_1876896
+
+  - name: Verify if a zone can have the the SOA serial modified to a specific value.
+    block:
+    - name: Create zone.
+      ipadnszone:
+        ipaadmin_password: SomeADMINpassword
+        name: testzone.local
+        state: present
+
+    - name: Modify zone with serial, refresh, retry and expire.
+      ipadnszone:
+        ipaadmin_password: SomeADMINpassword
+        name: testzone.local
+        serial: 4567
+        refresh: 70
+        retry: 89
+        expire: 200
+
+    - name: Verify zone was modified to the correct values
+      shell: |
+         echo SomeADMINpassword | kinit -c {{ KRB5CCNAME }} admin
+         KRB5CCNAME={{ KRB5CCNAME }} ipa dnszone-show testzone.local
+         kdestroy -A -q -c {{ KRB5CCNAME }}
+      register: result
+      failed_when: |
+        result.failed or not (
+          "serial: 4567" in result.stdout
+          and "refresh: 70" in result.stdout
+          and "retry: 89" in result.stdout
+          and "expire: 200" in result.stdout
+        )
+
+    - name: Remove test zone.
+      ipadnszone:
+        ipaadmin_password: SomeADMINpassword
+        name: testzone.local
+        state: absent
+
+    vars:
+      KRB5CCNAME: verify_bz_1876896
+
   - name: Ensure zone is present.
     ipadnszone:
       ipaadmin_password: SomeADMINpassword


### PR DESCRIPTION
Due to an issue with FreeIPA, when modifying the SOA serial attribute
along with other attributes, the value is ignored. In order to have
the value provided, the attribute is set is a later call to dnszone-mod
allowing it to retain the desired value.

Ref: https://pagure.io/freeipa/issue/8489