### PR TITLE
utils/changelog: Fix get_commit to use proper variable

### DIFF
--- a/utils/changelog
+++ b/utils/changelog
@@ -87,7 +87,7 @@ def store(commits, prs, authors, commit, author, merge, msg):
 
 def get_commit(commits, commit):
     _commits = [value for key, value in commits.items()
-                if key.startswith(merge)]
+                if key.startswith(commit)]
     if len(_commits) == 1:
         return _commits[0]
     return commit


### PR DESCRIPTION
The function get_commit was using the global merge variable instead of
the local commit variable. Therefore it returned the wrong commit
subject for merges without subject.