### PR TITLE
utils/build-galaxy-release.sh: Fix default namespace and collection name

### DIFF
--- a/utils/build-galaxy-release.sh
+++ b/utils/build-galaxy-release.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-namespace="${1:freeipa}"
-collection="${2:ansible_freeipa}"
+namespace="${1-freeipa}"
+collection="${2-ansible_freeipa}"
 collection_prefix="${namespace}.${collection}"
 
 galaxy_version=$(git describe --tags | sed -e "s/^v//")


### PR DESCRIPTION
The default namespace and collection name was not set due to using ":"
instead of "-" while setting the variables internally.