### PR TITLE
Fix container build.

### DIFF
--- a/molecule/centos-8-build/molecule.yml
+++ b/molecule/centos-8-build/molecule.yml
@@ -3,7 +3,7 @@ driver:
   name: docker
 platforms:
   - name: centos-8-build
-    image: centos:8
+    image: "centos:centos8"
     pre_build_image: true
     hostname: ipaserver.test.local
     dns_servers:

--- a/molecule/fedora-latest-build/molecule.yml
+++ b/molecule/fedora-latest-build/molecule.yml
@@ -3,7 +3,7 @@ driver:
   name: docker
 platforms:
   - name: fedora-latest-build
-    image: fedora-latest
+    image: "fedora:latest"
     dockerfile: Dockerfile
     hostname: ipaserver.test.local
     dns_servers:

--- a/tests/azure/azure-pipelines.yml
+++ b/tests/azure/azure-pipelines.yml
@@ -15,7 +15,7 @@ trigger:
 - master
 
 pool:
-  vmImage: 'ubuntu-18.04'
+  vmImage: 'ubuntu-20.04'
 
 stages:
 - stage: Centos7

--- a/tests/azure/build-containers.yml
+++ b/tests/azure/build-containers.yml
@@ -11,7 +11,7 @@ schedules:
 trigger: none
 
 pool:
-  vmImage: 'ubuntu-18.04'
+  vmImage: 'ubuntu-20.04'
 
 jobs:
 

--- a/tests/azure/templates/build_container.yml
+++ b/tests/azure/templates/build_container.yml
@@ -15,7 +15,7 @@ jobs:
     inputs:
       versionSpec: '3.6'
 
-  - script: python -m pip install --upgrade pip setuptools wheel
+  - script: python -m pip install --upgrade pip setuptools wheel ansible
     displayName: Install tools
 
   - script: pip install molecule[docker]


### PR DESCRIPTION
For some time, testing containers were failing to build in Azure pipelines. This PR addresses this problems by updating the vmImages, explicitly installing failing packages, and modifying the base images for the IPA containers.