### PR TITLE
Fix build-galaxy.sh execution and add running info.

### DIFF
--- a/utils/build-galaxy-release.sh
+++ b/utils/build-galaxy-release.sh
@@ -15,49 +15,61 @@ find . -name "*~" -exec rm {} \;
 sed -i -e "s/ansible.module_utils.ansible_freeipa_module/ansible_collections.${collection_prefix}.plugins.module_utils.ansible_freeipa_module/" plugins/modules/*.py
 
 (cd plugins/module_utils && {
-    ln -s ../../roles/*/module_utils/*.py .
+    ln -sf ../../roles/*/module_utils/*.py .
 })
 
 (cd plugins/modules && {
     sed -i -e "s/ansible.module_utils.ansible_ipa_/ansible_collections.${collection_prefix}.plugins.module_utils.ansible_ipa_/" ../../roles/*/library/*.py
-    ln -s ../../roles/*/library/*.py .
+    ln -sf ../../roles/*/library/*.py .
 })
 
 [ ! -x plugins/action_plugins ] && mkdir plugins/action_plugins
 (cd plugins/action_plugins && {
-    ln -s ../../roles/*/action_plugins/*.py .
+    ln -sf ../../roles/*/action_plugins/*.py .
 })
 
+echo "Fixing examples in plugins/modules..."
 find plugins/modules -name "*.py" -print0 |
-    while IFS= read -d -r '' line; do
+    while IFS= read -d '' -r line; do
         python utils/galaxyfy-module-EXAMPLES.py "$line" \
                "ipa" "$collection_prefix"
     done
+echo -e "\033[AFixing examples in plugins/modules... \033[32;1mDONE\033[0m"
 
+echo "Fixing examples in roles/*/library..."
 find roles/*/library -name "*.py" -print0 |
-    while IFS= read -d -r '' line; do
+    while IFS= read -d '' -r line; do
         python utils/galaxyfy-module-EXAMPLES.py "$line" \
                "ipa" "$collection_prefix"
     done
+echo -e "\033[AFixing examples in roles/*/library... \033[32;1mDONE\033[0m"
 
-for x in roles/*/tasks/*.yml; do
+echo "Fixing playbooks in roles/*/tasks..."
+for line in roles/*/tasks/*.yml; do
     python utils/galaxyfy-playbook.py "$line" "ipa" "$collection_prefix"
 done
+echo -e "\033[AFixing playbooks in roles/*tasks... \033[32;1mDONE\033[0m"
 
+echo "Fixing playbooks in playbooks..."
 find playbooks -name "*.yml" -print0 |
-    while IFS= read -d -r '' line; do
+    while IFS= read -d '' -r line; do
         python utils/galaxyfy-playbook.py "$line" "ipa" "$collection_prefix"
     done
+echo -e "\033[AFixing playbooks in playbooks... \033[32;1mDONE\033[0m"
 
+echo "Fixing README(s)..."
 find . -name "README*.md" -print0 |
-    while IFS= read -d -r '' line; do
+    while IFS= read -d '' -r line; do
         python utils/galaxyfy-README.py "$line" "ipa" "$collection_prefix"
     done
+echo -e "\033[AFixing examples in plugins/modules... \033[32;1mDONE\033[0m"
 
+echo "Fixing playbbooks in tests..."
 find tests -name "*.yml" -print0 |
-    while IFS= read -d -r '' line; do
+    while IFS= read -d '' -r line; do
         python utils/galaxyfy-playbook.py "$line" "ipa" "$collection_prefix"
     done
+echo -e "\033[AFixing playbooks in tests... \033[32;1mDONE\033[0m"
 
 #git diff
 


### PR DESCRIPTION
This patch adds a missing argument to `read` and adds information
on which step is being executed.