### PR TITLE
ansible-doc-test: Ignore unhandled paths

### DIFF
--- a/utils/ansible-doc-test
+++ b/utils/ansible-doc-test
@@ -86,8 +86,8 @@ def ansible_doc_test(path, verbose):
                 if module == "":
                     module = None
             elif len(_path) > 1:
-                print("The given path '%s' is not valid." % path)
-                sys.exit(1)
+                # Ignore other paths
+                return 0
 
         elif path in ["roles", "roles/"]:
             # roles only
@@ -97,14 +97,14 @@ def ansible_doc_test(path, verbose):
             if len(_path) == 1:
                 module = _path[0]
             else:
-                print("The given path '%s' is not valid." % path)
-                sys.exit(1)
+                # Ignore other paths
+                return 0
         elif path in ["plugins", "plugins/",
                       "plugins/modules", "plugins/modules/"]:
             only_modules = True
         else:
-            print("The given path '%s' is not valid." % path)
-            sys.exit(1)
+            # Ignore other paths
+            return 0
 
     errors = 0
     try:


### PR DESCRIPTION
Currently the script is failing with The given path '...' is not valid
if a path is not handled by the script. This is resulting in issues if
module_utils and action plugins are updated for example.

The solution is to simply ignore paths that are not handled.