### PR TITLE
Faster pre-commit by running ansible-lint only when necessary.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ repos:
   rev: v4.3.5
   hooks:
   - id: ansible-lint
-    always_run: true
+    always_run: false
     pass_filenames: true
     files: \.(yaml|yml)$
     entry: env ANSIBLE_LIBRARY=./plugins/modules ANSIBLE_MODULE_UTILS=./plugins/module_utils ansible-lint --force-color


### PR DESCRIPTION
This patch disables ansible-lint `always_run` flag, as this was
making patches that did not change any YAML file take longer in
the pre-commit step, as ansible-lint was executed with no parameter,
thus, searching and evaluating all YAML files in the repository.

With this change, if no YAML file is modified, ansible-lint is skipped.