### PR TITLE
Force plugins to execute using LANGUAGE='C'.

### DIFF
--- a/plugins/module_utils/ansible_freeipa_module.py
+++ b/plugins/module_utils/ansible_freeipa_module.py
@@ -93,6 +93,9 @@ except ImportError:
 if six.PY3:
     unicode = str
 
+# ansible-freeipa requires locale to be C, IPA requires utf-8.
+os.environ["LANGUAGE"] = "C"
+
 
 def valid_creds(module, principal):  # noqa
     """Get valid credentials matching the princial, try GSSAPI first."""

--- a/tests/environment/test_locale.yml
+++ b/tests/environment/test_locale.yml
@@ -1,0 +1,32 @@
+---
+- name: Test language variations
+  hosts: ipaserver
+
+  tasks:
+  - name: Ensure a host is not present, with language set to "de_DE".
+    ipahost:
+      ipaadmin_password: SomeADMINpassword
+      name: nonexistent
+      state: absent
+    environment:
+      LANGUAGE: "de_DE"
+    register: result
+    failed_when: result.failed or result.changed
+
+  - name: Ensure a host is not present, with language set to "C".
+    ipahost:
+      ipaadmin_password: SomeADMINpassword
+      name: nonexistent
+      state: absent
+    environment:
+      LANGUAGE: "C"
+    register: result
+    failed_when: result.failed or result.changed
+
+  - name: Ensure a host is not present, using controller language.
+    ipahost:
+      ipaadmin_password: SomeADMINpassword
+      name: nonexistent
+      state: absent
+    register: result
+    failed_when: result.failed or result.changed


### PR DESCRIPTION
IPA translates exception messages and Ansible uses controller's
language to execute plugins on target hosts, and since ansible-freeipa
uses Exceptions messages to detect some errors and/or states, using any
language that has a translation for the required messages may cause the
plugin to misbehave.

This patch modifies ansible_freeipa_module in plugin/module_utils to
force the use of "C" as the language by setting the environment variable
LANGUAGE.

Tests were added to verify the correct behavior:

    tests/environment/test_locale.yml

The first test will fail, if ansible_freeipa_module is not patched, with
the message:

   host_show failed: nonexistent: host nicht gefunden

This issue is not present if the language selected does not provide
a translation for the eror message.

This patch does not fix encoding issues that might occur in certain
releases (e.g.: CentOS 8.3).

Fix #516