### PR TITLE
yamllint: Run yaml linter only on modified files in pre-commit.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,7 @@ repos:
   rev: v1.25.0
   hooks:
   - id: yamllint
-    args: ['.']
+    files: \.(yaml|yml)$
 - repo: https://gitlab.com/pycqa/flake8
   rev: 3.8.4
   hooks:


### PR DESCRIPTION
With the parameter `args: ['.']`, yamllint would run over every
file during pre-commit, including those not being commited, and it
would allow for false negatives, not allowing a commit, even if
commited yaml files had no issues, but another file, not par of the
commit, had.

Changing the yamllint parameter to `files: \.(yaml|yml)$` it will
check only files being commited, preventing false negatives, and
allowing for faster commits.