### PR TITLE
ansible-doc-test: ANSIBLE_LIBRARY needs to be set internally

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Run ansible-doc-test
         run: |
           python -m pip install "ansible < 2.10"
-          ANSIBLE_LIBRARY="." python utils/ansible-doc-test roles plugins
+          ANSIBLE_LIBRARY="." python utils/ansible-doc-test -v roles plugins
   
   check_docs_latest:
     name: Check Ansible Documentation with latest Ansible.

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -28,5 +28,5 @@ jobs:
       - name: Run ansible-doc-test
         run: |
           python -m pip install ansible
-          ANSIBLE_LIBRARY="." python utils/ansible-doc-test roles plugins
+          ANSIBLE_LIBRARY="." python utils/ansible-doc-test -v roles plugins
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,6 +26,6 @@ repos:
   - id: ansible-doc-test
     name: Verify Ansible roles and module documentation.
     language: python
-    entry: env ANSIBLE_LIBRARY=./plugins/modules utils/ansible-doc-test
+    entry: utils/ansible-doc-test
     # args: ['-v', 'roles', 'plugins']
     files: ^.*.py$

--- a/utils/ansible-doc-test
+++ b/utils/ansible-doc-test
@@ -29,12 +29,16 @@ import subprocess
 
 def run_ansible_doc(role, module, verbose=False):
     playbook_dir, module_path = get_playbook_dir(role, module)
+    module_dir = os.path.dirname(module_path)
 
-    command = ["ansible-doc",
+    command = ["env",
+               "ANSIBLE_LIBRARY=%s" % module_dir,
+               "ansible-doc",
                "--playbook-dir=%s" % playbook_dir,
                "--type=module",
                "-vvv",
                module]
+
     process = subprocess.run(command,
                              stdout=subprocess.PIPE,
                              stderr=subprocess.PIPE)


### PR DESCRIPTION
**.pre-commit-config.yaml: Do not set ANSIBLE_LIBRARY for ansible-doc-test**

With latest Ansible (4.0.0) it is needed to have a complete path for
ANSIBLE_LIBRARY. It is not good to hard code this in the
.pre-commit-config.yaml file for plugins and also all roles. Instead
it will be set in ansible-doc-test as it knows the path for each file
that is checked.

**.github/workflows/docs.yml: Enable verbose mode for ansible-doc-test**

Currently ansible-doc-test is run silently. There is no output about
the checked files in the test results. Therefore verbose mode has been
enabled.

**ansible-doc-test: Set ANSIBLE_LIBRARY using module_dir internally**

ANSIBLE_LIBRARY needs to be set properly for new Ansible version 4.0.0
to make sure that it is able to find the module that is checked.

For every file that needs to be checked, there is a separate ansible-doc
call. ANSIBLE_LIBRARY is set using os.path.dirname on the module_path.
