### PR TITLE
ipa[server,replica]: Support memory check from command line installers

### DIFF
--- a/roles/ipareplica/README.md
+++ b/roles/ipareplica/README.md
@@ -153,6 +153,7 @@ Variable | Description | Required
 `ipareplica_no_host_dns` | Do not use DNS for hostname lookup during installation. (bool, default: false) | no
 `ipareplica_skip_conncheck` | Skip connection check to remote master. (bool, default: false) | no
 `ipareplica_pki_config_override` | Path to ini file with config overrides. This is only usable with recent FreeIPA versions. (string) | no
+`ipareplica_mem_check` | Checking for minimum required memory for the deployment.  This is only usable with recent FreeIPA versions (4.8.10+) else ignored. (bool, default: yes) | no
 
 Server Vaiables
 ---------------

--- a/roles/ipareplica/defaults/main.yml
+++ b/roles/ipareplica/defaults/main.yml
@@ -5,6 +5,7 @@
 ipareplica_no_host_dns: no
 ipareplica_skip_conncheck: no
 ipareplica_hidden_replica: no
+ipareplica_mem_check: yes
 ### server ###
 ipareplica_setup_adtrust: no
 ipareplica_setup_ca: no

--- a/roles/ipareplica/tasks/install.yml
+++ b/roles/ipareplica/tasks/install.yml
@@ -75,8 +75,10 @@
     hostname: "{{ ipareplica_hostname | default(ansible_fqdn) }}"
     ca_cert_files: "{{ ipareplica_ca_cert_files | default([]) }}"
     hidden_replica: "{{ ipareplica_hidden_replica }}"
+    skip_mem_check: "{{ not ipareplica_mem_check }}"
     ### server ###
     setup_adtrust: "{{ ipareplica_setup_adtrust }}"
+    setup_ca: "{{ ipareplica_setup_ca }}"
     setup_kra: "{{ ipareplica_setup_kra }}"
     setup_dns: "{{ ipareplica_setup_dns }}"
     no_pkinit: "{{ ipareplica_no_pkinit }}"

--- a/roles/ipaserver/README.md
+++ b/roles/ipaserver/README.md
@@ -205,6 +205,7 @@ Variable | Description | Required
 `ipaserver_realm` | The Kerberos realm of an existing IPA deployment. (string) | no
 `ipaserver_hostname` | Fully qualified name of the server. (string) | no
 `ipaserver_no_host_dns` | Do not use DNS for hostname lookup during installation. (bool, default: false) | no
+`ipaserver_mem_check` | Checking for minimum required memory for the deployment. This is only usable with recent FreeIPA versions (4.8.10+) else ignored. (bool, default: yes) | no
 
 Server Variables
 ----------------

--- a/roles/ipaserver/defaults/main.yml
+++ b/roles/ipaserver/defaults/main.yml
@@ -10,6 +10,7 @@ ipaserver_setup_dns: no
 ipaserver_no_hbac_allow: no
 ipaserver_no_pkinit: no
 ipaserver_no_ui_redirect: no
+ipaserver_mem_check: yes
 ### ssl certificate ###
 ### client ###
 ipaclient_mkhomedir: no

--- a/roles/ipaserver/module_utils/ansible_ipa_server.py
+++ b/roles/ipaserver/module_utils/ansible_ipa_server.py
@@ -37,7 +37,8 @@ __all__ = ["IPAChangeConf", "certmonger", "sysrestore", "root_logger",
            "validate_dm_password", "read_cache", "write_cache",
            "adtrustinstance", "IPAAPI_USER", "sync_time", "PKIIniLoader",
            "default_subject_base", "default_ca_subject_dn",
-           "check_ldap_conf", "encode_certificate", "decode_certificate"]
+           "check_ldap_conf", "encode_certificate", "decode_certificate",
+           "check_available_memory"]
 
 import sys
 import logging
@@ -139,6 +140,10 @@ if NUM_VERSION >= 40500:
     except ImportError:
         def default_ca_subject_dn(subject_base):
             return DN(('CN', 'Certificate Authority'), subject_base)
+    try:
+        from ipaserver.install.installutils import check_available_memory
+    except ImportError:
+        check_available_memory = None
 
     try:
         from ipaserver.install import adtrustinstance

--- a/roles/ipaserver/tasks/install.yml
+++ b/roles/ipaserver/tasks/install.yml
@@ -69,6 +69,7 @@
     ca_cert_files: "{{ ipaserver_ca_cert_files | default(omit) }}"
     no_host_dns: "{{ ipaserver_no_host_dns }}"
     pki_config_override: "{{ ipaserver_pki_config_override | default(omit) }}"
+    skip_mem_check: "{{ not ipaserver_mem_check }}"
     ### server ###
     setup_adtrust: "{{ ipaserver_setup_adtrust }}"
     setup_kra: "{{ ipaserver_setup_kra }}"


### PR DESCRIPTION
The common_check function in the replica installer code has been changed
for the new memory checker code. With this the server and replica command
line installers got the option --skip-mem-check.

The server and replica role now also support the memory cheker and there
are new variables for server and replica:

    ipaserver_mem_check - for ipaserver
    ipareplica_mem_check - for ipaserver

These bool values default to yes and can be turned off in the inventory
or playbook if needed.

Related to freeipa PR https://pagure.io/freeipa/issue/8404 (Detect and
fail if not enough memory is available for installation)

Fixes: #450 (IPA Replica Installation Fails)