### PR TITLE
Improve ipapermission member management.

### DIFF
--- a/tests/permission/test_permission.yml
+++ b/tests/permission/test_permission.yml
@@ -6,6 +6,15 @@
   tasks:
   - include_tasks: ../env_freeipa_facts.yml
 
+  - name: Ensure testing groups are present.
+    ipagroup:
+      ipaadmin_password: SomeADMINpassword
+      name: "{{ item }}"
+      state: present
+    with_items:
+      - rbacgroup1
+      - rbacgroup2
+
   # CLEANUP TEST ITEMS
 
   - name: Ensure permission perm-test-1 is absent
@@ -24,6 +33,8 @@
       ipaadmin_password: SomeADMINpassword
       name: perm-test-1
       object_type: host
+      memberof: rbacgroup1
+      filter: '(cn=*.ipa.*)'
       right: all
     register: result
     failed_when: not result.changed or result.failed
@@ -33,7 +44,103 @@
       ipaadmin_password: SomeADMINpassword
       name: perm-test-1
       object_type: host
+      memberof: rbacgroup1
+      filter: '(cn=*.ipa.*)'
       right: all
+    register: result
+    failed_when: result.changed or result.failed
+
+  - name: Ensure permission perm-test-1 has an extra filter '(cn=*.internal.*)'
+    ipapermission:
+      ipaadmin_password: SomeADMINpassword
+      name: perm-test-1
+      filter: '(cn=*.internal.*)'
+      action: member
+    register: result
+    failed_when: not result.changed or result.failed
+
+  - name: Ensure permission perm-test-1 has an extra filter '(cn=*.internal.*)', again
+    ipapermission:
+      ipaadmin_password: SomeADMINpassword
+      name: perm-test-1
+      filter: '(cn=*.internal.*)'
+      action: member
+    register: result
+    failed_when: result.changed or result.failed
+
+  - name: Ensure permission perm-test-1 `right` has `write`
+    ipapermission:
+      ipaadmin_password: SomeADMINpassword
+      name: perm-test-1
+      right: write
+      action: member
+    register: result
+    failed_when: not result.changed or result.failed
+
+  - name: Ensure permission perm-test-1 `right` has `write`, again
+    ipapermission:
+      ipaadmin_password: SomeADMINpassword
+      name: perm-test-1
+      right: write
+      action: member
+    register: result
+    failed_when: result.changed or result.failed
+
+  - name: Ensure permission perm-test-1 `right` has no `write`
+    ipapermission:
+      ipaadmin_password: SomeADMINpassword
+      name: perm-test-1
+      right: write
+      action: member
+      state: absent
+    register: result
+    failed_when: not result.changed or result.failed
+
+  - name: Ensure permission perm-test-1 `right` has no `write`, again
+    ipapermission:
+      ipaadmin_password: SomeADMINpassword
+      name: perm-test-1
+      right: write
+      action: member
+      state: absent
+    register: result
+    failed_when: result.changed or result.failed
+
+  - name: Ensure permission perm-test-1 `memberof` has `rbackgroup2`
+    ipapermission:
+      ipaadmin_password: SomeADMINpassword
+      name: perm-test-1
+      memberof: rbacgroup2
+      action: member
+    register: result
+    failed_when: not result.changed or result.failed
+
+  - name: Ensure permission perm-test-1 `memberof` has `rbackgroup2`, again
+    ipapermission:
+      ipaadmin_password: SomeADMINpassword
+      name: perm-test-1
+      memberof: rbacgroup2
+      action: member
+    register: result
+    failed_when: result.changed or result.failed
+
+  - name: Ensure permission perm-test-1 `memberof` item `rbackgroup1` is absent
+    ipapermission:
+      ipaadmin_password: SomeADMINpassword
+      name: perm-test-1
+      memberof: rbacgroup1
+      action: member
+      state: absent
+    register: result
+    failed_when: not result.changed or result.failed
+
+  - name: Ensure permission perm-test-1 `memberof` item `rbackgroup1` is absent, again
+    ipapermission:
+      ipaadmin_password: SomeADMINpassword
+      name: perm-test-1
+      memberof: rbacgroup1
+      action: member
+      state: absent
     register: result
     failed_when: result.changed or result.failed
 
@@ -163,6 +270,34 @@
     register: result
     failed_when: result.changed or result.failed
 
+  - name: Ensure permission perm-test-1 has rawfilter '(objectclass=ipagroup)'
+    ipapermission:
+      ipaadmin_password: SomeADMINpassword
+      name: perm-test-1
+      rawfilter: '(objectclass=ipagroup)'
+      action: member
+    register: result
+    failed_when: not result.changed or result.failed
+
+  - name: Ensure permission perm-test-1 has rawfilter '(objectclass=ipagroup)', again
+    ipapermission:
+      ipaadmin_password: SomeADMINpassword
+      name: perm-test-1
+      rawfilter: '(objectclass=ipagroup)'
+      action: member
+    register: result
+    failed_when: result.changed or result.failed
+
+  - name: Ensure filter and rawfilter cannot be used together.
+    ipapermission:
+      ipaadmin_password: SomeADMINpassword
+      name: perm-test-1
+      rawfilter: '(objectclass=ipagroup)'
+      filter: '(cn=*.internal.*)'
+      action: member
+    register: result
+    failed_when: not result.failed or "Cannot specify target filter and extra target filter simultaneously" not in result.msg
+
   - name: Rename permission perm-test-1 to perm-test-renamed
     ipapermission:
       ipaadmin_password: SomeADMINpassword
@@ -213,7 +348,7 @@
 
   # CLEANUP TEST ITEMS
 
-  - name: Ensure permission perm-test-1 is absent
+  - name: Ensure testing permissions are absent
     ipapermission:
       ipaadmin_password: SomeADMINpassword
       name:
@@ -221,3 +356,12 @@
       - perm-test-bindtype-test
       - perm-test-renamed
       state: absent
+
+  - name: Ensure testing groups are absent.
+    ipagroup:
+      ipaadmin_password: SomeADMINpassword
+      name: "{{ item }}"
+      state: absent
+    with_items:
+      - rbacgroup1
+      - rbacgroup2


### PR DESCRIPTION
In `ipapermission` plugin, Some attributtes were not being managed
when `action: member` was enabled.

This patch enable member management for `right`, `rawfilter`,
`filter, and fixes management of `memberof`.

Fix issue #489 