### PR TITLE
tests/azure: Set ANSIBLE_LIBRARY, deactivate NTP

### DIFF
--- a/molecule/resources/playbooks/prepare-build.yml
+++ b/molecule/resources/playbooks/prepare-build.yml
@@ -25,3 +25,4 @@
       ipadm_password: SomeDMpassword
       ipaserver_domain: test.local
       ipaserver_realm: TEST.LOCAL
+      ipaclient_no_ntp: yes

--- a/tests/azure/templates/build_container.yml
+++ b/tests/azure/templates/build_container.yml
@@ -23,6 +23,8 @@ jobs:
 
   - script: molecule create -s ${{ parameters.build_scenario_name }}
     displayName: Create test container
+    env:
+      ANSIBLE_LIBRARY: ./molecule
 
   - script: |
       docker stop ${{ parameters.build_scenario_name }}

--- a/tests/azure/templates/playbook_tests.yml
+++ b/tests/azure/templates/playbook_tests.yml
@@ -44,6 +44,8 @@ jobs:
       cp -a plugins/module_utils/* ~/.ansible/module_utils
       molecule create -s ${{ parameters.scenario }}
     displayName: Setup test container
+    env:
+      ANSIBLE_LIBRARY: ./molecule
 
   - script: |
       pytest \

--- a/tests/azure/templates/pytest_tests.yml
+++ b/tests/azure/templates/pytest_tests.yml
@@ -36,6 +36,8 @@ jobs:
       cp -a plugins/module_utils/* ~/.ansible/module_utils
       molecule create -s ${{ parameters.scenario }}
     displayName: Setup test container
+    env:
+      ANSIBLE_LIBRARY: ./molecule
 
   - script: |
       pytest \


### PR DESCRIPTION
1) Set ANSIBLE_LIBRARY to fix unknown interpreter issue
    
    The ANSIBLE_LIBRARY environment variable needs to point to molecule
    directory.

2) Deactivate NTP in prepare-build

    In CentOS 8 and also Fedora the configuration and start of chrony
    fails with
    
      Fatal error : adjtimex(0x8001) failed : Operation not permitted
    
    For more information: https://bugzilla.redhat.com/show_bug.cgi?id=1772053
    NTP will not be needed before a separate namespace is used for clocks.

