### PR TITLE
ansible_doc_test pre commit: Set ANSIBLE_LIBRARY to test current repo

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,7 +25,7 @@ repos:
   hooks:
   - id: ansible-doc-test
     name: Verify Ansible roles and module documentation.
-    language: script
-    entry: utils/ansible-doc-test
+    language: python
+    entry: env ANSIBLE_LIBRARY=./plugins/modules utils/ansible-doc-test
     # args: ['-v', 'roles', 'plugins']
     files: ^.*.py$


### PR DESCRIPTION
It is needed to set ANSIBLE_LIBRARY to make sure that the current repo is
tested.