### PR TITLE
Fix changing the type of an existing Vault.

### DIFF
--- a/tests/vault/env_cleanup.yml
+++ b/tests/vault/env_cleanup.yml
@@ -38,35 +38,27 @@
       name: vaultgroup
       state: absent
 
-  - name: Remove password file from target host.
+  - name: Remove files from target host.
     file:
-      path: "{{ ansible_env.HOME }}/password.txt"
+      path: "{{ ansible_env.HOME }}/{{ item }}"
       state: absent
+    with_items:
+    - private.pem
+    - public.pem
+    - old_private.pem
+    - old_public.pem
+    - password.txt
+    - data.txt
+    - in.txt
 
-  - name: Remove public key file from target host.
+  - name: Remove files from controller.
     file:
-      path: "{{ ansible_env.HOME }}/public.pem"
+      path: "{{ playbook_dir }}/{{ item }}"
       state: absent
-
-  - name: Remove private key file from target host.
-    file:
-      path: "{{ ansible_env.HOME }}/private.pem"
-      state: absent
-
-  - name: Remove output data file from target host.
-    file:
-      path: "{{ ansible_env.HOME }}/data.txt"
-      state: absent
-
-  - name: Remove input data file from target host.
-    file:
-      path: "{{ ansible_env.HOME }}/in.txt"
-      state: absent
-
-  - name: Remove private/public key files.
-    shell:
-      cmd: rm -f private.pem public.pem
     delegate_to: localhost
     become: no
-    args:
-      warn: no  # suppres warning for not using the `file` module.
+    with_items:
+    - private.pem
+    - public.pem
+    - old_private.pem
+    - old_public.pem

--- a/tests/vault/env_cleanup.yml
+++ b/tests/vault/env_cleanup.yml
@@ -43,13 +43,17 @@
       path: "{{ ansible_env.HOME }}/{{ item }}"
       state: absent
     with_items:
-    - private.pem
-    - public.pem
-    - old_private.pem
-    - old_public.pem
+    - A_private.pem
+    - A_public.pem
+    - B_private.pem
+    - B_public.pem
+    - A_private.b64
+    - A_public.b64
+    - B_private.b64
+    - B_public.b64
     - password.txt
-    - data.txt
     - in.txt
+    - out.txt
 
   - name: Remove files from controller.
     file:
@@ -58,7 +62,11 @@
     delegate_to: localhost
     become: no
     with_items:
-    - private.pem
-    - public.pem
-    - old_private.pem
-    - old_public.pem
+    - A_private.pem
+    - A_public.pem
+    - B_private.pem
+    - B_public.pem
+    - A_private.b64
+    - A_public.b64
+    - B_private.b64
+    - B_public.b64

--- a/tests/vault/env_setup.yml
+++ b/tests/vault/env_setup.yml
@@ -8,21 +8,27 @@
       cmd: |
         openssl genrsa -out "{{ item }}private.pem" 2048
         openssl rsa -in "{{ item }}private.pem" -outform PEM -pubout -out "{{ item }}public.pem"
+        base64 "{{ item }}public.pem" -w5000 > "{{ item }}public.b64"
+        base64 "{{ item }}private.pem" -w5000 > "{{ item }}private.b64"
     delegate_to: localhost
     become: no
     with_items:
-    - ""
-    - old_
+    - A_
+    - B_
 
   - name: Copy files to target host.
     copy:
       src: "{{ playbook_dir }}/{{ item }}"
       dest: "{{ ansible_env.HOME }}/{{ item }}"
     with_items:
-    - private.pem
-    - public.pem
-    - old_private.pem
-    - old_public.pem
+    - A_private.pem
+    - A_public.pem
+    - B_private.pem
+    - B_public.pem
+    - A_private.b64
+    - A_public.b64
+    - B_private.b64
+    - B_public.b64
     - password.txt
     - in.txt
 

--- a/tests/vault/env_setup.yml
+++ b/tests/vault/env_setup.yml
@@ -3,37 +3,28 @@
   - name: Ensure environment is clean.
     import_tasks: env_cleanup.yml
 
-  - name: Create private key file.
+  - name: Create private/public key pair.
     shell:
-      cmd: openssl genrsa -out private.pem 2048
+      cmd: |
+        openssl genrsa -out "{{ item }}private.pem" 2048
+        openssl rsa -in "{{ item }}private.pem" -outform PEM -pubout -out "{{ item }}public.pem"
     delegate_to: localhost
     become: no
+    with_items:
+    - ""
+    - old_
 
-  - name: Create public key file.
-    shell:
-      cmd: openssl rsa -in private.pem -outform PEM -pubout -out public.pem
-    delegate_to: localhost
-    become: no
-
-  - name: Copy password file to target host.
+  - name: Copy files to target host.
     copy:
-      src: "{{ playbook_dir }}/password.txt"
-      dest: "{{ ansible_env.HOME }}/password.txt"
-
-  - name: Copy public key file to target host.
-    copy:
-      src: "{{ playbook_dir }}/public.pem"
-      dest: "{{ ansible_env.HOME }}/public.pem"
-
-  - name: Copy private key file to target host.
-    copy:
-      src: "{{ playbook_dir }}/private.pem"
-      dest: "{{ ansible_env.HOME }}/private.pem"
-
-  - name: Copy input data file to target host.
-    copy:
-      src: "{{ playbook_dir }}/in.txt"
-      dest: "{{ ansible_env.HOME }}/in.txt"
+      src: "{{ playbook_dir }}/{{ item }}"
+      dest: "{{ ansible_env.HOME }}/{{ item }}"
+    with_items:
+    - private.pem
+    - public.pem
+    - old_private.pem
+    - old_public.pem
+    - password.txt
+    - in.txt
 
   - name: Ensure vaultgroup exists.
     ipagroup:

--- a/tests/vault/tasks_vault_members.yml
+++ b/tests/vault/tasks_vault_members.yml
@@ -25,9 +25,9 @@
   - name: Ensure vault is present
     ipavault:
       ipaadmin_password: SomeADMINpassword
-      name: "{{vault.name}}"
-      vault_type: "{{vault.vault_type}}"
-      public_key: "{{lookup('file', 'private.pem', rstrip=False) | b64encode}}"
+      name: "{{ vault.name }}"
+      vault_type: "{{ vault.vault_type }}"
+      public_key: "{{lookup('file', 'A_private.b64')}}"
     register: result
     failed_when: not result.changed
     when: vault.vault_type == 'asymmetric'

--- a/tests/vault/test_vault_asymmetric.yml
+++ b/tests/vault/test_vault_asymmetric.yml
@@ -14,7 +14,7 @@
       ipaadmin_password: SomeADMINpassword
       name: asymvault
       vault_type: asymmetric
-      public_key: "{{ lookup('file', 'old_public.pem', rstrip=True) | b64encode }}"
+      public_key: "{{ lookup('file', 'A_public.b64') }}"
     register: result
     failed_when: result.failed or not result.changed
 
@@ -23,11 +23,11 @@
       ipaadmin_password: SomeADMINpassword
       name: asymvault
       vault_type: asymmetric
-      public_key: "{{ lookup('file', 'old_public.pem', rstrip=True) | b64encode }}"
+      public_key: "{{ lookup('file', 'A_public.b64') }}"
     register: result
     failed_when: result.failed or result.changed
 
-  - name: Archive data to asymmetric vault using "old" key.
+  - name: Archive data to asymmetric vault.
     ipavault:
       ipaadmin_password: SomeADMINpassword
       name: asymvault
@@ -35,68 +35,68 @@
     register: result
     failed_when: result.failed or not result.changed
 
-  - name: Retrieve data from asymmetric vault using "old" key.
+  - name: Retrieve data from asymmetric vault using key A.
     ipavault:
       ipaadmin_password: SomeADMINpassword
       name: asymvault
-      private_key: "{{ lookup('file', 'old_private.pem', rstrip=True) | b64encode }}"
+      private_key: "{{ lookup('file', 'A_private.b64') }}"
       state: retrieved
     register: result
     failed_when: result.failed or result.changed or result.vault.data != 'SomeValue'
 
-  - name: Change asymmetric vault key to "new" key.
+  - name: Change asymmetric vault key to B.
     ipavault:
       ipaadmin_password: SomeADMINpassword
       name: asymvault
       vault_type: asymmetric
-      public_key: "{{ lookup('file', 'public.pem', rstrip=True) | b64encode }}"
-      private_key: "{{ lookup('file', 'old_private.pem', rstrip=True) | b64encode }}"
+      public_key: "{{ lookup('file', 'B_public.b64') }}"
+      private_key: "{{ lookup('file', 'A_private.b64') }}"
     register: result
     failed_when: result.failed or not result.changed
 
-  - name: Retrieve data from asymmetric vault using "new" key.
+  - name: Retrieve data from asymmetric vault using key B.
     ipavault:
       ipaadmin_password: SomeADMINpassword
       name: asymvault
-      private_key: "{{ lookup('file', 'private.pem', rstrip=True) | b64encode }}"
+      private_key: "{{ lookup('file', 'B_private.b64') }}"
       state: retrieved
     register: result
     failed_when: result.failed or result.changed or result.vault.data != 'SomeValue'
 
-  - name: Change asymmetric vault key from_file to "old"
+  - name: Change asymmetric vault key to A, using key_file
     ipavault:
       ipaadmin_password: SomeADMINpassword
       name: asymvault
       vault_type: asymmetric
-      public_key_file: old_public.pem
-      private_key: "{{ lookup('file', 'private.pem', rstrip=True) | b64encode }}"
+      public_key_file: "{{ ansible_env.HOME }}/A_public.pem"
+      private_key: "{{ lookup('file', 'B_private.b64') }}"
     register: result
     failed_when: result.failed or not result.changed
 
-  - name: Retrieve data from asymmetric vault using old key file.
+  - name: Retrieve data from asymmetric vault using key A, with key_file.
     ipavault:
       ipaadmin_password: SomeADMINpassword
       name: asymvault
-      private_key_file: old_private.pem
+      private_key_file: "{{ ansible_env.HOME }}/A_private.pem"
       state: retrieved
     register: result
     failed_when: result.failed or result.changed or result.vault.data != 'SomeValue'
 
-  - name: Change asymmetric vault key to "new" key, using only files
+  - name: Change asymmetric vault key to B key, using key_files
     ipavault:
       ipaadmin_password: SomeADMINpassword
       name: asymvault
       vault_type: asymmetric
-      public_key_file: public.pem
-      private_key_file: old_private.pem
+      public_key_file: "{{ ansible_env.HOME }}/B_public.pem"
+      private_key_file: "{{ ansible_env.HOME }}/A_private.pem"
     register: result
     failed_when: result.failed or not result.changed
 
-  - name: Retrieve data from asymmetric vault, using new "key".
+  - name: Retrieve data from asymmetric vault, using key B.
     ipavault:
       ipaadmin_password: SomeADMINpassword
       name: asymvault
-      private_key: "{{ lookup('file', 'private.pem', rstrip=True) | b64encode }}"
+      private_key: "{{ lookup('file', 'B_private.b64') }}"
       state: retrieved
     register: result
     failed_when: result.failed or result.changed or result.vault.data != 'SomeValue'
@@ -132,7 +132,7 @@
     ipavault:
       ipaadmin_password: SomeADMINpassword
       name: asymvault
-      private_key: "{{ lookup('file', 'private.pem', rstrip=True) | b64encode }}"
+      private_key: "{{ lookup('file', 'B_private.b64') }}"
       state: retrieved
     register: result
     failed_when: result.vault.data != 'SomeADMINpassword' or result.changed
@@ -149,7 +149,7 @@
     ipavault:
       ipaadmin_password: SomeADMINpassword
       name: asymvault
-      private_key: "{{ lookup('file', 'private.pem', rstrip=True) | b64encode }}"
+      private_key: "{{ lookup('file', 'B_private.b64') }}"
       state: retrieved
     register: result
     failed_when: result.vault.data != 'Hello World.' or result.changed
@@ -159,7 +159,7 @@
       ipaadmin_password: SomeADMINpassword
       name: asymvault
       out: "{{ ansible_env.HOME }}/data.txt"
-      private_key: "{{ lookup('file', 'private.pem', rstrip=True) | b64encode }}"
+      private_key: "{{ lookup('file', 'B_private.b64') }}"
       state: retrieved
     register: result
     failed_when: result.changed or result.failed or (result.vault.data | default(false))
@@ -182,7 +182,7 @@
     ipavault:
       ipaadmin_password: SomeADMINpassword
       name: asymvault
-      private_key: "{{ lookup('file', 'private.pem', rstrip=True) | b64encode }}"
+      private_key: "{{ lookup('file', 'B_private.b64') }}"
       state: retrieved
     register: result
     failed_when: result.vault.data != 'The world of π is half rounded.' or result.changed
@@ -200,7 +200,7 @@
     ipavault:
       ipaadmin_password: SomeADMINpassword
       name: asymvault
-      private_key: "{{ lookup('file', 'private.pem', rstrip=True) | b64encode }}"
+      private_key: "{{ lookup('file', 'B_private.b64') }}"
       state: retrieved
     register: result
     failed_when: result.vault.data != 'Another World.' or result.changed
@@ -217,7 +217,7 @@
     ipavault:
       ipaadmin_password: SomeADMINpassword
       name: asymvault
-      private_key: "{{ lookup('file', 'private.pem', rstrip=True) | b64encode }}"
+      private_key: "{{ lookup('file', 'B_private.b64') }}"
       state: retrieved
     register: result
     failed_when: result.vault.data != 'c' or result.changed
@@ -242,7 +242,7 @@
     ipavault:
       ipaadmin_password: SomeADMINpassword
       name: asymvault
-      public_key_file: "{{ ansible_env.HOME }}/public.pem"
+      public_key_file: "{{ ansible_env.HOME }}/B_public.pem"
       vault_type: asymmetric
     register: result
     failed_when: not result.changed
@@ -251,7 +251,7 @@
     ipavault:
       ipaadmin_password: SomeADMINpassword
       name: asymvault
-      public_key_file: "{{ ansible_env.HOME }}/public.pem"
+      public_key_file: "{{ ansible_env.HOME }}/B_public.pem"
       vault_type: asymmetric
     register: result
     failed_when: result.changed
@@ -268,7 +268,7 @@
     ipavault:
       ipaadmin_password: SomeADMINpassword
       name: asymvault
-      private_key: "{{ lookup('file', 'private.pem', rstrip=True) | b64encode }}"
+      private_key: "{{ lookup('file', 'B_private.b64') }}"
       state: retrieved
     register: result
     failed_when: result.vault.data != 'Hello World.' or result.changed
@@ -277,7 +277,7 @@
     ipavault:
       ipaadmin_password: SomeADMINpassword
       name: asymvault
-      private_key_file: "{{ ansible_env.HOME }}/private.pem"
+      private_key_file: "{{ ansible_env.HOME }}/B_private.pem"
       state: retrieved
     register: result
     failed_when: result.vault.data != 'Hello World.' or result.changed

--- a/tests/vault/test_vault_asymmetric.yml
+++ b/tests/vault/test_vault_asymmetric.yml
@@ -14,18 +14,111 @@
       ipaadmin_password: SomeADMINpassword
       name: asymvault
       vault_type: asymmetric
-      public_key: "{{ lookup('file', 'public.pem', rstrip=False) | b64encode }}"
+      public_key: "{{ lookup('file', 'old_public.pem', rstrip=True) | b64encode }}"
     register: result
-    failed_when: not result.changed
+    failed_when: result.failed or not result.changed
 
   - name: Ensure asymmetric vault is present, again
     ipavault:
       ipaadmin_password: SomeADMINpassword
       name: asymvault
       vault_type: asymmetric
-      public_key: "{{ lookup('file', 'public.pem', rstrip=False) | b64encode }}"
+      public_key: "{{ lookup('file', 'old_public.pem', rstrip=True) | b64encode }}"
     register: result
-    failed_when: result.changed
+    failed_when: result.failed or result.changed
+
+  - name: Archive data to asymmetric vault using "old" key.
+    ipavault:
+      ipaadmin_password: SomeADMINpassword
+      name: asymvault
+      vault_data: SomeValue
+    register: result
+    failed_when: result.failed or not result.changed
+
+  - name: Retrieve data from asymmetric vault using "old" key.
+    ipavault:
+      ipaadmin_password: SomeADMINpassword
+      name: asymvault
+      private_key: "{{ lookup('file', 'old_private.pem', rstrip=True) | b64encode }}"
+      state: retrieved
+    register: result
+    failed_when: result.failed or result.changed or result.vault.data != 'SomeValue'
+
+  - name: Change asymmetric vault key to "new" key.
+    ipavault:
+      ipaadmin_password: SomeADMINpassword
+      name: asymvault
+      vault_type: asymmetric
+      public_key: "{{ lookup('file', 'public.pem', rstrip=True) | b64encode }}"
+      private_key: "{{ lookup('file', 'old_private.pem', rstrip=True) | b64encode }}"
+    register: result
+    failed_when: result.failed or not result.changed
+
+  - name: Retrieve data from asymmetric vault using "new" key.
+    ipavault:
+      ipaadmin_password: SomeADMINpassword
+      name: asymvault
+      private_key: "{{ lookup('file', 'private.pem', rstrip=True) | b64encode }}"
+      state: retrieved
+    register: result
+    failed_when: result.failed or result.changed or result.vault.data != 'SomeValue'
+
+  - name: Change asymmetric vault key from_file to "old"
+    ipavault:
+      ipaadmin_password: SomeADMINpassword
+      name: asymvault
+      vault_type: asymmetric
+      public_key_file: old_public.pem
+      private_key: "{{ lookup('file', 'private.pem', rstrip=True) | b64encode }}"
+    register: result
+    failed_when: result.failed or not result.changed
+
+  - name: Retrieve data from asymmetric vault using old key file.
+    ipavault:
+      ipaadmin_password: SomeADMINpassword
+      name: asymvault
+      private_key_file: old_private.pem
+      state: retrieved
+    register: result
+    failed_when: result.failed or result.changed or result.vault.data != 'SomeValue'
+
+  - name: Change asymmetric vault key to "new" key, using only files
+    ipavault:
+      ipaadmin_password: SomeADMINpassword
+      name: asymvault
+      vault_type: asymmetric
+      public_key_file: public.pem
+      private_key_file: old_private.pem
+    register: result
+    failed_when: result.failed or not result.changed
+
+  - name: Retrieve data from asymmetric vault, using new "key".
+    ipavault:
+      ipaadmin_password: SomeADMINpassword
+      name: asymvault
+      private_key: "{{ lookup('file', 'private.pem', rstrip=True) | b64encode }}"
+      state: retrieved
+    register: result
+    failed_when: result.failed or result.changed or result.vault.data != 'SomeValue'
+
+  - name: Change asymmetric vault key to A, without specifying vault_type.
+    ipavault:
+      ipaadmin_password: SomeADMINpassword
+      name: asymvault
+      vault_type: asymmetric
+      public_key: "{{ lookup('file', 'A_public.b64') }}"
+      private_key: "{{ lookup('file', 'B_private.b64') }}"
+    register: result
+    failed_when: result.failed or not result.changed
+
+  - name: Change asymmetric vault key to B, with key files, without specifying vault_type.
+    ipavault:
+      ipaadmin_password: SomeADMINpassword
+      name: asymvault
+      public_key_file: "{{ ansible_env.HOME }}/B_public.pem"
+      private_key_file: "{{ ansible_env.HOME }}/A_private.pem"
+    register: result
+    failed_when: result.failed or not result.changed
 
   - name: Archive data to asymmetric vault, matching `no_log` field.
     ipavault:
@@ -39,12 +132,12 @@
     ipavault:
       ipaadmin_password: SomeADMINpassword
       name: asymvault
-      private_key: "{{ lookup('file', 'private.pem', rstrip=False) | b64encode }}"
+      private_key: "{{ lookup('file', 'private.pem', rstrip=True) | b64encode }}"
       state: retrieved
     register: result
     failed_when: result.vault.data != 'SomeADMINpassword' or result.changed
 
-  - name: Archive data to asymmetric vault
+  - name: Change data in asymmetric vault
     ipavault:
       ipaadmin_password: SomeADMINpassword
       name: asymvault
@@ -52,11 +145,11 @@
     register: result
     failed_when: not result.changed
 
-  - name: Retrieve data from asymmetric vault.
+  - name: Retrieve changed data from asymmetric vault.
     ipavault:
       ipaadmin_password: SomeADMINpassword
       name: asymvault
-      private_key: "{{ lookup('file', 'private.pem', rstrip=False) | b64encode }}"
+      private_key: "{{ lookup('file', 'private.pem', rstrip=True) | b64encode }}"
       state: retrieved
     register: result
     failed_when: result.vault.data != 'Hello World.' or result.changed
@@ -66,7 +159,7 @@
       ipaadmin_password: SomeADMINpassword
       name: asymvault
       out: "{{ ansible_env.HOME }}/data.txt"
-      private_key: "{{ lookup('file', 'private.pem', rstrip=False) | b64encode }}"
+      private_key: "{{ lookup('file', 'private.pem', rstrip=True) | b64encode }}"
       state: retrieved
     register: result
     failed_when: result.changed or result.failed or (result.vault.data | default(false))
@@ -89,7 +182,7 @@
     ipavault:
       ipaadmin_password: SomeADMINpassword
       name: asymvault
-      private_key: "{{ lookup('file', 'private.pem', rstrip=False) | b64encode }}"
+      private_key: "{{ lookup('file', 'private.pem', rstrip=True) | b64encode }}"
       state: retrieved
     register: result
     failed_when: result.vault.data != 'The world of π is half rounded.' or result.changed
@@ -107,7 +200,7 @@
     ipavault:
       ipaadmin_password: SomeADMINpassword
       name: asymvault
-      private_key: "{{ lookup('file', 'private.pem', rstrip=False) | b64encode }}"
+      private_key: "{{ lookup('file', 'private.pem', rstrip=True) | b64encode }}"
       state: retrieved
     register: result
     failed_when: result.vault.data != 'Another World.' or result.changed
@@ -124,7 +217,7 @@
     ipavault:
       ipaadmin_password: SomeADMINpassword
       name: asymvault
-      private_key: "{{ lookup('file', 'private.pem', rstrip=False) | b64encode }}"
+      private_key: "{{ lookup('file', 'private.pem', rstrip=True) | b64encode }}"
       state: retrieved
     register: result
     failed_when: result.vault.data != 'c' or result.changed
@@ -175,7 +268,7 @@
     ipavault:
       ipaadmin_password: SomeADMINpassword
       name: asymvault
-      private_key: "{{ lookup('file', 'private.pem', rstrip=False) | b64encode }}"
+      private_key: "{{ lookup('file', 'private.pem', rstrip=True) | b64encode }}"
       state: retrieved
     register: result
     failed_when: result.vault.data != 'Hello World.' or result.changed
@@ -206,4 +299,4 @@
     failed_when: result.changed
 
   - name: Cleanup testing environment.
-    import_tasks: env_setup.yml
+    import_tasks: env_cleanup.yml

--- a/tests/vault/test_vault_change_type.yml
+++ b/tests/vault/test_vault_change_type.yml
@@ -1,0 +1,304 @@
+---
+- name: Test vault
+  hosts: ipaserver
+  become: true
+  # Need to gather facts for ansible_env.
+  gather_facts: true
+
+  tasks:
+  - name: Setup testing environment.
+    import_tasks: env_setup.yml
+
+  - name: Ensure test_vault is absent.
+    ipavault:
+      ipaadmin_password: SomeADMINpassword
+      name: test_vault
+      state: absent
+
+  - name: Create standard vault with no data archived.
+    ipavault:
+      ipaadmin_password: SomeADMINpassword
+      name: test_vault
+      vault_type: standard
+
+  - name: Change from standard to asymmetric
+    ipavault:
+      ipaadmin_password: SomeADMINpassword
+      name: test_vault
+      vault_type: asymmetric
+      public_key: "{{ lookup('file', 'public.pem', rstrip=True) | b64encode }}"
+    register: result
+    failed_when: result.failed or not result.changed
+
+  - block:
+    - name: Change from asymmetric to symmetric
+      ipavault:
+        ipaadmin_password: SomeADMINpassword
+        name: test_vault
+        vault_type: symmetric
+        private_key: "{{ lookup('file', 'private.pem') | b64encode }}"
+        password: SomeVAULTpassword
+      register: result
+      failed_when: result.failed or not result.changed
+
+    - name: Verify assymetric-only fields are not present.
+      shell: |
+         echo SomeADMINpassword | kinit -c {{ KRB5CCNAME }} admin
+         KRB5CCNAME={{ KRB5CCNAME }} ipa vault-show test_vault
+         kdestroy -A -q -c {{ KRB5CCNAME }}
+      register: result
+      failed_when: result.failed or "Public Key:" in result.stdout
+
+    vars:
+      KRB5CCNAME: verify_change_from_asymmetric
+
+  - block:
+    - name: Change from symmetric to standard
+      ipavault:
+        ipaadmin_password: SomeADMINpassword
+        name: test_vault
+        vault_type: standard
+        password: SomeVAULTpassword
+      register: result
+      failed_when: result.failed or not result.changed
+
+    - name: Verify salt is not present.
+      shell: |
+         echo SomeADMINpassword | kinit -c {{ KRB5CCNAME }} admin
+         KRB5CCNAME={{ KRB5CCNAME }} ipa vault-show test_vault
+         kdestroy -A -q -c {{ KRB5CCNAME }}
+      register: result
+      failed_when: result.failed or "Salt:" in result.stdout
+
+    vars:
+      KRB5CCNAME: verify_change_from_symmetric
+
+  - name: Change from standard to symmetric
+    ipavault:
+      ipaadmin_password: SomeADMINpassword
+      name: test_vault
+      vault_type: symmetric
+      password: SomeVAULTpassword
+    register: result
+    failed_when: result.failed or not result.changed
+
+  - block:
+    - name: Change from symmetric to asymmetric
+      ipavault:
+        ipaadmin_password: SomeADMINpassword
+        name: test_vault
+        vault_type: asymmetric
+        password: SomeVAULTpassword
+        public_key: "{{ lookup('file', 'public.pem') | b64encode }}"
+      register: result
+      failed_when: result.failed or not result.changed
+
+    - name: Verify salt is not present.
+      shell: |
+         echo SomeADMINpassword | kinit -c {{ KRB5CCNAME }} admin
+         KRB5CCNAME={{ KRB5CCNAME }} ipa vault-show test_vault
+         kdestroy -A -q -c {{ KRB5CCNAME }}
+      register: result
+      failed_when: result.failed or "Salt:" in result.stdout
+
+    vars:
+      KRB5CCNAME: verify_change_from_symmetric
+
+  - block:
+    - name: Change from asymmetric to standard
+      ipavault:
+        ipaadmin_password: SomeADMINpassword
+        name: test_vault
+        vault_type: standard
+        private_key: "{{ lookup('file', 'private.pem') | b64encode }}"
+      register: result
+      failed_when: result.failed or not result.changed
+
+    - name: Verify assymetric-only fields are not present.
+      shell: |
+         echo SomeADMINpassword | kinit -c {{ KRB5CCNAME }} admin
+         KRB5CCNAME={{ KRB5CCNAME }} ipa vault-show test_vault
+         kdestroy -A -q -c {{ KRB5CCNAME }}
+      register: result
+      failed_when: result.failed or "Public Key:" in result.stdout
+
+    vars:
+      KRB5CCNAME: verify_change_from_asymmetric
+
+  - name: Ensure test_vault is absent.
+    ipavault:
+      ipaadmin_password: SomeADMINpassword
+      name: test_vault
+      state: absent
+
+  - name: Create standard vault with data archived.
+    ipavault:
+      ipaadmin_password: SomeADMINpassword
+      name: test_vault
+      vault_type: standard
+      data: hello
+
+  - name: Change from standard to asymmetric, with data
+    ipavault:
+      ipaadmin_password: SomeADMINpassword
+      name: test_vault
+      vault_type: asymmetric
+      public_key: "{{ lookup('file', 'public.pem', rstrip=True) | b64encode }}"
+    register: result
+    failed_when: result.failed or not result.changed
+
+  - name: Retrieve data from asymmetric vault.
+    ipavault:
+      ipaadmin_password: SomeADMINpassword
+      name: test_vault
+      private_key: "{{ lookup('file', 'private.pem', rstrip=True) | b64encode }}"
+      state: retrieved
+    register: result
+    failed_when: result.failed or result.changed or result.vault.data != 'hello'
+
+  - block:
+    - name: Change from asymmetric to symmetric, with data
+      ipavault:
+        ipaadmin_password: SomeADMINpassword
+        name: test_vault
+        vault_type: symmetric
+        private_key: "{{ lookup('file', 'private.pem') | b64encode }}"
+        password: SomeVAULTpassword
+      register: result
+      failed_when: result.failed or not result.changed
+
+    - name: Verify assymetric-only fields are not present.
+      shell: |
+         echo SomeADMINpassword | kinit -c {{ KRB5CCNAME }} admin
+         KRB5CCNAME={{ KRB5CCNAME }} ipa vault-show test_vault
+         kdestroy -A -q -c {{ KRB5CCNAME }}
+      register: result
+      failed_when: result.failed or "Public Key:" in result.stdout
+
+    vars:
+      KRB5CCNAME: verify_change_from_asymmetric
+
+  - name: Retrieve data from symmetric vault.
+    ipavault:
+      ipaadmin_password: SomeADMINpassword
+      name: test_vault
+      password: SomeVAULTpassword
+      state: retrieved
+    register: result
+    failed_when: result.failed or result.changed or result.vault.data != 'hello'
+
+  - block:
+    - name: Change from symmetric to standard, with data
+      ipavault:
+        ipaadmin_password: SomeADMINpassword
+        name: test_vault
+        vault_type: standard
+        password: SomeVAULTpassword
+      register: result
+      failed_when: result.failed or not result.changed
+
+    - name: Verify salt is not present.
+      shell: |
+         echo SomeADMINpassword | kinit -c {{ KRB5CCNAME }} admin
+         KRB5CCNAME={{ KRB5CCNAME }} ipa vault-show test_vault
+         kdestroy -A -q -c {{ KRB5CCNAME }}
+      register: result
+      failed_when: result.failed or "Salt:" in result.stdout
+
+    vars:
+      KRB5CCNAME: verify_change_from_symmetric
+
+  - name: Retrieve data from standard vault.
+    ipavault:
+      ipaadmin_password: SomeADMINpassword
+      name: test_vault
+      state: retrieved
+    register: result
+    failed_when: result.failed or result.changed or result.vault.data != 'hello'
+
+  - name: Change from standard to symmetric, with data
+    ipavault:
+      ipaadmin_password: SomeADMINpassword
+      name: test_vault
+      vault_type: symmetric
+      password: SomeVAULTpassword
+    register: result
+    failed_when: result.failed or not result.changed
+
+  - name: Retrieve data from symmetric vault.
+    ipavault:
+      ipaadmin_password: SomeADMINpassword
+      name: test_vault
+      state: retrieved
+      password: SomeVAULTpassword
+    register: result
+    failed_when: result.failed or result.changed or result.vault.data != 'hello'
+
+  - block:
+    - name: Change from symmetric to asymmetric, with data
+      ipavault:
+        ipaadmin_password: SomeADMINpassword
+        name: test_vault
+        vault_type: asymmetric
+        password: SomeVAULTpassword
+        public_key: "{{ lookup('file', 'public.pem') | b64encode }}"
+      register: result
+      failed_when: result.failed or not result.changed
+
+    - name: Verify salt is not present.
+      shell: |
+         echo SomeADMINpassword | kinit -c {{ KRB5CCNAME }} admin
+         KRB5CCNAME={{ KRB5CCNAME }} ipa vault-show test_vault
+         kdestroy -A -q -c {{ KRB5CCNAME }}
+      register: result
+      failed_when: result.failed or "Salt:" in result.stdout
+
+    vars:
+      KRB5CCNAME: verify_change_from_symmetric
+
+  - name: Retrieve data from asymmetric vault.
+    ipavault:
+      ipaadmin_password: SomeADMINpassword
+      name: test_vault
+      state: retrieved
+      private_key: "{{ lookup('file', 'private.pem', rstrip=True) | b64encode }}"
+    register: result
+    failed_when: result.failed or result.changed or result.vault.data != 'hello'
+
+  - block:
+    - name: Change from asymmetric to standard, with data
+      ipavault:
+        ipaadmin_password: SomeADMINpassword
+        name: test_vault
+        vault_type: standard
+        private_key: "{{ lookup('file', 'private.pem') | b64encode }}"
+      register: result
+      failed_when: result.failed or not result.changed or result.failed
+
+    - name: Verify assymetric-only fields are not present.
+      shell: |
+         echo SomeADMINpassword | kinit -c {{ KRB5CCNAME }} admin
+         KRB5CCNAME={{ KRB5CCNAME }} ipa vault-show test_vault
+         kdestroy -A -q -c {{ KRB5CCNAME }}
+      register: result
+      failed_when: result.failed or "Public Key:" in result.stdout
+
+    vars:
+      KRB5CCNAME: verify_change_from_asymmetric
+
+  - name: Retrieve data from standard vault.
+    ipavault:
+      ipaadmin_password: SomeADMINpassword
+      name: test_vault
+      state: retrieved
+    register: result
+    failed_when: result.failed or result.changed or result.vault.data != 'hello'
+
+  - name: Remove test_vault.
+    ipavault:
+      ipaadmin_password: SomeADMINpassword
+      name: test_vault
+      state: absent
+
+  - name: Cleanup testing environment.
+    import_tasks: env_cleanup.yml

--- a/tests/vault/test_vault_change_type.yml
+++ b/tests/vault/test_vault_change_type.yml
@@ -26,7 +26,7 @@
       ipaadmin_password: SomeADMINpassword
       name: test_vault
       vault_type: asymmetric
-      public_key: "{{ lookup('file', 'public.pem', rstrip=True) | b64encode }}"
+      public_key: "{{ lookup('file', 'A_public.b64') }}"
     register: result
     failed_when: result.failed or not result.changed
 
@@ -36,7 +36,7 @@
         ipaadmin_password: SomeADMINpassword
         name: test_vault
         vault_type: symmetric
-        private_key: "{{ lookup('file', 'private.pem') | b64encode }}"
+        private_key: "{{ lookup('file', 'A_private.b64') }}"
         password: SomeVAULTpassword
       register: result
       failed_when: result.failed or not result.changed
@@ -89,7 +89,7 @@
         name: test_vault
         vault_type: asymmetric
         password: SomeVAULTpassword
-        public_key: "{{ lookup('file', 'public.pem') | b64encode }}"
+        public_key: "{{ lookup('file', 'A_public.b64') }}"
       register: result
       failed_when: result.failed or not result.changed
 
@@ -110,7 +110,7 @@
         ipaadmin_password: SomeADMINpassword
         name: test_vault
         vault_type: standard
-        private_key: "{{ lookup('file', 'private.pem') | b64encode }}"
+        private_key: "{{ lookup('file', 'A_private.b64') }}"
       register: result
       failed_when: result.failed or not result.changed
 
@@ -143,7 +143,7 @@
       ipaadmin_password: SomeADMINpassword
       name: test_vault
       vault_type: asymmetric
-      public_key: "{{ lookup('file', 'public.pem', rstrip=True) | b64encode }}"
+      public_key: "{{ lookup('file', 'A_public.b64') }}"
     register: result
     failed_when: result.failed or not result.changed
 
@@ -151,7 +151,7 @@
     ipavault:
       ipaadmin_password: SomeADMINpassword
       name: test_vault
-      private_key: "{{ lookup('file', 'private.pem', rstrip=True) | b64encode }}"
+      private_key: "{{ lookup('file', 'A_private.b64') }}"
       state: retrieved
     register: result
     failed_when: result.failed or result.changed or result.vault.data != 'hello'
@@ -162,7 +162,7 @@
         ipaadmin_password: SomeADMINpassword
         name: test_vault
         vault_type: symmetric
-        private_key: "{{ lookup('file', 'private.pem') | b64encode }}"
+        private_key: "{{ lookup('file', 'A_private.b64') }}"
         password: SomeVAULTpassword
       register: result
       failed_when: result.failed or not result.changed
@@ -241,7 +241,7 @@
         name: test_vault
         vault_type: asymmetric
         password: SomeVAULTpassword
-        public_key: "{{ lookup('file', 'public.pem') | b64encode }}"
+        public_key: "{{ lookup('file', 'A_public.b64') }}"
       register: result
       failed_when: result.failed or not result.changed
 
@@ -261,7 +261,7 @@
       ipaadmin_password: SomeADMINpassword
       name: test_vault
       state: retrieved
-      private_key: "{{ lookup('file', 'private.pem', rstrip=True) | b64encode }}"
+      private_key: "{{ lookup('file', 'A_private.b64') }}"
     register: result
     failed_when: result.failed or result.changed or result.vault.data != 'hello'
 
@@ -271,7 +271,7 @@
         ipaadmin_password: SomeADMINpassword
         name: test_vault
         vault_type: standard
-        private_key: "{{ lookup('file', 'private.pem') | b64encode }}"
+        private_key: "{{ lookup('file', 'A_private.b64') }}"
       register: result
       failed_when: result.failed or not result.changed or result.failed
 

--- a/tests/vault/test_vault_standard.yml
+++ b/tests/vault/test_vault_standard.yml
@@ -138,4 +138,4 @@
     failed_when: result.changed
 
   - name: Cleanup testing environment.
-    import_tasks: env_setup.yml
+    import_tasks: env_cleanup.yml

--- a/tests/vault/test_vault_symmetric.yml
+++ b/tests/vault/test_vault_symmetric.yml
@@ -43,7 +43,7 @@
       password: SomeVAULTpassword
       state: retrieved
     register: result
-    failed_when: result.vault.data != 'SomeADMINpassword' or result.changed
+    failed_when: result.changed or result.failed or result.vault.data != 'SomeADMINpassword'
 
   - name: Archive data to symmetric vault
     ipavault:
@@ -61,7 +61,7 @@
       password: SomeVAULTpassword
       state: retrieved
     register: result
-    failed_when: result.vault.data != 'Hello World.' or result.changed
+    failed_when: result.changed or result.failed or result.vault.data != 'Hello World.'
 
   - name: Retrieve data from symmetric vault into file {{ ansible_env.HOME }}/data.txt.
     ipavault:
@@ -86,7 +86,7 @@
       password: SomeVAULTpassword
       vault_data: The world of π is half rounded.
     register: result
-    failed_when: not result.changed
+    failed_when: result.failed or not result.changed
 
   - name: Retrieve data from symmetric vault.
     ipavault:
@@ -95,7 +95,7 @@
       password: SomeVAULTpassword
       state: retrieved
     register: result
-    failed_when: result.vault.data != 'The world of π is half rounded.' or result.changed
+    failed_when: result.failed or result.changed or result.vault.data != 'The world of π is half rounded.'
 
   - name: Archive data in symmetric vault, from file.
     ipavault:
@@ -104,7 +104,7 @@
       in: "{{ ansible_env.HOME }}/in.txt"
       password: SomeVAULTpassword
     register: result
-    failed_when: not result.changed
+    failed_when: result.failed or not result.changed
 
   - name: Retrieve data from symmetric vault.
     ipavault:
@@ -113,7 +113,7 @@
       password: SomeVAULTpassword
       state: retrieved
     register: result
-    failed_when: result.vault.data != 'Another World.' or result.changed
+    failed_when: result.failed or result.changed or result.vault.data != 'Another World.'
 
   - name: Archive data with single character to symmetric vault
     ipavault:
@@ -122,7 +122,7 @@
       password: SomeVAULTpassword
       vault_data: c
     register: result
-    failed_when: not result.changed
+    failed_when: result.failed or not result.changed
 
   - name: Retrieve data from symmetric vault.
     ipavault:
@@ -131,7 +131,7 @@
       password: SomeVAULTpassword
       state: retrieved
     register: result
-    failed_when: result.vault.data != 'c' or result.changed
+    failed_when: result.failed or result.changed or result.vault.data != 'c'
 
   - name: Ensure symmetric vault is absent
     ipavault:
@@ -139,7 +139,7 @@
       name: symvault
       state: absent
     register: result
-    failed_when: not result.changed
+    failed_when: result.failed or not result.changed
 
   - name: Ensure symmetric vault is absent, again
     ipavault:
@@ -147,7 +147,7 @@
       name: symvault
       state: absent
     register: result
-    failed_when: result.changed
+    failed_when: result.failed or result.changed
 
   - name: Ensure symmetric vault is present, with password from file.
     ipavault:
@@ -157,7 +157,7 @@
       password_file: "{{ ansible_env.HOME }}/password.txt"
       vault_type: symmetric
     register: result
-    failed_when: not result.changed
+    failed_when: result.failed or not result.changed
 
   - name: Ensure symmetric vault is present, with password from file, again.
     ipavault:
@@ -167,7 +167,7 @@
       password_file: "{{ ansible_env.HOME }}/password.txt"
       vault_type: symmetric
     register: result
-    failed_when: result.changed
+    failed_when: result.failed or result.changed
 
   - name: Archive data to symmetric vault
     ipavault:
@@ -176,7 +176,7 @@
       vault_data: Hello World.
       password: SomeVAULTpassword
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Retrieve data from symmetric vault.
     ipavault:
@@ -185,7 +185,7 @@
       password: SomeVAULTpassword
       state: retrieved
     register: result
-    failed_when: result.vault.data != 'Hello World.' or result.changed
+    failed_when: result.failed or result.changed or result.vault.data != 'Hello World.'
 
   - name: Retrieve data from symmetric vault, with password file.
     ipavault:
@@ -194,7 +194,7 @@
       password_file: "{{ ansible_env.HOME }}/password.txt"
       state: retrieved
     register: result
-    failed_when: result.vault.data != 'Hello World.' or result.changed
+    failed_when: result.failed or result.changed or result.vault.data != 'Hello World.'
 
   - name: Retrieve data from symmetric vault, with wrong password.
     ipavault:
@@ -203,7 +203,7 @@
       password: SomeWRONGpassword
       state: retrieved
     register: result
-    failed_when: not result.failed or "Invalid credentials" not in result.msg
+    failed_when: result.changed or not result.failed or "Invalid credentials" not in result.msg
 
   - name: Change vault password.
     ipavault:
@@ -212,7 +212,7 @@
       password: SomeVAULTpassword
       new_password: SomeNEWpassword
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Retrieve data from symmetric vault, with new password.
     ipavault:
@@ -221,7 +221,7 @@
       password: SomeNEWpassword
       state: retrieved
     register: result
-    failed_when: result.vault.data != 'Hello World.' or result.changed
+    failed_when: result.failed or result.changed or result.vault.data != 'Hello World.'
 
   - name: Retrieve data from symmetric vault, with old password.
     ipavault:
@@ -240,7 +240,7 @@
       new_password: SomeVAULTpassword
       salt: AAAAAAAAAAAAAAAAAAAAAAA=
     register: result
-    failed_when: not result.changed
+    failed_when: result.failed or not result.changed
 
   - name: Change symmetric vault salt, without changing password
     ipavault:
@@ -250,7 +250,7 @@
       new_password: SomeVAULTpassword
       salt: MTIzNDU2Nzg5MDEyMzQ1Ngo=
     register: result
-    failed_when: not result.changed
+    failed_when: result.failed or not result.changed
 
   - name: Try to change symmetric vault salt, without providing any password
     ipavault:
@@ -258,7 +258,7 @@
       name: symvault
       salt: MTIzNDU2Nzg5MDEyMzQ1Ngo=
     register: result
-    failed_when: not result.failed and  "Vault `salt` can only change when changing the password." not in result.msg
+    failed_when: not result.failed and "Vault `salt` can only change when changing the password." not in result.msg
 
   - name: Try to change symmetric vault salt, without providing `password`
     ipavault:
@@ -294,7 +294,7 @@
       name: symvault
       state: absent
     register: result
-    failed_when: not result.changed
+    failed_when: result.failed or not result.changed
 
   - name: Ensure symmetric vault is absent, again
     ipavault:
@@ -302,7 +302,7 @@
       name: symvault
       state: absent
     register: result
-    failed_when: result.changed
+    failed_when: result.failed or result.changed
 
   - name: Try to change password of inexistent vault.
     ipavault:
@@ -340,7 +340,7 @@
       password: SomeVAULTpassword
       state: retrieved
     register: result
-    failed_when: result.vault.data != 'Hello World.' or result.changed
+    failed_when: result.failed or result.changed or result.vault.data != 'Hello World.'
 
   - name: Ensure symmetric vault is absent
     ipavault:
@@ -348,7 +348,7 @@
       name: symvault
       state: absent
     register: result
-    failed_when: not result.changed
+    failed_when: result.failed or not result.changed
 
   - name: Cleanup testing environment.
     import_tasks: env_cleanup.yml


### PR DESCRIPTION
Current implementation does not allow the change of an existingi Vault
type. To allow it, data is retrieved from the current vault, the vault
is modifiend, and then, data is stored again in the new vault.

Due to changing the process of modifying a vault, this change also
fixes the update of asymmetric vault keys. To change the key used,
the task must provide the old private key, used to retrieve data,
and the new public_key, used to store the data again. A new alias
was added to public_key (new_public_key) and public_key_file
(new_public_key_file) so that the playbook better express the
intention of the tak.

Vault tests have been updated to better test against the new update
process, and a new test file has bee added:

    tests/vault/test_vault_change_type.