### PR TITLE
example playbooks: ipaselfservice examples mentioned ipadelegation.

### DIFF
--- a/playbooks/selfservice/selfservice-absent.yml
+++ b/playbooks/selfservice/selfservice-absent.yml
@@ -1,11 +1,11 @@
 ---
-- name: Delegation absent
+- name: Selfservice absent
   hosts: ipaserver
   become: true
 
   tasks:
-  - name: Ensure delegation "basic manager attributes" is absent
-    ipadelegation:
+  - name: Ensure selfservice "basic manager attributes" is absent
+    ipaselfservice:
       ipaadmin_password: SomeADMINpassword
       name: "basic manager attributes"
       state: absent

--- a/playbooks/selfservice/selfservice-member-absent.yml
+++ b/playbooks/selfservice/selfservice-member-absent.yml
@@ -1,15 +1,15 @@
 ---
-- name: Delegation member absent
+- name: Selfservice member absent
   hosts: ipaserver
   become: true
 
   tasks:
-  - name: Ensure delegation "basic manager attributes" member attributes employeenumber and employeetype are absent
-    ipadelegation:
+  - name: Ensure selfservice "basic manager attributes" member attributes employeenumber and employeetype are absent
+    ipaselfservice:
       ipaadmin_password: SomeADMINpassword
       name: "basic manager attributes"
       attribute:
-      - employeenumber
-      - employeetype
+      - businesscategory
+      - departmentnumber
       action: member
       state: absent

--- a/playbooks/selfservice/selfservice-member-present.yml
+++ b/playbooks/selfservice/selfservice-member-present.yml
@@ -1,11 +1,11 @@
 ---
-- name: Delegation member present
+- name: Selfservice member present
   hosts: ipaserver
   become: true
 
   tasks:
-  - name: Ensure delegation "basic manager attributes" member attribute departmentnumber is present
-    ipadelegation:
+  - name: Ensure selfservice "basic manager attributes" member attribute departmentnumber is present
+    ipaselfservice:
       ipaadmin_password: SomeADMINpassword
       name: "basic manager attributes"
       attribute:

--- a/playbooks/selfservice/selfservice-present.yml
+++ b/playbooks/selfservice/selfservice-present.yml
@@ -1,11 +1,11 @@
 ---
-- name: Delegation present
+- name: Selfservice present
   hosts: ipaserver
   become: true
 
   tasks:
-  - name: Ensure delegation "basic manager attributes" is present
-    ipadelegation:
+  - name: Ensure selfservice "basic manager attributes" is present
+    ipaselfservice:
       ipaadmin_password: SomeADMINpassword
       name: "basic manager attributes"
       permission: read


### PR DESCRIPTION
The example playbooks for ipaselfservice were using the wrong module,
ipadelegation. This patch changes the references from ipadelegation
to ipaselfservice on these example playbooks.

Fix [RHBZ#1922060](https://bugzilla.redhat.com/show_bug.cgi?id=1922060)