### PR TITLE
Enhance ipaservice tests.

### DIFF
--- a/README-service.md
+++ b/README-service.md
@@ -311,6 +311,8 @@ Variable | Description | Required
 `allow_retrieve_keytab_host` \| `ipaallowedtoperform_read_keys_host` | Hosts allowed to retrieve a keytab from of host. | no
 `allow_retrieve_keytab_hostgroup` \| `ipaallowedtoperform_read_keys_hostgroup` | Host groups allowed to retrieve a keytab of this host. | no
 `continue` | Continuous mode: don't stop on errors. Valid only if `state` is `absent`. Default: `no` (bool) | no
+`smb` | Service is an SMB service. If set, `cifs/` will be prefixed to the service name if needed. | no
+`netbiosname` | NETBIOS name for the SMB service. Only with `smb: yes`. | no
 `action` | Work on service or member level. It can be on of `member` or `service` and defaults to `service`. | no
 `state` | The state to ensure. It can be one of `present`, `absent`, or `disabled`, default: `present`. | no
 

--- a/plugins/modules/ipaservice.py
+++ b/plugins/modules/ipaservice.py
@@ -561,6 +561,15 @@ def main():
                             if remove in args:
                                 del args[remove]
 
+                        if (
+                            "krbprincipalauthind" in args
+                            and (
+                                args.get("krbprincipalauthind", [""]) ==
+                                res_find.get("krbprincipalauthind", [""])
+                            )
+                          ):
+                            del args["krbprincipalauthind"]
+
                         if not compare_args_ipa(ansible_module, args,
                                                 res_find):
                             commands.append([name, "service_mod", args])

--- a/plugins/modules/ipaservice.py
+++ b/plugins/modules/ipaservice.py
@@ -91,7 +91,7 @@ options:
     type: list
     aliases: ["krbprincipalname"]
   smb:
-    description: Add a SMB service. Can only be used with new services.
+    description: Add a SMB service.
     required: false
     type: bool
   netbiosname:
@@ -234,20 +234,10 @@ from ansible.module_utils.ansible_freeipa_module import temp_kinit, \
 import ipalib.errors
 
 
-def find_service(module, name, netbiosname):
+def find_service(module, name):
     _args = {
         "all": True,
     }
-
-    # Search for a SMB/cifs service.
-    if netbiosname is not None:
-        _result = api_command(
-            module, "service_find", to_text(netbiosname), _args)
-
-        for _res_find in _result.get('result', []):
-            for uid in _res_find.get('uid', []):
-                if uid.startswith("%s$@" % netbiosname):
-                    return _res_find
 
     try:
         _result = api_command(module, "service_show", to_text(name), _args)
@@ -287,6 +277,19 @@ def gen_args(pac_type, auth_ind, skip_host_check, force, requires_pre_auth,
     return _args
 
 
+def gen_args_smb(netbiosname, ok_as_delegate, ok_to_auth_as_delegate):
+    _args = {}
+
+    if netbiosname is not None:
+        _args['ipantflatname'] = netbiosname
+    if ok_as_delegate is not None:
+        _args['ipakrbokasdelegate'] = (ok_as_delegate)
+    if ok_to_auth_as_delegate is not None:
+        _args['ipakrboktoauthasdelegate'] = (ok_to_auth_as_delegate)
+
+    return _args
+
+
 def check_parameters(module, state, action, names, parameters):
     assert isinstance(parameters, dict)
 
@@ -310,15 +313,13 @@ def check_parameters(module, state, action, names, parameters):
         if action == 'service':
             invalid = ['delete_continue']
 
-            if parameters.get('smb', False):
-                invalid.extend(['force', 'auth_ind', 'skip_host_check',
-                                'requires_pre_auth', 'auth_ind', 'pac_type'])
-
-                for _invalid in invalid:
-                    if parameters.get(_invalid, False):
-                        module.fail_json(
-                            msg="Argument '%s' can not be used with SMB "
-                                "service." % _invalid)
+            if (
+                not parameters.get('smb', False)
+                and parameters.get('netbiosname')
+            ):
+                module.fail_json(
+                    msg="Argument 'netbiosname' can not be used without "
+                        "SMB service.")
         else:
             invalid.append('delete_continue')
 
@@ -494,11 +495,9 @@ def main():
         commands = []
 
         for name in names:
-            res_find = find_service(ansible_module, name, netbiosname)
+            res_find = find_service(ansible_module, name)
 
             if state == "present":
-                # if service exists, 'smb' cannot be used.
-
                 if action == "service":
                     args = gen_args(
                         pac_type, auth_ind, skip_host_check, force,
@@ -507,13 +506,24 @@ def main():
                     if not has_skip_host_check and 'skip_host_check' in args:
                         del args['skip_host_check']
 
+                    if smb:
+                        if res_find is None:
+                            _name = "cifs/" + name
+                            res_find = find_service(ansible_module, _name)
+                            if res_find is None:
+                                _args = gen_args_smb(
+                                    netbiosname, ok_as_delegate,
+                                    ok_to_auth_as_delegate)
+                                commands.append(
+                                    [name, 'service_add_smb', _args])
+                                res_find = {}
+                            # service_add_smb will prefix 'name' with
+                            # "cifs/", so we will need to change it here,
+                            # so that service_mod, if called later, works.
+                            name = _name
+
                     if res_find is None:
-                        if smb:
-                            if netbiosname is not None:
-                                args['ipantflatname'] = netbiosname
-                            commands.append([name, 'service_add_smb', args])
-                        else:
-                            commands.append([name, 'service_add', args])
+                        commands.append([name, 'service_add', args])
 
                         certificate_add = certificate or []
                         certificate_del = []

--- a/tests/service/certificate/test_service_certificate.yml
+++ b/tests/service/certificate/test_service_certificate.yml
@@ -58,6 +58,7 @@
     ipaservice:
       ipaadmin_password: SomeADMINpassword
       name: "HTTP/{{ test_host }}"
+      continue: yes
       state: absent
 
   # tests
@@ -76,7 +77,7 @@
       ok_as_delegate: no
       ok_to_auth_as_delegate: no
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure service is present, again
     ipaservice:
@@ -85,7 +86,7 @@
       certificate:
         - "{{ lookup('file', 'cert1.b64') }}"
       pac_type:
-        - MS_PAC
+        - MS-PAC
         - PAD
       auth_ind: otp
       force: no
@@ -93,7 +94,7 @@
       ok_as_delegate: no
       ok_to_auth_as_delegate: no
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Ensure service is disabled
     ipaservice:
@@ -101,7 +102,7 @@
       name: "HTTP/{{ test_host }}"
       state: disabled
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure service member certificate is present.
     ipaservice:
@@ -112,7 +113,7 @@
       action: member
       state: present
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure service member certificate is present, again.
     ipaservice:
@@ -123,7 +124,7 @@
       action: member
       state: present
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Ensure service multiple member certificates are present, with duplicate.
     ipaservice:
@@ -135,7 +136,7 @@
       action: member
       state: present
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure service member certificate is absent.
     ipaservice:
@@ -146,7 +147,7 @@
       action: member
       state: absent
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure service member certificate is absent, again.
     ipaservice:
@@ -157,7 +158,7 @@
       action: member
       state: absent
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Ensure service member certificates are absent.
     ipaservice:
@@ -169,7 +170,7 @@
       action: member
       state: absent
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure service multiple member certificates is present.
     ipaservice:
@@ -180,7 +181,7 @@
       action: member
       state: present
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure service is disabled
     ipaservice:
@@ -188,7 +189,7 @@
       name: "HTTP/{{ test_host }}"
       state: disabled
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure service is disabled, again.
     ipaservice:
@@ -196,13 +197,14 @@
       name: "HTTP/{{ test_host }}"
       state: disabled
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   # cleanup
   - name: Ensure services are absent.
     ipaservice:
       ipaadmin_password: SomeADMINpassword
       name: "HTTP/{{ test_host }}"
+      continue: yes
       state: absent
 
   - name: Ensure host is absent

--- a/tests/service/env_cleanup.yml
+++ b/tests/service/env_cleanup.yml
@@ -8,7 +8,9 @@
       - "HTTP/{{ nohost_fqdn }}"
       - HTTP/svc.ihavenodns.info
       - HTTP/no.idontexist.local
+      - HTTP/no.idontexist.info
       - "cifs/{{ host1_fqdn }}"
+    continue: yes
     state: absent
 
 - name: Ensure host "{{ svc_fqdn }}" is absent

--- a/tests/service/env_setup.yml
+++ b/tests/service/env_setup.yml
@@ -61,13 +61,3 @@
   ipahostgroup:
     ipaadmin_password: SomeADMINpassword
     name: hostgroup02
-
-- name: Ensure services are absent.
-  ipaservice:
-    ipaadmin_password: SomeADMINpassword
-    name:
-    - "HTTP/{{ svc_fqdn }}"
-    - "HTTP/{{ nohost_fqdn }}"
-    - HTTP/svc.ihavenodns.info
-    - HTTP/no.idontexist.info
-    state: absent

--- a/tests/service/test_service.yml
+++ b/tests/service/test_service.yml
@@ -469,6 +469,7 @@
         ipaservice:
           ipaadmin_password: SomeADMINpassword
           name: "{{ host1_fqdn }}"
+          pac_type: NONE
           smb: yes
           netbiosname: SAMBASVC
         register: result
@@ -478,8 +479,39 @@
         ipaservice:
           ipaadmin_password: SomeADMINpassword
           name: "{{ host1_fqdn }}"
+          pac_type: NONE
           smb: yes
           netbiosname: SAMBASVC
+        register: result
+        failed_when: result.changed or result.failed
+
+      - name: Modify SMB service.
+        ipaservice:
+          ipaadmin_password: SomeADMINpassword
+          name: "{{ host1_fqdn }}"
+          smb: yes
+          netbiosname: SAMBASVC
+          allow_retrieve_keytab_user:
+            - user01
+            - user02
+          allow_retrieve_keytab_group:
+            - group01
+            - group02
+        register: result
+        failed_when: not result.changed or result.failed
+
+      - name: Modify SMB service, again.
+        ipaservice:
+          ipaadmin_password: SomeADMINpassword
+          name: "{{ host1_fqdn }}"
+          smb: yes
+          netbiosname: SAMBASVC
+          allow_retrieve_keytab_user:
+            - user01
+            - user02
+          allow_retrieve_keytab_group:
+            - group01
+            - group02
         register: result
         failed_when: result.changed or result.failed
 

--- a/tests/service/test_service.yml
+++ b/tests/service/test_service.yml
@@ -39,14 +39,14 @@
           ok_as_delegate: no
           ok_to_auth_as_delegate: no
         register: result
-        failed_when: not result.changed
+        failed_when: not result.changed or result.failed
 
       - name: Ensure service is present, again
         ipaservice:
           ipaadmin_password: SomeADMINpassword
           name: "HTTP/{{ svc_fqdn }}"
           pac_type:
-            - MS_PAC
+            - MS-PAC
             - PAD
           auth_ind: otp
           skip_host_check: no
@@ -55,7 +55,7 @@
           ok_as_delegate: no
           ok_to_auth_as_delegate: no
         register: result
-        failed_when: result.changed
+        failed_when: result.changed or result.failed
 
       - name: Modify service.
         ipaservice:
@@ -65,7 +65,7 @@
           ok_as_delegate: yes
           ok_to_auth_as_delegate: yes
         register: result
-        failed_when: not result.changed
+        failed_when: not result.changed or result.failed
 
       - name: Modify service, again.
         ipaservice:
@@ -75,7 +75,7 @@
           ok_as_delegate: yes
           ok_to_auth_as_delegate: yes
         register: result
-        failed_when: result.changed
+        failed_when: result.changed or result.failed
 
       - name: Ensure service is present, without host object.
         ipaservice:
@@ -83,7 +83,7 @@
           name: "HTTP/{{ nohost_fqdn }}"
           skip_host_check: yes
         register: result
-        failed_when: not result.changed
+        failed_when: not result.changed or result.failed
 
       - name: Ensure service is present, without host object, again.
         ipaservice:
@@ -91,7 +91,7 @@
           name: "HTTP/{{ nohost_fqdn }}"
           skip_host_check: yes
         register: result
-        failed_when: result.changed
+        failed_when: result.changed or result.failed
 
       - name: Ensure service is present, with host not in DNS.
         ipaservice:
@@ -100,7 +100,7 @@
           skip_host_check: no
           force: yes
         register: result
-        failed_when: not result.changed
+        failed_when: not result.changed or result.failed
 
       - name: Ensure service is present, with host not in DNS, again.
         ipaservice:
@@ -109,7 +109,7 @@
           skip_host_check: no
           force: yes
         register: result
-        failed_when: result.changed
+        failed_when: result.changed or result.failed
 
       - name: Ensure service is present, whithout host object and with host not in DNS.
         ipaservice:
@@ -118,7 +118,7 @@
           skip_host_check: yes
           force: yes
         register: result
-        failed_when: not result.changed
+        failed_when: not result.changed or result.failed
 
       - name: Ensure service is present, whithout host object and with host not in DNS, again.
         ipaservice:
@@ -127,7 +127,7 @@
           skip_host_check: yes
           force: yes
         register: result
-        failed_when: result.changed
+        failed_when: result.changed or result.failed
 
       - name: Principal host/test.example.com present in service.
         ipaservice:
@@ -137,7 +137,7 @@
             - host/test.example.com
           action: member
         register: result
-        failed_when: not result.changed
+        failed_when: not result.changed or result.failed
 
       - name: Principal host/test.example.com present in service, again.
         ipaservice:
@@ -147,7 +147,8 @@
             - host/test.example.com
           action: member
         register: result
-        failed_when: result.changed
+        failed_when:
+          result.changed or (result.failed and "already contains one or more values" not in result.msg)
 
       - name: Principal host/test.example.com absent in service.
         ipaservice:
@@ -158,7 +159,7 @@
           action: member
           state: absent
         register: result
-        failed_when: not result.changed
+        failed_when: not result.changed or result.failed
 
       - name: Principal host/test.example.com absent in service, again.
         ipaservice:
@@ -169,7 +170,8 @@
           action: member
           state: absent
         register: result
-        failed_when: result.changed
+        failed_when:
+          result.changed or (result.failed and "does not contain 'one or more values to remove'" not in result.msg)
 
       - name: Ensure host can manage service.
         ipaservice:
@@ -180,7 +182,7 @@
           - "{{ host2_fqdn }}"
           action: member
         register: result
-        failed_when: not result.changed
+        failed_when: not result.changed or result.failed
 
       - name: Ensure host can manage service, again.
         ipaservice:
@@ -189,7 +191,7 @@
           host: "{{ host1_fqdn }}"
           action: member
         register: result
-        failed_when: result.changed
+        failed_when: result.changed or result.failed
 
       - name: Ensure host cannot manage service.
         ipaservice:
@@ -201,7 +203,7 @@
           action: member
           state: absent
         register: result
-        failed_when: not result.changed
+        failed_when: not result.changed or result.failed
 
       - name: Ensure host cannot manage service, again.
         ipaservice:
@@ -213,7 +215,7 @@
           action: member
           state: absent
         register: result
-        failed_when: result.changed
+        failed_when: result.changed or result.failed
 
       - name: Service "HTTP/{{ svc_fqdn }}" members allow_create_keytab present for users, groups, hosts and hostgroups.
         ipaservice:
@@ -233,7 +235,7 @@
           - hostgroup02
           action: member
         register: result
-        failed_when: not result.changed
+        failed_when: not result.changed or result.failed
 
       - name: Service "HTTP/{{ svc_fqdn }}" members allow_create_keytab present for users, groups, hosts and hostgroups, again.
         ipaservice:
@@ -253,7 +255,7 @@
           - hostgroup02
           action: member
         register: result
-        failed_when: result.changed
+        failed_when: result.changed or result.failed
 
       - name: Service "HTTP/{{ svc_fqdn }}" members allow_create_keytab absent for users, groups, hosts and hostgroups.
         ipaservice:
@@ -274,7 +276,7 @@
           action: member
           state: absent
         register: result
-        failed_when: not result.changed
+        failed_when: not result.changed or result.failed
 
       - name: Service "HTTP/{{ svc_fqdn }}" members allow_create_keytab absent for users, groups, hosts and hostgroups, again.
         ipaservice:
@@ -295,7 +297,7 @@
           action: member
           state: absent
         register: result
-        failed_when: result.changed
+        failed_when: result.changed or result.failed
 
       - name: Service "HTTP/{{ svc_fqdn }}" members allow_retrieve_keytab present for users, groups, hosts and hostgroups
         ipaservice:
@@ -315,7 +317,7 @@
           - hostgroup02
           action: member
         register: result
-        failed_when: not result.changed
+        failed_when: not result.changed or result.failed
 
       - name: Service "HTTP/{{ svc_fqdn }}" members allow_retrieve_keytab present for users, groups, hosts and hostgroups, again.
         ipaservice:
@@ -335,7 +337,7 @@
           - hostgroup02
           action: member
         register: result
-        failed_when: result.changed
+        failed_when: result.changed or result.failed
 
       - name: Service "HTTP/{{ svc_fqdn }}" members allow_retrieve_keytab absent for users, groups, hosts and hostgroups.
         ipaservice:
@@ -356,7 +358,7 @@
           action: member
           state: absent
         register: result
-        failed_when: not result.changed
+        failed_when: not result.changed or result.failed
 
       - name: Service "HTTP/{{ svc_fqdn }}" members allow_retrieve_keytab absent for users, groups, hosts and hostgroups, again.
         ipaservice:
@@ -377,23 +379,25 @@
           action: member
           state: absent
         register: result
-        failed_when: result.changed
+        failed_when: result.changed or result.failed
 
       - name: Ensure service is absent
         ipaservice:
           ipaadmin_password: SomeADMINpassword
           name: "HTTP/{{ svc_fqdn }}"
+          continue: yes
           state: absent
         register: result
-        failed_when: not result.changed
+        failed_when: not result.changed or result.failed
 
       - name: Ensure service is absent, again
         ipaservice:
           ipaadmin_password: SomeADMINpassword
           name: "HTTP/{{ svc_fqdn }}"
+          continue: yes
           state: absent
         register: result
-        failed_when: result.changed
+        failed_when: result.changed or result.failed
 
       - name: Ensure service is present, with multiple auth_ind values.
         ipaservice:
@@ -403,7 +407,7 @@
           skip_host_check: no
           force: yes
         register: result
-        failed_when: not result.changed
+        failed_when: not result.changed or result.failed
 
       - name: Ensure service is present, with multiple auth_ind values, again.
         ipaservice:
@@ -413,7 +417,7 @@
           skip_host_check: no
           force: yes
         register: result
-        failed_when: result.changed
+        failed_when: result.changed or result.failed
 
       - name: Clear auth_ind.
         ipaservice:
@@ -423,7 +427,7 @@
           skip_host_check: no
           force: yes
         register: result
-        failed_when: not result.changed
+        failed_when: not result.changed or result.failed
 
       - name: Clear auth_ind, again.
         ipaservice:
@@ -433,7 +437,7 @@
           skip_host_check: no
           force: yes
         register: result
-        failed_when: result.changed
+        failed_when: result.changed or result.failed
 
       - name: Ensure services are absent.
         ipaservice:
@@ -446,7 +450,7 @@
           continue: yes
           state: absent
         register: result
-        failed_when: not result.changed
+        failed_when: not result.changed or result.failed
 
       - name: Ensure services are absent.
         ipaservice:
@@ -459,7 +463,7 @@
           continue: yes
           state: absent
         register: result
-        failed_when: result.changed
+        failed_when: result.changed or result.failed
 
       - name: Ensure SMB service is present.
         ipaservice:
@@ -468,7 +472,7 @@
           smb: yes
           netbiosname: SAMBASVC
         register: result
-        failed_when: not result.changed
+        failed_when: not result.changed or result.failed
 
       - name: Ensure SMB service is again.
         ipaservice:
@@ -477,23 +481,25 @@
           smb: yes
           netbiosname: SAMBASVC
         register: result
-        failed_when: result.changed
+        failed_when: result.changed or result.failed
 
       - name: Ensure SMB service is absent.
         ipaservice:
           ipaadmin_password: SomeADMINpassword
           name: "cifs/{{ host1_fqdn }}"
+          continue: yes
           state: absent
         register: result
-        failed_when: not result.changed
+        failed_when: not result.changed or result.failed
 
       - name: Ensure SMB service is absent, again.
         ipaservice:
           ipaadmin_password: SomeADMINpassword
           name: "cifs/{{ host1_fqdn }}"
+          continue: yes
           state: absent
         register: result
-        failed_when: result.changed
+        failed_when: result.changed or result.failed
 
       # cleanup
       - name: Cleanup test environment

--- a/tests/service/test_service_disable.yml
+++ b/tests/service/test_service_disable.yml
@@ -40,7 +40,7 @@
       - "{{ lookup('file', 'cert1.b64', rstrip=False) }}"
       force: no
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Obtain keytab
     shell: ipa-getkeytab -s "{{ ansible_facts['fqdn'] }}" -p "mysvc1/{{ ansible_facts['fqdn'] }}" -k mysvc1.keytab
@@ -56,7 +56,7 @@
       name: "mysvc1/{{ ansible_facts['fqdn'] }}"
       state: disabled
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Verify keytab
     shell: ipa service-find "mysvc1/{{ ansible_facts['fqdn'] }}"
@@ -77,7 +77,7 @@
       name: "mysvc1/{{ ansible_facts['fqdn'] }}"
       state: disabled
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Verify keytab
     shell: ipa service-find "mysvc1/{{ ansible_facts['fqdn'] }}"
@@ -90,7 +90,7 @@
       name: "mysvc1/{{ ansible_facts['fqdn'] }}"
       state: disabled
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Ensure service is absent
     ipaservice:

--- a/tests/service/test_service_keytab.yml
+++ b/tests/service/test_service_keytab.yml
@@ -33,7 +33,7 @@
       - user02
       action: member
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Service "HTTP/{{ svc_fqdn }}" members allow_create_keytab present for users, again.
     ipaservice:
@@ -44,7 +44,7 @@
       - user02
       action: member
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Service "HTTP/{{ svc_fqdn }}" members allow_create_keytab absent for users.
     ipaservice:
@@ -56,7 +56,7 @@
       action: member
       state: absent
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Service "HTTP/{{ svc_fqdn }}" members allow_create_keytab absent for users, again.
     ipaservice:
@@ -68,7 +68,7 @@
       action: member
       state: absent
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Service "HTTP/{{ svc_fqdn }}" members allow_create_keytab present for group.
     ipaservice:
@@ -79,7 +79,7 @@
       - group02
       action: member
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Service "HTTP/{{ svc_fqdn }}" members allow_create_keytab present for group, again.
     ipaservice:
@@ -90,7 +90,7 @@
       - group02
       action: member
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Service "HTTP/{{ svc_fqdn }}" members allow_create_keytab absent for group.
     ipaservice:
@@ -102,7 +102,7 @@
       action: member
       state: absent
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Service "HTTP/{{ svc_fqdn }}" members allow_create_keytab absent for group, again.
     ipaservice:
@@ -114,7 +114,7 @@
       action: member
       state: absent
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Service "HTTP/{{ svc_fqdn }}" members allow_create_keytab present for host.
     ipaservice:
@@ -125,7 +125,7 @@
       - "{{ host2_fqdn }}"
       action: member
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Service "HTTP/{{ svc_fqdn }}" members allow_create_keytab present for host, again.
     ipaservice:
@@ -136,7 +136,7 @@
       - "{{ host2_fqdn }}"
       action: member
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Service "HTTP/{{ svc_fqdn }}" members allow_create_keytab absent for host.
     ipaservice:
@@ -148,7 +148,7 @@
       action: member
       state: absent
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Service "HTTP/{{ svc_fqdn }}" members allow_create_keytab absent for host, again.
     ipaservice:
@@ -160,7 +160,7 @@
       action: member
       state: absent
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Service "HTTP/{{ svc_fqdn }}" members allow_create_keytab present for hostgroup.
     ipaservice:
@@ -171,7 +171,7 @@
       - hostgroup02
       action: member
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Service "HTTP/{{ svc_fqdn }}" members allow_create_keytab present for hostgroup, again.
     ipaservice:
@@ -182,7 +182,7 @@
       - hostgroup02
       action: member
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Service "HTTP/{{ svc_fqdn }}" members allow_create_keytab absent for hostgroup.
     ipaservice:
@@ -194,7 +194,7 @@
       state: absent
       action: member
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Service "HTTP/{{ svc_fqdn }}" members allow_create_keytab absent for hostgroup, again.
     ipaservice:
@@ -206,7 +206,7 @@
       action: member
       state: absent
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Service "HTTP/{{ svc_fqdn }}" members allow_retrieve_keytab present for users.
     ipaservice:
@@ -217,7 +217,7 @@
       - user02
       action: member
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Service "HTTP/{{ svc_fqdn }}" members allow_retrieve_keytab present for users, again.
     ipaservice:
@@ -228,7 +228,7 @@
       - user02
       action: member
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Service "HTTP/{{ svc_fqdn }}" members allow_retrieve_keytab absent for users.
     ipaservice:
@@ -240,7 +240,7 @@
       action: member
       state: absent
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Service "HTTP/{{ svc_fqdn }}" members allow_retrieve_keytab absent for users, again.
     ipaservice:
@@ -252,7 +252,7 @@
       action: member
       state: absent
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Service "HTTP/{{ svc_fqdn }}" members allow_retrieve_keytab present for group.
     ipaservice:
@@ -263,7 +263,7 @@
       - group02
       action: member
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Service "HTTP/{{ svc_fqdn }}" members allow_retrieve_keytab present for group, again.
     ipaservice:
@@ -274,7 +274,7 @@
       - group02
       action: member
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Service "HTTP/{{ svc_fqdn }}" members allow_retrieve_keytab absent for group.
     ipaservice:
@@ -286,7 +286,7 @@
       action: member
       state: absent
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Service "HTTP/{{ svc_fqdn }}" members allow_retrieve_keytab absent for group, again.
     ipaservice:
@@ -298,7 +298,7 @@
       action: member
       state: absent
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Service "HTTP/{{ svc_fqdn }}" members allow_retrieve_keytab present for host.
     ipaservice:
@@ -309,7 +309,7 @@
       - "{{ host2_fqdn }}"
       action: member
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Service "HTTP/{{ svc_fqdn }}" members allow_retrieve_keytab present for host, again.
     ipaservice:
@@ -320,7 +320,7 @@
       - "{{ host2_fqdn }}"
       action: member
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Service "HTTP/{{ svc_fqdn }}" members allow_retrieve_keytab absent for host.
     ipaservice:
@@ -332,7 +332,7 @@
       action: member
       state: absent
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Service "HTTP/{{ svc_fqdn }}" members allow_retrieve_keytab absent for host, again.
     ipaservice:
@@ -344,7 +344,7 @@
       action: member
       state: absent
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Service "HTTP/{{ svc_fqdn }}" members allow_retrieve_keytab present for hostgroup.
     ipaservice:
@@ -355,7 +355,7 @@
       - hostgroup02
       action: member
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Service "HTTP/{{ svc_fqdn }}" members allow_retrieve_keytab present for hostgroup, again.
     ipaservice:
@@ -366,7 +366,7 @@
       - hostgroup02
       action: member
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Service "HTTP/{{ svc_fqdn }}" members allow_retrieve_keytab absent for hostgroup.
     ipaservice:
@@ -378,7 +378,7 @@
       action: member
       state: absent
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Service "HTTP/{{ svc_fqdn }}" members allow_retrieve_keytab absent for hostgroup, again.
     ipaservice:
@@ -390,7 +390,7 @@
       action: member
       state: absent
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   # cleanup
   - name: Clean-up envirnoment.

--- a/tests/service/test_service_without_skip_host_check.yml
+++ b/tests/service/test_service_without_skip_host_check.yml
@@ -24,14 +24,14 @@
       ok_as_delegate: no
       ok_to_auth_as_delegate: no
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure service is present, again
     ipaservice:
       ipaadmin_password: SomeADMINpassword
       name: "HTTP/{{ svc_fqdn }}"
       pac_type:
-        - MS_PAC
+        - MS-PAC
         - PAD
       auth_ind: otp
       force: no
@@ -39,7 +39,7 @@
       ok_as_delegate: no
       ok_to_auth_as_delegate: no
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Modify service.
     ipaservice:
@@ -49,7 +49,7 @@
       ok_as_delegate: yes
       ok_to_auth_as_delegate: yes
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Modify service, again.
     ipaservice:
@@ -59,7 +59,7 @@
       ok_as_delegate: yes
       ok_to_auth_as_delegate: yes
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Ensure service is present, with host not in DNS.
     ipaservice:
@@ -67,7 +67,7 @@
       name: HTTP/svc.ihavenodns.info
       force: yes
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure service is present, with host not in DNS, again.
     ipaservice:
@@ -75,7 +75,7 @@
       name: HTTP/svc.ihavenodns.info
       force: yes
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Principal host/test.example.com present in service.
     ipaservice:
@@ -85,9 +85,9 @@
         - host/test.example.com
       action: member
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
-  - name: Principal host/test.exabple.com present in service, again.
+  - name: Principal host/test.example.com present in service, again.
     ipaservice:
       ipaadmin_password: SomeADMINpassword
       name: "HTTP/{{ svc_fqdn }}"
@@ -95,7 +95,8 @@
         - host/test.example.com
       action: member
     register: result
-    failed_when: result.changed
+    failed_when:
+      result.changed or (result.failed and "already contains one or more values" not in result.msg)
 
   - name: Principal host/test.example.com absent in service.
     ipaservice:
@@ -106,7 +107,7 @@
       action: member
       state: absent
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Principal host/test.example.com absent in service, again.
     ipaservice:
@@ -117,7 +118,8 @@
       action: member
       state: absent
     register: result
-    failed_when: result.changed
+    failed_when:
+      result.changed or (result.failed and "does not contain 'one or more values to remove'" not in result.msg)
 
   - name: Ensure host can manage service.
     ipaservice:
@@ -128,7 +130,7 @@
       - "{{ host2_fqdn }}"
       action: member
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure host can manage service, again.
     ipaservice:
@@ -137,7 +139,7 @@
       host: "{{ host1_fqdn }}"
       action: member
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Ensure host cannot manage service.
     ipaservice:
@@ -149,7 +151,7 @@
       action: member
       state: absent
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure host cannot manage service, again.
     ipaservice:
@@ -161,7 +163,7 @@
       action: member
       state: absent
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Service "HTTP/{{ svc_fqdn }}" members allow_create_keytab present for users, groups, hosts and hostgroups.
     ipaservice:
@@ -181,7 +183,7 @@
       - hostgroup02
       action: member
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Service "HTTP/{{ svc_fqdn }}" members allow_create_keytab present for users, groups, hosts and hostgroups, again.
     ipaservice:
@@ -201,7 +203,7 @@
       - hostgroup02
       action: member
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Service "HTTP/{{ svc_fqdn }}" members allow_create_keytab absent for users, groups, hosts and hostgroups.
     ipaservice:
@@ -222,7 +224,7 @@
       action: member
       state: absent
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Service "HTTP/{{ svc_fqdn }}" members allow_create_keytab absent for users, groups, hosts and hostgroups, again.
     ipaservice:
@@ -243,7 +245,7 @@
       action: member
       state: absent
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Service "HTTP/{{ svc_fqdn }}" members allow_retrieve_keytab present for users, groups, hosts and hostgroups
     ipaservice:
@@ -263,7 +265,7 @@
       - hostgroup02
       action: member
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Service "HTTP/{{ svc_fqdn }}" members allow_retrieve_keytab present for users, groups, hosts and hostgroups, again.
     ipaservice:
@@ -283,7 +285,7 @@
       - hostgroup02
       action: member
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Service "HTTP/{{ svc_fqdn }}" members allow_retrieve_keytab absent for users, groups, hosts and hostgroups.
     ipaservice:
@@ -304,7 +306,7 @@
       action: member
       state: absent
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Service "HTTP/{{ svc_fqdn }}" members allow_retrieve_keytab absent for users, groups, hosts and hostgroups, again.
     ipaservice:
@@ -325,16 +327,17 @@
       action: member
       state: absent
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   #
   - name: Ensure service is absent
     ipaservice:
       ipaadmin_password: SomeADMINpassword
       name: "HTTP/{{ svc_fqdn }}"
+      continue: yes
       state: absent
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure service is absent, again
     ipaservice:
@@ -342,7 +345,7 @@
       name: "HTTP/{{ svc_fqdn }}"
       state: absent
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   # cleanup
   - name: Cleanup test environment


### PR DESCRIPTION
This PR fixes ipaservice tests by enabling test fail when `result.failed` is `True`,
and fix the module handling EmptyModList and DuplicateEntry exceptions.