### PR TITLE
Fix privilege with permisions

### DIFF
--- a/plugins/module_utils/ansible_freeipa_module.py
+++ b/plugins/module_utils/ansible_freeipa_module.py
@@ -285,6 +285,23 @@ def compare_args_ipa(module, args, ipa):  # noqa
     """
     base_debug_msg = "Ansible arguments and IPA commands differed. "
 
+    # If both args and ipa are None, return there's no difference.
+    # If only one is None, return there is a difference.
+    # This tests avoid unecessary invalid access to attributes.
+    if args is None and ipa is None:
+        return True
+    if args is None or ipa is None:
+        module.debug(
+            base_debug_msg + "args is%s None an ipa is%s None" % (
+                "" if args is None else " not", "" if ipa is None else " not",
+            )
+        )
+        return False
+
+    # Fail if args or ipa are not dicts.
+    if not (isinstance(args, dict) and isinstance(ipa, dict)):
+        raise TypeError("Expected 'dicts' to compare.")
+
     for key in args.keys():
         if key not in ipa:
             module.debug(

--- a/plugins/modules/ipaprivilege.py
+++ b/plugins/modules/ipaprivilege.py
@@ -234,14 +234,22 @@ def main():
                 if action == "privilege":
                     # Found the privilege
                     if res_find is not None:
+                        res_cmp = {
+                            k: v for k, v in res_find.items()
+                            if k not in [
+                                "objectclass", "cn", "dn",
+                                "memberof_permisssion"
+                            ]
+                        }
                         # For all settings is args, check if there are
                         # different settings in the find result.
                         # If yes: modify
-                        if not compare_args_ipa(ansible_module, args,
-                                                res_find):
+                        if args and not compare_args_ipa(ansible_module, args,
+                                                         res_cmp):
                             commands.append([name, "privilege_mod", args])
                     else:
                         commands.append([name, "privilege_add", args])
+                        res_find = {}
 
                     member_args = {}
                     if permission:

--- a/tests/privilege/test_privilege.yml
+++ b/tests/privilege/test_privilege.yml
@@ -140,6 +140,30 @@
     register: result
     failed_when: result.changed or result.failed
 
+  - name: Ensure "Broad Privilege" is absent.
+    ipaprivilege:
+      ipaadmin_password: SomeADMINpassword
+      name: Broad Privilege
+      state: absent
+
+  - name: Ensure privilege Broad Privilege is created with permission. (issue 529)
+    ipaprivilege:
+      ipaadmin_password: SomeADMINpassword
+      name: Broad Privilege
+      permission:
+      - "Write IPA Configuration"
+    register: result
+    failed_when: not result.changed or result.failed
+
+  - name: Ensure privilege Broad Privilege is created with permission, again. (issue 529)
+    ipaprivilege:
+      ipaadmin_password: SomeADMINpassword
+      name: Broad Privilege
+      permission:
+      - "Write IPA Configuration"
+    register: result
+    failed_when: result.changed or result.failed
+
   # CLEANUP TEST ITEMS
 
   - name: Ensure privilege testing privileges are absent


### PR DESCRIPTION
This PR fixes the behavior of `ipaprivilege` when a privilege is created with permissions.

As `None` was being passed to `compare_args_ipa()` (in `ansible_freeipa_modutils.py`) an exception was being raised. This was fixed by testing the function parameters to handle `None` values.
 
Also the behavior for creating and modifying privileges were fixed in the ipaprivilege module, so that a privilege can be created with permissions, and idempotence is ensured.

Fixes #529 