### PR TITLE
ipabackup: Fix undefined vars for conditions in shell tasks without else

### DIFF
--- a/roles/ipabackup/tasks/backup.yml
+++ b/roles/ipabackup/tasks/backup.yml
@@ -4,13 +4,13 @@
 - name: Create backup
   shell: >
     ipa-backup
-    {{ "--gpg" if ipabackup_gpg | bool }}
-    {{ "--gpg-keyring="+ipabackup_gpg_keyring if ipabackup_gpg_keyring is defined }}
-    {{ "--data" if ipabackup_data | bool }}
-    {{ "--logs" if ipabackup_logs | bool }}
-    {{ "--online" if ipabackup_online | bool }}
-    {{ "--disable-role-check" if ipabackup_disable_role_check | bool }}
-    {{ "--log-file="+ipabackup_log_file if ipabackup_log_file is defined }}
+    {{ "--gpg" if ipabackup_gpg | bool else "" }}
+    {{ "--gpg-keyring="+ipabackup_gpg_keyring if ipabackup_gpg_keyring is defined else "" }}
+    {{ "--data" if ipabackup_data | bool else "" }}
+    {{ "--logs" if ipabackup_logs | bool else "" }}
+    {{ "--online" if ipabackup_online | bool else "" }}
+    {{ "--disable-role-check" if ipabackup_disable_role_check | bool else "" }}
+    {{ "--log-file="+ipabackup_log_file if ipabackup_log_file is defined else "" }}
   register: result_ipabackup
 
 - block:

--- a/roles/ipabackup/tasks/restore.yml
+++ b/roles/ipabackup/tasks/restore.yml
@@ -105,13 +105,13 @@
     ipa-restore
     {{ ipabackup_item }}
     --unattended
-    {{ "--password="+ipabackup_password if ipabackup_password is defined }}
-    {{ "--data" if ipabackup_data | bool }}
-    {{ "--online" if ipabackup_online | bool }}
-    {{ "--instance="+ipabackup_instance if ipabackup_instance is defined }}
-    {{ "--backend="+ipabackup_backend if ipabackup_backend is defined }}
-    {{ "--no-logs" if ipabackup_no_logs | bool }}
-    {{ "--log-file="+ipabackup_log_file if ipabackup_log_file is defined }}
+    {{ "--password="+ipabackup_password if ipabackup_password is defined else "" }}
+    {{ "--data" if ipabackup_data | bool else "" }}
+    {{ "--online" if ipabackup_online | bool else "" }}
+    {{ "--instance="+ipabackup_instance if ipabackup_instance is defined else "" }}
+    {{ "--backend="+ipabackup_backend if ipabackup_backend is defined else "" }}
+    {{ "--no-logs" if ipabackup_no_logs | bool else "" }}
+    {{ "--log-file="+ipabackup_log_file if ipabackup_log_file is defined else "" }}
   register: result_iparestore
   ignore_errors: yes
 
@@ -127,21 +127,21 @@
   command: >
     firewall-cmd
     --permanent
-    --zone="{{ ipabackup_firewalld_zone if ipabackup_firewalld_zone is defined }}"
+    {{ "--zone="+ipabackup_firewalld_zone if ipabackup_firewalld_zone is defined else "" }}
     --add-service=freeipa-ldap
     --add-service=freeipa-ldaps
-    {{ "--add-service=freeipa-trust" if ipabackup_service_adtrust in ipabackup_services }}
-    {{ "--add-service=dns" if ipabackup_service_dns in ipabackup_services }}
-    {{ "--add-service=ntp" if ipabackup_service_ntp in ipabackup_services }}
+    {{ "--add-service=freeipa-trust" if ipabackup_service_adtrust in ipabackup_services else "" }}
+    {{ "--add-service=dns" if ipabackup_service_dns in ipabackup_services else "" }}
+    {{ "--add-service=ntp" if ipabackup_service_ntp in ipabackup_services else "" }}
   when: ipabackup_setup_firewalld | bool
 
 - name: Configure firewalld runtime
   command: >
     firewall-cmd
-    --zone="{{ ipabackup_firewalld_zone if ipabackup_firewalld_zone is defined }}"
+    {{ "--zone="+ipabackup_firewalld_zone if ipabackup_firewalld_zone is defined else "" }}
     --add-service=freeipa-ldap
     --add-service=freeipa-ldaps
-    {{ "--add-service=freeipa-trust" if ipabackup_service_adtrust in ipabackup_services }}
-    {{ "--add-service=dns" if ipabackup_service_dns in ipabackup_services }}
-    {{ "--add-service=ntp" if ipabackup_service_ntp in ipabackup_services }}
+    {{ "--add-service=freeipa-trust" if ipabackup_service_adtrust in ipabackup_services else "" }}
+    {{ "--add-service=dns" if ipabackup_service_dns in ipabackup_services else "" }}
+    {{ "--add-service=ntp" if ipabackup_service_ntp in ipabackup_services else "" }}
   when: ipabackup_setup_firewalld | bool


### PR DESCRIPTION
The use of conditions in shell tasks without else clause is failing on
some systems with an undefined variable error.