### PR TITLE
ipapermission: Fix attrs and drop privilege handling

### DIFF
--- a/README-permission.md
+++ b/README-permission.md
@@ -43,7 +43,7 @@ Example playbook to make sure permission "MyPermission" is present:
 
 ```yaml
 ---
-- name: Playbook to create an IPA permission.
+- name: Playbook to handle IPA permissions
   hosts: ipaserver
   become: yes
 
@@ -56,39 +56,61 @@ Example playbook to make sure permission "MyPermission" is present:
       right: all
 ```
 
-Example playbook to make sure permission "MyPermission" member "privilege" with value "User Administrators" is present:
+
+Example playbook to ensure permission "MyPermission" is present with attr carlicense:
 
 ```yaml
 ---
-- name: Permission add privilege to a permission
+- name: Playbook to handle IPA permissions
   hosts: ipaserver
-  become: true
+  become: yes
 
   tasks:
-  - name: Ensure permission MyPermission is present with the User Administrators privilege present
+  - name: Ensure permission "MyPermission" is present with attr carlicense
     ipapermission:
       ipaadmin_password: SomeADMINpassword
       name: MyPermission
-      privilege: "User Administrators"
+      object_type: host
+      right: all
+      attrs:
+      - carlicense
+```
+
+
+Example playbook to ensure attr gecos is present in permission "MyPermission":
+
+```yaml
+---
+- name: Playbook to handle IPA permissions
+  hosts: ipaserver
+  become: yes
+
+  tasks:
+  - name: Ensure attr gecos is present in permission "MyPermission"
+    ipapermission:
+      ipaadmin_password: SomeADMINpassword
+      name: MyPermission
+      attrs:
+      - gecos
       action: member
 ```
 
 
-Example playbook to make sure permission "MyPermission" member "privilege" with value "User Administrators" is absent:
-
+Example playbook to ensure attr gecos is absent in permission "MyPermission":
 
 ```yaml
 ---
-- name: Permission remove privilege from a permission
+- name: Playbook to handle IPA permissions
   hosts: ipaserver
-  become: true
+  become: yes
 
   tasks:
-  - name: Ensure permission MyPermission is present without the User Administrators privilege
+  - name: Ensure attr gecos is present in permission "MyPermission"
     ipapermission:
       ipaadmin_password: SomeADMINpassword
       name: MyPermission
-      privilege: "User Administrators"
+      attrs:
+      - gecos
       action: member
       state: absent
 ```
@@ -98,34 +120,35 @@ Example playbook to make sure permission "MyPermission" is absent:
 
 ```yaml
 ---
-- name: Playbook to manage IPA permission.
+- name: Playbook to handle IPA permissions
   hosts: ipaserver
   become: yes
 
   tasks:
-  - ipapermission:
+  - name: Ensure permission "MyPermission" is absent
+    ipapermission:
       ipaadmin_password: SomeADMINpassword
       name: MyPermission
       state: absent
 ```
 
+
 Example playbook to make sure permission "MyPermission" is renamed to "MyNewPermission":
 
 ```yaml
 ---
-- name: Playbook to manage IPA permission.
+- name: Playbook to handle IPA permissions
   hosts: ipaserver
   become: yes
 
   tasks:
-  - ipapermission:
+  - name: Eure permission "MyPermission" is renamed to "MyNewPermission
+    ipapermission:
       ipaadmin_password: SomeADMINpassword
       name: MyPermission
       rename: MyNewPermission
       state: renamed
 ```
-
-
 
 
 Variables
@@ -140,7 +163,7 @@ Variable | Description | Required
 `ipaadmin_password` | The admin password is a string and is required if there is no admin ticket available on the node | no
 `name` \| `cn` | The permission name string. | yes
 `right` \| `ipapermright` | Rights to grant. It can be a list of one or more of `read`, `search`, `compare`, `write`, `add`, `delete`, and `all` default: `all` | no
-`attrs` | All attributes to which the permission applies | no
+`attrs` | All attributes to which the permission applies. | no
 `bindtype` \| `ipapermbindruletype` | Bind rule type. It can be one of `permission`, `all`, `self`, or `anonymous` defaults to `permission` for new permissions. Bind rule type `self` can only be used on IPA versions 4.8.7 or up.| no
 `subtree` \| `ipapermlocation` | Subtree to apply permissions to | no
 `filter` \| `extratargetfilter` | Extra target filter | no
@@ -153,9 +176,11 @@ Variable | Description | Required
 `object_type` | Type of IPA object (sets subtree and objectClass targetfilter) | no
 `no_members` | Suppress processing of membership | no
 `rename` | Rename the permission object | no
-`privilege` | Member Privilege of Permission | no
 `action` | Work on permission or member level. It can be on of `member` or `permission` and defaults to `permission`. | no
 `state` | The state to ensure. It can be one of `present`, `absent`, or `renamed` default: `present`. | no
+
+The `includedattrs` and `excludedattrs` variables are only usable for managed permisions and are not exposed by the module. Using `attrs` for managed permissions will result in the automatic generation of `includedattrs` and `excludedattrs` in the IPA server.
+
 
 Authors
 =======

--- a/tests/permission/test_permission.yml
+++ b/tests/permission/test_permission.yml
@@ -37,41 +37,127 @@
     register: result
     failed_when: result.changed or result.failed
 
-  - name: Ensure permission perm-test-1 member User Administrators privilege is present
+  - name: Ensure permission perm-test-1 is present with attr carlicense
     ipapermission:
       ipaadmin_password: SomeADMINpassword
       name: perm-test-1
-      privilege: "User Administrators"
+      attrs:
+      - carlicense
+    register: result
+    failed_when: not result.changed or result.failed
+
+  - name: Ensure permission perm-test-1 is present with attr carlicense again
+    ipapermission:
+      ipaadmin_password: SomeADMINpassword
+      name: perm-test-1
+      attrs:
+      - carlicense
+    register: result
+    failed_when: result.changed or result.failed
+
+  - name: Ensure permission perm-test-1 is present with attr carlicense and displayname
+    ipapermission:
+      ipaadmin_password: SomeADMINpassword
+      name: perm-test-1
+      attrs:
+      - carlicense
+      - displayname
+    register: result
+    failed_when: not result.changed or result.failed
+
+  - name: Ensure permission perm-test-1 is present with attr carlicense and displayname again
+    ipapermission:
+      ipaadmin_password: SomeADMINpassword
+      name: perm-test-1
+      attrs:
+      - carlicense
+      - displayname
+    register: result
+    failed_when: result.changed or result.failed
+
+  - name: Ensure attr gecos is present in permission perm-test-1
+    ipapermission:
+      ipaadmin_password: SomeADMINpassword
+      name: perm-test-1
+      attrs:
+      - gecos
       action: member
     register: result
     failed_when: not result.changed or result.failed
 
-  - name: Ensure permission perm-test-1 member User Administrators privilege is present again
+  - name: Ensure attr gecos is present in permission perm-test-1 again
     ipapermission:
       ipaadmin_password: SomeADMINpassword
       name: perm-test-1
-      privilege: "User Administrators"
+      attrs:
+      - gecos
       action: member
     register: result
     failed_when: result.changed or result.failed
 
-  - name: Ensure permission perm-test-1 member User Administrators privilege is absent
+  - name: Ensure attr gecos is absent in permission perm-test-1
     ipapermission:
       ipaadmin_password: SomeADMINpassword
       name: perm-test-1
-      privilege: "User Administrators"
+      attrs:
+      - gecos
       action: member
       state: absent
     register: result
     failed_when: not result.changed or result.failed
 
-  # NOTE: We use the "User Administrators" Privilege here since we don't have a module
-  # to make one. A test privilege should be used in the future.
-  - name: Ensure permission perm-test-1 member User Administrators privilege is absent again
+  - name: Ensure attr gecos is absent in permission perm-test-1 again
     ipapermission:
       ipaadmin_password: SomeADMINpassword
       name: perm-test-1
-      privilege: "User Administrators"
+      attrs:
+      - gecos
+      action: member
+      state: absent
+    register: result
+    failed_when: result.changed or result.failed
+
+  - name: Ensure attributes carlicense and displayname are present in permission "System{{':'}} Update DNS Entries"
+    ipapermission:
+      ipaadmin_password: SomeADMINpassword
+      name: "System: Update DNS Entries"
+      attrs:
+      - carlicense
+      - displayname
+      action: member
+    register: result
+    failed_when: not result.changed or result.failed
+
+  - name: Ensure attributes carlicense and displayname are present in permission "System{{':'}} Update DNS Entries" again
+    ipapermission:
+      ipaadmin_password: SomeADMINpassword
+      name: "System: Update DNS Entries"
+      attrs:
+      - carlicense
+      - displayname
+      action: member
+    register: result
+    failed_when: result.changed or result.failed
+
+  - name: Ensure attributes carlicense and displayname are present in permission "System{{':'}} Update DNS Entries"
+    ipapermission:
+      ipaadmin_password: SomeADMINpassword
+      name: "System: Update DNS Entries"
+      attrs:
+      - carlicense
+      - displayname
+      action: member
+      state: absent
+    register: result
+    failed_when: not result.changed or result.failed
+
+  - name: Ensure attributes carlicense and displayname are present in permission "System{{':'}} Update DNS Entries" again
+    ipapermission:
+      ipaadmin_password: SomeADMINpassword
+      name: "System: Update DNS Entries"
+      attrs:
+      - carlicense
+      - displayname
       action: member
       state: absent
     register: result


### PR DESCRIPTION
The attrs handling was not complete and did not support to ensure presence
or absence of attributes with action:member.

The includedattrs and excludedattrs parameters have not been added with
this change as the use of attrs will automatically set includedattrs and
excludedattrs. The includedattrs and excludedattrs parameters are only
usable for managed permissions and duplicating attrs.

The permission module may not handle privileges. An IPA internal only API
has been used for this. The prvilege variable and all related code paths
have been removed.

Fixes: #424 ([Permission Handling] Not able to add additional attributes
             with existing attributes)
Fixes: #425 ([Permission Handling] Not able to add member privilege while
             adding permission)