### PR TITLE
Allow user override of distro specific variables.

### DIFF
--- a/roles/ipabackup/README.md
+++ b/roles/ipabackup/README.md
@@ -328,6 +328,7 @@ ipabackup_from_controller | Copy backup from controller to server, restore if `s
 ipabackup_install_packages | Install needed packages to be able to apply the backup with `state: restored`, bool (default: `yes`) | no
 ipabackup_firewalld_zone | The value defines the firewall zone that will be used with `state: restored`. This needs to be an existing runtime and permanent zone, bool (default: `no`) | no
 ipabackup_setup_firewalld | The value defines if the needed services will automatically be opened in the firewall managed by firewalld with `state: restored`, bool (default: `yes`) | no
+`ipaclient_user_vars` | The absolute path to a file containing distro specific variables, superseding distro detection, used only with `state: restored`, string | no
 
 
 Authors

--- a/roles/ipabackup/tasks/restore.yml
+++ b/roles/ipabackup/tasks/restore.yml
@@ -6,6 +6,7 @@
 - name: Import variables specific to distribution
   include_vars: "{{ item }}"
   with_first_found:
+    - "{{ ipabackup_user_vars | default(omit) }}"
     - "{{ role_path }}/vars/{{ ansible_distribution }}-{{ ansible_distribution_version }}.yml"
     - "{{ role_path }}/vars/{{ ansible_distribution }}-{{ ansible_distribution_major_version }}.yml"
     - "{{ role_path }}/vars/{{ ansible_distribution }}.yml"

--- a/roles/ipaclient/README.md
+++ b/roles/ipaclient/README.md
@@ -199,6 +199,7 @@ Variable | Description | Required
 `ipaclient_allow_repair` | The bool value defines if an already joined or partly set-up client can be repaired. `ipaclient_allow_repair` defaults to `no`. Contrary to `ipaclient_force_join=yes` the host entry will not be changed on the server. | no
 `ipaclient_install_packages` | The bool value defines if the needed packages are installed on the node. `ipaclient_install_packages` defaults to `yes`. | no
 `ipaclient_on_master` | The bool value is only used in the server and replica installation process to install the client part. It should not be set otherwise. `ipaclient_on_master` defaults to `no`. | no
+`ipaclient_user_vars` | The absolute path to a file containing distro specific variables, superseding distro detection. (string) | no
 
 
 Authors

--- a/roles/ipaclient/tasks/main.yml
+++ b/roles/ipaclient/tasks/main.yml
@@ -4,6 +4,7 @@
 - name: Import variables specific to distribution
   include_vars: "{{ item }}"
   with_first_found:
+    - "{{ ipaclient_user_vars | default(omit) }}"
     - "{{ role_path }}/vars/{{ ansible_distribution }}-{{ ansible_distribution_version }}.yml"
     - "{{ role_path }}/vars/{{ ansible_distribution }}-{{ ansible_distribution_major_version }}.yml"
     - "{{ role_path }}/vars/{{ ansible_distribution }}.yml"

--- a/roles/ipareplica/README.md
+++ b/roles/ipareplica/README.md
@@ -253,6 +253,8 @@ Variable | Description | Required
 `ipareplica_install_packages` | The bool value defines if the needed packages are installed on the node. (bool, default: true) | no
 `ipareplica_setup_firewalld` | The value defines if the needed services will automatically be openen in the firewall managed by firewalld. (bool, default: true) | no
 `ipareplica_firewalld_zone` | The value defines the firewall zone that will be used. This needs to be an existing runtime and permanent zone. (string) | no
+`ipareplica_user_vars` | The absolute path to a file containing distro specific variables, superseding distro detection. (string) | no
+
 
 Authors
 =======

--- a/roles/ipareplica/tasks/main.yml
+++ b/roles/ipareplica/tasks/main.yml
@@ -4,6 +4,7 @@
 - name: Import variables specific to distribution
   include_vars: "{{ item }}"
   with_first_found:
+    - "{{ ipareplica_user_vars | default(omit) }}"
     - "vars/{{ ansible_distribution }}-{{ ansible_distribution_version }}.yml"
     - "vars/{{ ansible_distribution }}-{{ ansible_distribution_major_version }}.yml"
     - "vars/{{ ansible_distribution }}.yml"

--- a/roles/ipaserver/README.md
+++ b/roles/ipaserver/README.md
@@ -303,6 +303,8 @@ Variable | Description | Required
 `ipaserver_firewalld_zone` | The value defines the firewall zone that will be used. This needs to be an existing runtime and permanent zone. (string) | no
 `ipaserver_external_cert_files_from_controller` | Files containing the IPA CA certificates and the external CA certificate chains on the controller that will be copied to the ipaserver host to `/root` folder. (list of string) | no
 `ipaserver_copy_csr_to_controller` | Copy the generated CSR from the ipaserver to the controller as `"{{ inventory_hostname }}-ipa.csr"`. (bool) | no
+`ipaserver_user_vars` | The absolute path to a file containing distro specific variables, superseding distro detection. (string) | no
+
 
 Authors
 =======

--- a/roles/ipaserver/tasks/main.yml
+++ b/roles/ipaserver/tasks/main.yml
@@ -4,6 +4,7 @@
 - name: Import variables specific to distribution
   include_vars: "{{ item }}"
   with_first_found:
+    - "{{ ipaserver_user_vars | default(omit) }}"
     - "vars/{{ ansible_distribution }}-{{ ansible_distribution_version }}.yml"
     - "vars/{{ ansible_distribution }}-{{ ansible_distribution_major_version }}.yml"
     - "vars/{{ ansible_distribution }}.yml"


### PR DESCRIPTION
This patch adds variable *_user_vars to backup, server, replica and
client roles, allowing a user to provide a file to be used instead of
the distro specific ones.

This change allows usage of ansible-freeipa in non-supported distros
without requiring the addition of a distro specific file in the role
`vars` directory.