### PR TITLE
ipaclient: Do not fail on rmkeytab error #7

### DIFF
--- a/roles/ipaclient/tasks/install.yml
+++ b/roles/ipaclient/tasks/install.yml
@@ -181,8 +181,12 @@
     # Do not fail on error codes 3 and 5:
     #   3 - Unable to open keytab
     #   5 - Principal name or realm not found in keytab
+    #   7 - Failed to set cursor, typically when errcode
+    #       would be issued in past
     failed_when: result_ipa_rmkeytab.rc != 0 and
-                 result_ipa_rmkeytab.rc != 3 and result_ipa_rmkeytab.rc != 5
+                 result_ipa_rmkeytab.rc != 3 and
+                 result_ipa_rmkeytab.rc != 5 and
+                 result_ipa_rmkeytab.rc != 7
     when: (ipaclient_use_otp | bool or ipaclient_force_join | bool) and not ipaclient_on_master | bool
 
   - name: Install - Backup and set hostname


### PR DESCRIPTION
Due to commit f3f9672d527008dc741ac90aa465bac842eea08d (ipa-rmkeytab: Check
return value of krb5_kt_(start|end)_seq_get) in IPA 4.9.2 there is a new
error reported for ipa-rmkeytab in case of a non existing keytab file.
Using ipa-rmkeytab now results in the error 7 in this case.

The client role is using ipa-rmkeytab and needs to ignore error 7 also.

Fixes: #510 (ipa-client installation with OTP is failed with error code 7
             (keytab: /usr/sbin/ipa-rmkeytab returned 7))