### PR TITLE
change variable in get_ipabackup_dir.yml and update README.md

### DIFF
--- a/roles/ipabackup/tasks/get_ipabackup_dir.yml
+++ b/roles/ipabackup/tasks/get_ipabackup_dir.yml
@@ -1,6 +1,6 @@
 ---
 - name: Get IPA_BACKUP_DIR dir from ipaplatform
-  command: "{{ ansible_playbook_python }}"
+  command: "{{ ansible_python_interpreter | default('/usr/bin/python') }}"
   args:
     stdin: |
       from ipaplatform.paths import paths


### PR DESCRIPTION
**Fixes** #513

Details in the issue but basically :
```
- command: "{{ ansible_playbook_python }}"
+ command: "{{ ansible_python_interpreter | default('/usr/bin/python') }}"
```
in get_ipabackup_dir.yml and mention this variable or the default python path in README