### PR TITLE
add modules to manage automount management in ipa

### DIFF
--- a/README-automountkey.md
+++ b/README-automountkey.md
@@ -1,0 +1,88 @@
+Automountkey module
+=====================
+
+Description
+-----------
+
+The automountkey module allows the addition and removal of keys within an automount map. 
+
+It is desgined to follow the IPA api as closely as possible while ensuring ease of use.
+
+
+Features
+--------
+* Automount key management
+
+Supported FreeIPA Versions
+--------------------------
+
+FreeIPA versions 4.4.0 and up are supported by the ipaautomountkey module.
+
+Requirements
+------------
+**Controller**
+* Ansible version: 2.8+
+
+**Node**
+* Supported FreeIPA version (see above)
+
+
+Usage
+=====
+
+Example inventory file
+
+```ini
+[ipaserver]
+ipaserver.test.local
+```
+
+
+Example playbook to ensure presence of an automount map:
+
+```yaml
+---
+- name: Playbook to add an automount map
+  hosts: ipaserver
+  become: true
+
+  tasks:
+  - name: create key TestKey
+    ipaautomountkey:
+      ipaadmin_password: password01
+      locationcn: TestLocation
+      mapname: TestMap
+      key: TestKey
+      info: 192.168.122.1:/exports
+      state: present
+
+  - name: ensure key TestKey is absent
+    ipaautomountkey:
+      ipaadmin_password: password01
+      location: TestLocation
+      mapname: TestMap
+      key: TestKey
+      state: absent
+```
+
+Variables
+=========
+
+ipaautomountkey
+-------
+
+Variable | Description | Required
+-------- | ----------- | --------
+`ipaadmin_principal` | The admin principal is a string and defaults to `admin` | no
+`ipaadmin_password` | The admin password is a string and is required if there is no admin ticket available on the node | no
+`mapname` \| `cn` \| `name` \| `map` \| `automountkeyname` | Location name. | yes 
+`location` \| `automountlocationcn` | Location name. | yes 
+`key` \| `name` \| `automountkey` | Automount key to manage | yes 
+`info` \| `information` \| `automountinformation` | Mount information for the key | yes when state is `present`
+`state` | The state to ensure. It can be one of `present`, or `absent`, default: `present`. | no
+
+
+Authors
+=======
+
+Chris Procter

--- a/README-automountlocation.md
+++ b/README-automountlocation.md
@@ -1,0 +1,75 @@
+Automountlocation module
+=====================
+
+Description
+-----------
+
+The automountlocation module allows the addition and removal of locations for automount maps
+
+It is desgined to follow the IPA api as closely as possible while ensuring ease of use.
+
+
+Features
+--------
+* Automount location management
+
+Supported FreeIPA Versions
+--------------------------
+
+FreeIPA versions 4.4.0 and up are supported by the ipaautomountlocation module.
+
+Requirements
+------------
+**Controller**
+* Ansible version: 2.8+
+
+**Node**
+* Supported FreeIPA version (see above)
+
+
+Usage
+=====
+
+Example inventory file
+
+```ini
+[ipaserver]
+ipaserver.test.local
+```
+
+
+Example playbook to ensure presence of an automount location:
+
+```yaml
+---
+- name: Playbook to add an automount location
+  hosts: ipaserver
+  become: true
+
+  tasks:
+  - name: ensure a automount location named DMZ exists
+    ipaautomountlocation:
+      ipaadmin_password: password01
+      name: DMZ
+      state: present
+
+```
+
+Variables
+=========
+
+ipaautomountlocation
+-------
+
+Variable | Description | Required
+-------- | ----------- | --------
+`ipaadmin_principal` | The admin principal is a string and defaults to `admin` | no
+`ipaadmin_password` | The admin password is a string and is required if there is no admin ticket available on the node | no
+`name` \| `cn` \| `location` | Location name. | yes 
+`state` | The state to ensure. It can be one of `present`, or `absent`, default: `present`. | no
+
+
+Authors
+=======
+
+Chris Procter

--- a/README-automountmap.md
+++ b/README-automountmap.md
@@ -1,0 +1,78 @@
+Automountmap module
+=====================
+
+Description
+-----------
+
+The automountmap module allows the addition and removal of maps within automount locations. 
+
+It is desgined to follow the IPA api as closely as possible while ensuring ease of use.
+
+
+Features
+--------
+* Automount map management
+
+Supported FreeIPA Versions
+--------------------------
+
+FreeIPA versions 4.4.0 and up are supported by the ipaautomountmap module.
+
+Requirements
+------------
+**Controller**
+* Ansible version: 2.8+
+
+**Node**
+* Supported FreeIPA version (see above)
+
+
+Usage
+=====
+
+Example inventory file
+
+```ini
+[ipaserver]
+ipaserver.test.local
+```
+
+
+Example playbook to ensure presence of an automount map:
+
+```yaml
+---
+- name: Playbook to add an automount map
+  hosts: ipaserver
+  become: true
+
+  tasks:
+  - name: ensure map named auto.DMZ in location DMZ is created
+    ipaautomountmap:
+      ipaadmin_password: password01
+      name: auto.DMZ
+      location: DMZ
+      desc: "this is a map for servers in the DMZ"
+
+```
+
+Variables
+=========
+
+ipaautomountmap
+-------
+
+Variable | Description | Required
+-------- | ----------- | --------
+`ipaadmin_principal` | The admin principal is a string and defaults to `admin` | no
+`ipaadmin_password` | The admin password is a string and is required if there is no admin ticket available on the node | no
+`mapname` \| `cn` \| `name` \| `map` \| `automountmapname` | Location name. | yes 
+`location` \| `automountlocationcn` | Location name. | yes 
+`desc` \| `description` | Description of the map | yes 
+`state` | The state to ensure. It can be one of `present`, or `absent`, default: `present`. | no
+
+
+Authors
+=======
+
+Chris Procter

--- a/plugins/modules/ipaautomountkey.py
+++ b/plugins/modules/ipaautomountkey.py
@@ -1,0 +1,192 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Authors:
+#   Chris Procter <cprocter@redhat.com>
+#
+# Copyright (C) 2019 Red Hat
+# see file 'COPYING' for use and warranty information
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+ANSIBLE_METADATA = {
+    "metadata_version": "1.0",
+    "supported_by": "community",
+    "status": ["preview"],
+}
+
+
+DOCUMENTATION = '''
+---
+module: ipa_automountmap
+author: chris procter
+short_description: Manage FreeIPA autommount map
+description:
+- Add, delete, and modify an IPA automount map
+options:
+  ipaadmin_principal:
+    description: The admin principal
+    default: admin
+  ipaadmin_password:
+    description: The admin password
+    required: false
+  location:
+    description: automount location map is in
+    required: True
+    choices: ["automountlocationcn"]
+  mapname:
+    description: automount map to be managed
+    choices: ["map", "automountmapname"],
+    required: True
+  key:
+    description: automount key to be managed
+    required: true,
+    choicesr: ["name", "automountkey" ]
+  info:
+    description: Mount information for the key
+    required: true when state is 'present'
+    choices: ["information","automountinformation"]
+  state:
+    description: State to ensure
+    required: false
+    default: present
+    choices: ["present", "absent"]
+'''
+
+EXAMPLES = '''
+  - name: create key TestKey
+    ipaautomountkey:
+      ipaadmin_password: password01
+      locationcn: TestLocation
+      mapname: TestMap
+      key: TestKey
+      info: 192.168.122.1:/exports
+      state: present
+
+  - name: ensure key TestKey is absent
+    ipaautomountkey:
+      ipaadmin_password: password01
+      location: TestLocation
+      mapname: TestMap
+      key: TestKey
+      state: absent
+'''
+
+RETURN = '''
+'''
+
+
+from ansible.module_utils.ansible_freeipa_module import FreeIPABaseModule
+
+
+class AutomountLocation(FreeIPABaseModule):
+
+    ipa_param_mapping = {
+        'automountkey': "key",
+        'automountmapautomountmapname': "mapname",
+    }
+
+    def get_key(self, name, args):
+        response = dict()
+        try:
+            response = self.api_command("automountkey_find", name, args)
+        except Exception:
+            pass
+
+        if response.get("count", 0) == 1:
+            self.key = response["result"][0]
+        else:
+            self.key = None
+        return self.key
+
+    def check_ipa_params(self):
+        if not self.ipa_params.info and self.ipa_params.state == "present":
+            self.fail_json(msg="Value required for argument 'info'")
+
+    @property
+    def location_name(self):
+        return self.ipa_params.location
+
+    @property
+    def automountinformation(self):
+        return self.key.get('automountinformation', [None])[0]
+
+    def define_ipa_commands(self):
+        args = self.get_ipa_command_args()
+        self.get_key(self.location_name, args)
+
+        if not self.key and self.ipa_params.state == "present":
+            # does not exist and is wanted
+            args["automountinformation"] = self.ipa_params.info
+            self.add_ipa_command(
+                "automountkey_add",
+                name=self.location_name,
+                args=args
+            )
+        elif self.key is not None and self.ipa_params.state == "present":
+            # exists and is wanted, check for changes
+            if self.ipa_params.info != self.automountinformation:
+                args["newautomountinformation"] = self.ipa_params.info
+                self.add_ipa_command(
+                    "automountkey_mod",
+                    name=self.location_name,
+                    args=args
+                )
+        elif self.key and self.ipa_params.state == "absent":
+            # exists and is not wanted
+            self.add_ipa_command(
+                "automountkey_del",
+                name=self.location_name,
+                args=args
+            )
+
+
+def main():
+    ipa_module = AutomountLocation(
+        argument_spec=dict(
+            ipaadmin_principal=dict(type="str",
+                                    default="admin"
+                                    ),
+            ipaadmin_password=dict(type="str",
+                                   required=False,
+                                   no_log=True
+                                   ),
+            state=dict(type='str',
+                       default='present',
+                       choices=['present', 'absent']
+                       ),
+            location=dict(type="str",
+                          aliases=["automountlocationcn"],
+                          default=None,
+                          required=True
+                          ),
+            mapname=dict(type="str",
+                         aliases=["map", "automountmapname"],
+                         default=None,
+                         required=True
+                         ),
+            key=dict(type="str",
+                     required=True,
+                     aliases=["name", "automountkey"]
+                     ),
+            info=dict(type="str",
+                      aliases=["information", "automountinformation"]
+                      ),
+        ),
+    )
+    ipa_module.ipa_run()
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/ipaautomountlocation.py
+++ b/plugins/modules/ipaautomountlocation.py
@@ -1,0 +1,137 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+# Authors:
+#   Chris Procter <cprocter@redhat.com>
+#
+# Copyright (C) 2019 Red Hat
+# see file 'COPYING' for use and warranty information
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+ANSIBLE_METADATA = {
+    "metadata_version": "1.0",
+    "supported_by": "community",
+    "status": ["preview"],
+}
+
+
+DOCUMENTATION = '''
+---
+module: ipa_automountlocation
+author: chris procter
+short_description: Manage FreeIPA autommount locations
+description:
+- Add and delete an IPA automount location
+options:
+  ipaadmin_principal:
+    description: The admin principal
+    default: admin
+  ipaadmin_password:
+    description: The admin password
+    required: false
+  name:
+    description: The automount location to be managed
+    required: true
+    aliases: ["cn","location"]
+  state:
+    description: State to ensure
+    required: false
+    default: present
+    choices: ["present", "absent"]
+'''
+
+EXAMPLES = '''
+  - name: ensure a automount location named DMZ exists
+    ipaautomountlocation:
+      ipaadmin_password: password01
+      name: DMZ
+      state: present
+
+  - name: remove an automount location named DMZ if it exists
+    ipaautomountlocation:
+      ipaadmin_password: password01
+      name: DMZ
+      state: absent
+'''
+
+RETURN = '''
+'''
+
+from ansible.module_utils.ansible_freeipa_module import FreeIPABaseModule
+
+
+class AutomountLocation(FreeIPABaseModule):
+
+    ipa_param_mapping = {}
+
+    def get_location(self, location):
+        response = self.api_command("automountlocation_find",
+                                    location,
+                                    args={"cn": location})
+
+        if response["count"] == 1:
+            self.location = response["result"][0]
+        else:
+            self.location = None
+        return self.location
+
+    @property
+    def location_name(self):
+        return self.ipa_params.name
+
+    def define_ipa_commands(self):
+        self.get_location(self.location_name)
+
+        if not self.location and self.ipa_params.state == "present":
+            # does not exist and is wanted
+            self.add_ipa_command(
+                "automountlocation_add",
+                name=self.location_name,
+                args=None,
+            )
+        elif self.location and self.ipa_params.state == "absent":
+            # exists and is not wanted
+            self.add_ipa_command(
+                "automountlocation_del",
+                name=self.location_name,
+                args=None,
+            )
+
+
+def main():
+    ipa_module = AutomountLocation(
+        argument_spec=dict(
+            ipaadmin_principal=dict(type="str",
+                                    default="admin"
+                                    ),
+            ipaadmin_password=dict(type="str",
+                                   required=False,
+                                   no_log=True
+                                   ),
+            state=dict(type='str',
+                       default='present',
+                       choices=['present', 'absent']
+                       ),
+            name=dict(type="str",
+                      aliases=["cn", "location"],
+                      default=None,
+                      required=True
+                      ),
+        ),
+    )
+    ipa_module.ipa_run()
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/ipaautomountmap.py
+++ b/plugins/modules/ipaautomountmap.py
@@ -1,0 +1,174 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+# Authors:
+#   Chris Procter <cprocter@redhat.com>
+#
+# Copyright (C) 2019 Red Hat
+# see file 'COPYING' for use and warranty information
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+ANSIBLE_METADATA = {
+    "metadata_version": "1.0",
+    "supported_by": "community",
+    "status": ["preview"],
+}
+
+
+DOCUMENTATION = '''
+---
+module: ipa_automountmap
+author: chris procter
+short_description: Manage FreeIPA autommount map
+description:
+- Add, delete, and modify an IPA automount map
+options:
+  ipaadmin_principal:
+    description: The admin principal
+    default: admin
+  ipaadmin_password:
+    description: The admin password
+    required: false
+  location:
+    description: automount location map is in
+    required: True
+    choices: ["automountlocationcn"]
+  mapname:
+    description: automount map to be managed
+    choices: ["cn", "name", "map", "automountmapname"],
+    required: True
+  desc:
+    choices: ["description"],
+    required: false
+  state:
+    description: State to ensure
+    required: false
+    default: present
+    choices: ["present", "absent"]
+'''
+
+EXAMPLES = '''
+  - name: ensure map named auto.DMZ in location DMZ is created
+    ipaautomountmap:
+      ipaadmin_password: password01
+      name: auto.DMZ
+      location: DMZ
+      desc: "this is a map for servers in the DMZ"
+
+  - name: remove a map named auto.DMZ in location DMZ if it exists
+    ipaautomountmap:
+      ipaadmin_password: password01
+      name: auto.DMZ
+      location: DMZ
+      state: absent
+'''
+
+RETURN = '''
+'''
+
+from ansible.module_utils.ansible_freeipa_module import FreeIPABaseModule
+
+
+class AutomountLocation(FreeIPABaseModule):
+
+    ipa_param_mapping = {
+        "automountmapname": "mapname",
+    }
+
+    def get_map(self, location, args):
+        response = dict()
+        try:
+            # if the location doesn't exists this throws an error
+            # rather than just returning nothing
+            response = self.api_command("automountmap_find",
+                                        location,
+                                        args)
+        except Exception:
+            pass
+
+        if response.get("count", 0) == 1:
+            self.map = response["result"][0]
+        else:
+            self.map = None
+        return self.map
+
+    @property
+    def location_name(self):
+        return self.ipa_params.location
+
+    def define_ipa_commands(self):
+        args = self.get_ipa_command_args()
+        self.get_map(self.location_name, args)
+
+        if not self.map and self.ipa_params.state == "present":
+            # does not exist and is wanted
+            self.add_ipa_command(
+                "automountmap_add",
+                name=self.location_name,
+                args=args
+            )
+        elif self.map is not None and self.ipa_params.state == "present":
+            # exists and is wanted, check for changes
+            if self.ipa_params.desc != self.map.get('description', [None])[0]:
+                args['description'] = self.ipa_params.desc
+                self.add_ipa_command(
+                    "automountmap_mod",
+                    name=self.location_name,
+                    args=args
+                )
+        elif self.map and self.ipa_params.state == "absent":
+            # exists and is not wanted
+            self.add_ipa_command(
+                "automountmap_del",
+                name=self.location_name,
+                args=args
+            )
+
+
+def main():
+    ipa_module = AutomountLocation(
+        argument_spec=dict(
+            ipaadmin_principal=dict(type="str",
+                                    default="admin"
+                                    ),
+            ipaadmin_password=dict(type="str",
+                                   required=False,
+                                   no_log=True
+                                   ),
+            state=dict(type='str',
+                       default='present',
+                       choices=['present', 'absent']
+                       ),
+            location=dict(type="str",
+                          aliases=["automountlocationcn"],
+                          default=None,
+                          required=True
+                          ),
+            mapname=dict(type="str",
+                         aliases=["cn", "name", "map", "automountmapname"],
+                         default=None,
+                         required=True
+                         ),
+            desc=dict(type="str",
+                      aliases=["description"],
+                      required=False,
+                      default=None
+                      ),
+        ),
+    )
+    ipa_module.ipa_run()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/automountkey/test_automountkey.yml
+++ b/tests/automountkey/test_automountkey.yml
@@ -1,0 +1,145 @@
+---
+- name: Test automountmap
+  hosts: ipaserver
+  become: true
+  gather_facts: false
+
+  tasks:
+  - name: ensure location TestLocation is absent
+    ipaautomountlocation:
+      ipaadmin_password: password01
+      name: TestLocation
+      state: absent
+
+  - name: ensure map TestMap is absent
+    ipaautomountmap:
+      ipaadmin_password: password01
+      name: TestMap
+      location: TestLocation
+      state: absent
+
+  - name: ensure key TestKey is absent
+    ipaautomountkey:
+      ipaadmin_password: password01
+      automountlocationcn: TestLocation
+      automountmapname: TestMap
+      automountkey: TestKey
+      state: absent
+
+
+### create the environment for the tests
+  - name: create location TestLocation
+    ipaautomountlocation:
+      ipaadmin_password: password01
+      name: TestLocation
+      state: present
+
+  - name: ensure location TestLocation has been created
+    ipaautomountlocation:
+      ipaadmin_password: password01
+      name: TestLocation
+      state: present
+    register: result
+    failed_when: result.changed
+
+  - name: create map TestMap 
+    ipaautomountmap:
+      ipaadmin_password: password01
+      name: TestMap
+      location: TestLocation
+      desc: "this is a test map that should be deleted by the test"
+
+  - name: ensure map TestMap has been created
+    ipaautomountmap:
+      ipaadmin_password: password01
+      name: TestMap
+      location: TestLocation
+    register: result
+    failed_when: result.changed
+
+### test the key creation, and modification
+  - name: create key TestKey
+    ipaautomountkey:
+      ipaadmin_password: password01
+      automountlocationcn: TestLocation
+      automountmapname: TestMap
+      automountkey: TestKey
+      automountinformation: 192.168.122.1:/exports
+      state: present
+
+  - name: ensure key TestKey has been created
+    ipaautomountkey:
+      ipaadmin_password: password01
+      automountlocationcn: TestLocation
+      automountmapname: TestMap
+      automountkey: TestKey
+      automountinformation: 192.168.122.1:/exports
+      state: present
+    register: result
+    failed_when: result.changed
+
+## modify the key
+  - name: create key TestKey
+    ipaautomountkey:
+      ipaadmin_password: password01
+      automountlocationcn: TestLocation
+      automountmapname: TestMap
+      automountkey: TestKey
+      automountinformation: 192.168.122.1:/nfsshare
+      state: present
+
+  - name: ensure key TestKey has been created
+    ipaautomountkey:
+      ipaadmin_password: password01
+      automountlocationcn: TestLocation
+      automountmapname: TestMap
+      automountkey: TestKey
+      automountinformation: 192.168.122.1:/nfsshare
+      state: present
+    register: result
+    failed_when: result.changed
+
+
+### cleanup after the tests
+
+  - name: ensure key TestKey is absent
+    ipaautomountkey:
+      ipaadmin_password: password01
+      automountlocationcn: TestLocation
+      automountmapname: TestMap
+      automountkey: TestKey
+      state: absent
+
+
+  - name: ensure map TestMap is removed
+    ipaautomountmap:
+      ipaadmin_password: password01
+      name: TestMap
+      location: TestLocation
+      state: absent
+
+  - name: ensure map TestMap has been removed
+    ipaautomountmap:
+      ipaadmin_password: password01
+      name: TestMap
+      location: TestLocation
+      state: absent
+    register: result
+    failed_when: result.changed
+
+
+
+  - name: ensure location TestLocation is removed
+    ipaautomountlocation:
+      ipaadmin_password: password01
+      name: TestLocation
+      state: absent
+
+  - name: ensure location TestLocation is absent
+    ipaautomountlocation:
+      ipaadmin_password: password01
+      name: TestLocation
+      state: absent
+    register: result
+    failed_when: result.changed
+

--- a/tests/automountlocation/test_automountlocation.yml
+++ b/tests/automountlocation/test_automountlocation.yml
@@ -1,0 +1,41 @@
+---
+- name: Test automountlocation
+  hosts: ipaserver
+  become: true
+  gather_facts: false
+
+  tasks:
+  - name: ensure location TestLocation is absent
+    ipaautomountlocation:
+      ipaadmin_password: password01
+      name: TestLocation
+      state: absent
+
+  - name: ensure location TestLocation is created
+    ipaautomountlocation:
+      ipaadmin_password: password01
+      name: TestLocation
+      state: present
+
+  - name: ensure location TestLocation has been created
+    ipaautomountlocation:
+      ipaadmin_password: password01
+      name: TestLocation
+      state: present
+    register: result
+    failed_when: result.changed
+
+  - name: ensure location TestLocation is absent
+    ipaautomountlocation:
+      ipaadmin_password: password01
+      name: TestLocation
+      state: absent
+
+  - name: ensure location TestLocation is absent
+    ipaautomountlocation:
+      ipaadmin_password: password01
+      name: TestLocation
+      state: absent
+    register: result
+    failed_when: result.changed
+

--- a/tests/automountmap/test_automountmap.yml
+++ b/tests/automountmap/test_automountmap.yml
@@ -1,0 +1,92 @@
+---
+- name: Test automountmap
+  hosts: ipaserver
+  become: true
+  gather_facts: false
+
+  tasks:
+  - name: ensure location TestLocation is absent
+    ipaautomountlocation:
+      ipaadmin_password: password01
+      name: TestLocation
+      state: absent
+
+  - name: ensure map TestMap is absent
+    ipaautomountmap:
+      ipaadmin_password: password01
+      name: TestMap
+      location: TestLocation
+      state: absent
+
+  - name: ensure location TestLocation is created
+    ipaautomountlocation:
+      ipaadmin_password: password01
+      name: TestLocation
+      state: present
+
+  - name: ensure location TestLocation has been created
+    ipaautomountlocation:
+      ipaadmin_password: password01
+      name: TestLocation
+      state: present
+    register: result
+    failed_when: result.changed
+
+
+  - name: ensure map TestMap is created
+    ipaautomountmap:
+      ipaadmin_password: password01
+      name: TestMap
+      location: TestLocation
+      desc: "this is a test map that should be deleted by the test"
+
+  - name: ensure map TestMap has been created
+    ipaautomountmap:
+      ipaadmin_password: password01
+      name: TestMap
+      location: TestLocation
+    register: result
+    failed_when: result.changed
+
+  - name: ensure map TestMap has been created
+    ipaautomountmap:
+      ipaadmin_password: password01
+      name: TestMap
+      location: TestLocation
+      desc: "this is a changed description that should be deleted by the test"
+    register: result
+    failed_when: not result.changed
+
+
+  - name: ensure map TestMap is removed
+    ipaautomountmap:
+      ipaadmin_password: password01
+      name: TestMap
+      location: TestLocation
+      state: absent
+
+  - name: ensure map TestMap has been removed
+    ipaautomountmap:
+      ipaadmin_password: password01
+      name: TestMap
+      location: TestLocation
+      state: absent
+    register: result
+    failed_when: result.changed
+
+
+
+  - name: ensure location TestLocation is removed
+    ipaautomountlocation:
+      ipaadmin_password: password01
+      name: TestLocation
+      state: absent
+
+  - name: ensure location TestLocation is absent
+    ipaautomountlocation:
+      ipaadmin_password: password01
+      name: TestLocation
+      state: absent
+    register: result
+    failed_when: result.changed
+


### PR DESCRIPTION
This adds modules to manage the three components of automount maps as used by freeipa,  locations, maps and keys.

