### PR TITLE
Change test requirement testinfra to pytest-testinfra.

### DIFF
--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -2,6 +2,6 @@
 pytest>=2.7
 pytest-sourceorder>=0.5
 pytest-split-tests>=1.0.3
-testinfra>=5.0
+pytest-testinfra>=5.0
 jmespath>=0.9  # needed for the `json_query` filter
 pyyaml>=3


### PR DESCRIPTION
According to the testinfra changelog, since version 6.0.0, testinfra
is know as pytest-testinfra, and the use of testinfra is deprecated.
This change will prevent future isses when updating requirements using
`pip`.

Ref: https://testinfra.readthedocs.io/en/latest/changelog.html