### PR TITLE
ipadnszone: Fix values accepted by allow_transfer and allow_query.

### DIFF
--- a/plugins/module_utils/ansible_freeipa_module.py
+++ b/plugins/module_utils/ansible_freeipa_module.py
@@ -28,6 +28,7 @@ import os
 import uuid
 import tempfile
 import shutil
+import netaddr
 import gssapi
 from datetime import datetime
 from pprint import pformat
@@ -411,6 +412,24 @@ def is_valid_port(port):
         return True
 
     return False
+
+
+def is_ip_address(ipaddr):
+    """Test if given IP address is a valid IPv4 or IPv6 address."""
+    try:
+        netaddr.IPAddress(str(ipaddr))
+    except (netaddr.AddrFormatError, ValueError):
+        return False
+    return True
+
+
+def is_ip_network_address(ipaddr):
+    """Test if given IP address is a valid IPv4 or IPv6 address."""
+    try:
+        netaddr.IPNetwork(str(ipaddr))
+    except (netaddr.AddrFormatError, ValueError):
+        return False
+    return True
 
 
 def is_ipv4_addr(ipaddr):

--- a/plugins/modules/ipadnszone.py
+++ b/plugins/modules/ipadnszone.py
@@ -210,9 +210,9 @@ dnszone:
 from ipapython.dnsutil import DNSName  # noqa: E402
 from ansible.module_utils.ansible_freeipa_module import (
     FreeIPABaseModule,
-    is_ipv4_addr,
-    is_ipv6_addr,
-    is_valid_port,
+    is_ip_address,
+    is_ip_network_address,
+    is_valid_port
 )  # noqa: E402
 import ipalib.errors
 import netaddr
@@ -252,7 +252,13 @@ class DNSZoneModule(FreeIPABaseModule):
 
     def validate_ips(self, ips, error_msg):
         invalid_ips = [
-            ip for ip in ips if not is_ipv4_addr(ip) or is_ipv6_addr(ip)
+            ip for ip in ips
+            if not any([
+                is_ip_address(ip),
+                is_ip_network_address(ip),
+                ip == "any",
+                ip == "none"
+            ])
         ]
         if any(invalid_ips):
             self.fail_json(msg=error_msg % invalid_ips)
@@ -309,7 +315,7 @@ class DNSZoneModule(FreeIPABaseModule):
             forwarders = []
             for forwarder in self.ipa_params.forwarders:
                 ip_address = forwarder.get("ip_address")
-                if not (is_ipv4_addr(ip_address) or is_ipv6_addr(ip_address)):
+                if not (is_ip_address(ip_address)):
                     self.fail_json(
                         msg="Invalid IP for DNS forwarder: %s" % ip_address
                     )


### PR DESCRIPTION
In FreeIPA CLI, The attributes `allow_query` and `allow_transfer` can
hold IPv4 or IPv6 address or network address, and the values `none` and
`any`.

This patch adds support for network addresses, `none` and `any`, which
were not supported.

Fix issue #475.