### PR TITLE
Fix and enhance tests

### DIFF
--- a/tests/config/test_config.yml
+++ b/tests/config/test_config.yml
@@ -110,84 +110,84 @@
       ipaadmin_password: SomeADMINpassword
       emaildomain: somedomain.test
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure the default e-mail domain is somedomain.test, again.
     ipaconfig:
       ipaadmin_password: SomeADMINpassword
       emaildomain: somedomain.test
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: set default shell to '/bin/someshell'
     ipaconfig:
       ipaadmin_password: SomeADMINpassword
       defaultshell: /bin/someshell
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: set default shell to '/bin/someshell', again.
     ipaconfig:
       ipaadmin_password: SomeADMINpassword
       defaultshell: /bin/someshell
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: set default group
     ipaconfig:
       ipaadmin_password: SomeADMINpassword
       defaultgroup: somedefaultgroup
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
-  - name: set default group
+  - name: set default group, again
     ipaconfig:
       ipaadmin_password: SomeADMINpassword
       defaultgroup: somedefaultgroup
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: set default home directory
     ipaconfig:
       ipaadmin_password: SomeADMINpassword
       homedirectory: /Users
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
-  - name: set default home directory
+  - name: set default home directory, again
     ipaconfig:
       ipaadmin_password: SomeADMINpassword
       homedirectory: /Users
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: set pac-type
     ipaconfig:
       ipaadmin_password: SomeADMINpassword
       pac_type: "nfs:NONE"
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: set pac-type, again.
     ipaconfig:
       ipaadmin_password: SomeADMINpassword
       pac_type: "nfs:NONE"
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: set maxusername to 33
     ipaconfig:
       ipaadmin_password: SomeADMINpassword
       maxusername: 33
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: set maxusername to 33, again.
     ipaconfig:
       ipaadmin_password: SomeADMINpassword
       maxusername: 33
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: set maxhostname to 77
     block:
@@ -195,13 +195,13 @@
           ipaadmin_password: SomeADMINpassword
           maxhostname: 77
         register: result
-        failed_when: not result.changed
+        failed_when: not result.changed or result.failed
 
       - ipaconfig:
           ipaadmin_password: SomeADMINpassword
           maxhostname: 77
         register: result
-        failed_when: result.changed
+        failed_when: result.changed or result.failed
     when: ipa_version is version('4.8.0', '>=')
 
   - name: set pwdexpnotify to 17
@@ -209,126 +209,126 @@
       ipaadmin_password: SomeADMINpassword
       pwdexpnotify: 17
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: set pwdexpnotify to 17, again
     ipaconfig:
       ipaadmin_password: SomeADMINpassword
       pwdexpnotify: 17
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: set searchrecordslimit to -1
     ipaconfig:
       ipaadmin_password: SomeADMINpassword
       searchrecordslimit: -1
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: set searchrecordslimit to -1, again.
     ipaconfig:
       ipaadmin_password: SomeADMINpassword
       searchrecordslimit: -1
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: set searchtimelimit to 12345
     ipaconfig:
       ipaadmin_password: SomeADMINpassword
       searchtimelimit: 12345
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: set searchtimelimit to 12345, again.
     ipaconfig:
       ipaadmin_password: SomeADMINpassword
       searchtimelimit: 12345
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: change enable_migration
     ipaconfig:
       ipaadmin_password: SomeADMINpassword
       enable_migration: '{{ not previousconfig.config.enable_migration }}'
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: change enable_migration, again
     ipaconfig:
       ipaadmin_password: SomeADMINpassword
       enable_migration: '{{ not previousconfig.config.enable_migration }}'
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: set configstring to AllowNThash
     ipaconfig:
       ipaadmin_password: SomeADMINpassword
       configstring: AllowNThash
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: set configstring to AllowNThash, again.
     ipaconfig:
       ipaadmin_password: SomeADMINpassword
       configstring: AllowNThash
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: set selinuxusermaporder
     ipaconfig:
       ipaadmin_password: SomeADMINpassword
       selinuxusermaporder: 'user_u:s0$staff_u:s0-s0:c0.c1023$sysadm_u:s0-s0:c0.c1023$unconfined_u:s0-s0:c0.c1023'
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: set selinuxusermaporder, again
     ipaconfig:
       ipaadmin_password: SomeADMINpassword
       selinuxusermaporder: 'user_u:s0$staff_u:s0-s0:c0.c1023$sysadm_u:s0-s0:c0.c1023$unconfined_u:s0-s0:c0.c1023'
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: set selinuxusermapdefault
     ipaconfig:
       ipaadmin_password: SomeADMINpassword
       selinuxusermapdefault: 'user_u:s0'
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: set selinuxusermapdefault, again
     ipaconfig:
       ipaadmin_password: SomeADMINpassword
       selinuxusermapdefault: 'user_u:s0'
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: set groupsearch to `description`
     ipaconfig:
       ipaadmin_password: SomeADMINpassword
       groupsearch: description
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: set groupsearch to `gidNumber`, again
     ipaconfig:
       ipaadmin_password: SomeADMINpassword
       groupsearch: description
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: set usersearch to `uidNumber`
     ipaconfig:
       ipaadmin_password: SomeADMINpassword
       usersearch: uidNumber
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: set usersearch to `uidNumber`, again
     ipaconfig:
       ipaadmin_password: SomeADMINpassword
       usersearch: uidNumber
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: reset changed fields
     ipaconfig:
@@ -354,7 +354,7 @@
       domain_resolution_order: '{{previousconfig.config.domain_resolution_order | default(omit)}}'
       ca_renewal_master_server: '{{previousconfig.config.ca_renewal_master_server | default(omit)}}'
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: reset maxhostname
     block:
@@ -387,7 +387,7 @@
       domain_resolution_order: '{{previousconfig.config.domain_resolution_order | default(omit)}}'
       ca_renewal_master_server: '{{previousconfig.config.ca_renewal_master_server | default(omit)}}'
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: reset maxhostname
     block:

--- a/tests/dnsconfig/test_dnsconfig.yml
+++ b/tests/dnsconfig/test_dnsconfig.yml
@@ -53,7 +53,7 @@
       forward_policy: only
       allow_sync_ptr: yes
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Set dnsconfig, with the same values.
     ipadnsconfig:
@@ -66,7 +66,7 @@
       forward_policy: only
       allow_sync_ptr: yes
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Ensure forwarder is absent.
     ipadnsconfig:
@@ -75,7 +75,7 @@
         - ip_address: 8.8.8.8
       state: absent
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure forwarder is absent, again.
     ipadnsconfig:
@@ -84,63 +84,63 @@
         - ip_address: 8.8.8.8
       state: absent
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Disable global forwarders.
     ipadnsconfig:
       ipaadmin_password: SomeADMINpassword
       forward_policy: none
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Disable global forwarders, again.
     ipadnsconfig:
       ipaadmin_password: SomeADMINpassword
       forward_policy: none
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Re-enable global forwarders.
     ipadnsconfig:
       ipaadmin_password: SomeADMINpassword
       forward_policy: first
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Re-enable global forwarders, again.
     ipadnsconfig:
       ipaadmin_password: SomeADMINpassword
       forward_policy: first
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Disable PTR record synchronization.
     ipadnsconfig:
       ipaadmin_password: SomeADMINpassword
       allow_sync_ptr: no
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Disable PTR record synchronization, again.
     ipadnsconfig:
       ipaadmin_password: SomeADMINpassword
       allow_sync_ptr: no
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Re-enable PTR record synchronization.
     ipadnsconfig:
       ipaadmin_password: SomeADMINpassword
       allow_sync_ptr: yes
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Re-enable PTR record synchronization, again.
     ipadnsconfig:
       ipaadmin_password: SomeADMINpassword
       allow_sync_ptr: yes
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Ensure all forwarders are absent.
     ipadnsconfig:
@@ -152,7 +152,7 @@
           port: 53
       state: absent
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
 
   - name: Ensure all forwarders are absent, again.
@@ -165,7 +165,7 @@
           port: 53
       state: absent
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   # Cleanup.
   - name: Ensure forwarders are absent.

--- a/tests/dnsforwardzone/test_dnsforwardzone.yml
+++ b/tests/dnsforwardzone/test_dnsforwardzone.yml
@@ -23,7 +23,7 @@
       forwardpolicy: first
       skip_overlap_check: true
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: ensure forwardzone example.com is present again
     ipadnsforwardzone:
@@ -35,7 +35,7 @@
       forwardpolicy: first
       skip_overlap_check: true
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: ensure forwardzone example.com has two forwarders
     ipadnsforwardzone:
@@ -49,7 +49,7 @@
       forwardpolicy: first
       skip_overlap_check: true
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: ensure forwardzone example.com has one forwarder again
     ipadnsforwardzone:
@@ -61,7 +61,7 @@
       skip_overlap_check: true
       state: present
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: skip_overlap_check can only be set on creation so change nothing
     ipadnsforwardzone:
@@ -73,7 +73,7 @@
       skip_overlap_check: false
       state: present
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: ensure forwardzone example.com is absent.
     ipadnsforwardzone:
@@ -81,7 +81,7 @@
       name: example.com
       state: absent
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: ensure forwardzone example.com is absent, again.
     ipadnsforwardzone:
@@ -89,7 +89,7 @@
       name: example.com
       state: absent
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: change all the things at once
     ipadnsforwardzone:
@@ -104,7 +104,7 @@
       skip_overlap_check: true
       permission: yes
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: change zone forward policy
     ipadnsforwardzone:
@@ -112,7 +112,7 @@
       name: example.com
       forwardpolicy: first
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: change zone forward policy, again
     ipadnsforwardzone:
@@ -120,7 +120,7 @@
       name: example.com
       forwardpolicy: first
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: ensure forwardzone example.com is absent.
     ipadnsforwardzone:
@@ -147,7 +147,7 @@
       forwarders:
         - ip_address: 8.8.8.8
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: ensure forwardzone example.com is created with minimal args, again
     ipadnsforwardzone:
@@ -170,7 +170,7 @@
           port: 8053
       action: member
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: add a forwarder to any existing ones, again
     ipadnsforwardzone:
@@ -195,7 +195,7 @@
         - ip_address: 8.8.8.8
       action: member
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: remove a single forwarder
     ipadnsforwardzone:
@@ -206,7 +206,7 @@
         - ip_address: 8.8.8.8
       action: member
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: remove a single forwarder, again
     ipadnsforwardzone:
@@ -229,7 +229,7 @@
           port: 8053
       action: member
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Add a permission for per-forward zone access delegation.
     ipadnsforwardzone:
@@ -238,7 +238,7 @@
       permission: yes
       action: member
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Add a permission for per-forward zone access delegation, again.
     ipadnsforwardzone:
@@ -247,7 +247,7 @@
       permission: yes
       action: member
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Remove a permission for per-forward zone access delegation.
     ipadnsforwardzone:
@@ -256,7 +256,7 @@
       permission: no
       action: member
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Remove a permission for per-forward zone access delegation, again.
     ipadnsforwardzone:
@@ -265,7 +265,7 @@
       permission: no
       action: member
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: disable the forwarder
     ipadnsforwardzone:
@@ -273,7 +273,7 @@
       name: example.com
       state: disabled
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: disable the forwarder again
     ipadnsforwardzone:
@@ -281,7 +281,7 @@
       name: example.com
       state: disabled
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: enable the forwarder
     ipadnsforwardzone:
@@ -289,7 +289,7 @@
       name: example.com
       state: enabled
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: enable the forwarder, again
     ipadnsforwardzone:
@@ -297,7 +297,7 @@
       name: example.com
       state: enabled
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: ensure forwardzone example.com is absent again
     ipadnsforwardzone:

--- a/tests/dnsforwardzone/test_dnsforwardzone.yml
+++ b/tests/dnsforwardzone/test_dnsforwardzone.yml
@@ -127,6 +127,16 @@
       ipaadmin_password: SomeADMINpassword
       name: example.com
       state: absent
+    register: result
+    failed_when: not result.changed or result.failed
+
+  - name: ensure forwardzone example.com is absent, again.
+    ipadnsforwardzone:
+      ipaadmin_password: SomeADMINpassword
+      name: example.com
+      state: absent
+    register: result
+    failed_when: result.changed or result.failed
 
   - name: ensure forwardzone example.com is created with minimal args
     ipadnsforwardzone:
@@ -139,6 +149,17 @@
     register: result
     failed_when: not result.changed
 
+  - name: ensure forwardzone example.com is created with minimal args, again
+    ipadnsforwardzone:
+      ipaadmin_password: SomeADMINpassword
+      state: present
+      name: example.com
+      skip_overlap_check: true
+      forwarders:
+        - ip_address: 8.8.8.8
+    register: result
+    failed_when: result.changed or result.failed
+
   - name: add a forwarder to any existing ones
     ipadnsforwardzone:
       ipaadmin_password: SomeADMINpassword
@@ -150,6 +171,18 @@
       action: member
     register: result
     failed_when: not result.changed
+
+  - name: add a forwarder to any existing ones, again
+    ipadnsforwardzone:
+      ipaadmin_password: SomeADMINpassword
+      state: present
+      name: example.com
+      forwarders:
+        - ip_address: 4.4.4.4
+          port: 8053
+      action: member
+    register: result
+    failed_when: result.changed or result.failed
 
   - name: check the list of forwarders is what we expect
     ipadnsforwardzone:
@@ -174,6 +207,17 @@
       action: member
     register: result
     failed_when: not result.changed
+
+  - name: remove a single forwarder, again
+    ipadnsforwardzone:
+      ipaadmin_password: SomeADMINpassword
+      state: absent
+      name: example.com
+      forwarders:
+        - ip_address: 8.8.8.8
+      action: member
+    register: result
+    failed_when: result.changed or result.failed
 
   - name: check the list of forwarders is what we expect now
     ipadnsforwardzone:

--- a/tests/dnsrecord/env_vars.yml
+++ b/tests/dnsrecord/env_vars.yml
@@ -4,9 +4,9 @@
   set_fact:
     ipv4_prefix: "{{ ansible_facts['default_ipv4'].address.split('.')[:-1] |
                      join('.') }}"
-    ipv4_reverse_sufix: "{{ ansible_facts['default_ipv4'].address.split('.')[:-1] |
-                            reverse |
-                            join('.') }}"
+    ipv4_reverse: "{{ ansible_facts['default_ipv4'].address.split('.')[:-1] |
+                      reverse |
+                      join('.') }}"
 
 - name: Set zone prefixes.
   set_fact:
@@ -14,7 +14,7 @@
     safezone: 'safezone.test'
     zone_ipv6_reverse: "ip6.arpa."
     zone_ipv6_reverse_workaround: "d.f.ip6.arpa."
-    zone_prefix_reverse: "in-addr.arpa"
-    zone_prefix_reverse_24: "{{ ipv4_prefix.split('.')[::-1] | join ('.') }}.in-addr.arpa"
-    zone_prefix_reverse_16: "{{ ipv4_prefix.split('.')[1::-1] | join ('.') }}.in-addr.arpa"
-    zone_prefix_reverse_8: "{{ ipv4_prefix.split('.')[2::-1] | join ('.') }}.in-addr.arpa"
+    zone_prefix_reverse: "in-addr.arpa."
+    zone_prefix_reverse_24: "{{ ipv4_reverse.split('.')[:] | join ('.') }}.in-addr.arpa."
+    zone_prefix_reverse_16: "{{ ipv4_reverse.split('.')[1:] | join ('.') }}.in-addr.arpa."
+    zone_prefix_reverse_8: "{{ ipv4_reverse.split('.')[2:] | join ('.') }}.in-addr.arpa."

--- a/tests/dnsrecord/test_dnsrecord.yml
+++ b/tests/dnsrecord/test_dnsrecord.yml
@@ -289,6 +289,7 @@
       name: host04
       ip_address: "{{ ipv4_prefix }}.114"
       reverse: yes
+    failed_when: result.changed or result.failed
 
   - name: Ensure that 'host04' has an A record with reverse, again.
     ipadnsrecord:
@@ -425,6 +426,8 @@
     register: result
     failed_when: result.changed or result.failed
 
+  # This task only ensures proper records are present,
+  # it is not testing anything, and should not faild.
   - name: Ensure that 'host04' has a A record with reverse, for NS record.
     ipadnsrecord:
       ipaadmin_password: SomeADMINpassword
@@ -433,17 +436,7 @@
       ip_address: "{{ ipv4_prefix }}.114"
       reverse: yes
     register: result
-    failed_when: not result.changed or result.failed
-
-  - name: Ensure that 'host04' has a A record with reverse, for NS record, again.
-    ipadnsrecord:
-      ipaadmin_password: SomeADMINpassword
-      zone_name: "{{ testzone }}"
-      name: host04
-      ip_address: "{{ ipv4_prefix }}.114"
-      reverse: yes
-    register: result
-    failed_when: result.changed or result.failed
+    failed_when: result.failed
 
   - name: Ensure that 'host04' has NS record.
     ipadnsrecord:
@@ -461,7 +454,9 @@
       name: host04
       ns_hostname: host04
     register: result
-    failed_when: result.changed or result.failed
+    # IPA issue 8850 should be fixed before we handle the failed_when
+    # message. For now, we'll just test if it does not fail.
+    failed_when: result.changed or not result.failed
 
   - name: Ensure that 'host04' NS record is absent.
     ipadnsrecord:
@@ -632,7 +627,7 @@
       ds_key_tag: 54321
       ds_rec: 12345 3 1 84763786e4213cca9a6938dba5dacd64f87ec216
     register: result
-    failed_when: result.changed or result.failed
+    failed_when: result.changed or (result.failed and "DS record does not contain" not in result.msg)
 
   - name: Ensure that 'iron01' DS record is absent.
     ipadnsrecord:
@@ -692,7 +687,7 @@
       afsdb_subtype: 2
       afsdb_rec: "1 host04.{{ testzone }}"
     register: result
-    failed_when: result.changed or result.failed
+    failed_when: result.changed or (result.failed and "AFSDB record does not contain" not in result.msg)
 
   - name: Ensure that 'host04' AFSDB record is absent.
     ipadnsrecord:
@@ -796,7 +791,7 @@
       kx_preference: 20
       kx_rec: "10 keyex.{{ testzone }}"
     register: result
-    failed_when: result.changed or result.failed
+    failed_when: result.changed or (result.failed and "KX record does not contain" not in result.msg)
 
   - name: Ensure that 'host04' KX record is present with preference set to 20, one more time.
     ipadnsrecord:
@@ -960,7 +955,7 @@
       naptr_regexp: "!^.*$!sip:info@example.com!"
       naptr_replacement: "."
     register: result
-    failed_when: result.failed or not result.changed
+    failed_when: result.failed or not result.changed or result.failed
 
   - name: Ensure that '_sip._udp' service has NAPTR record, again.
     ipadnsrecord:
@@ -1099,7 +1094,7 @@
       srv_target: sip-server."{{ testzone }}"
       srv_rec: "10 10 5060 sip-server.{{ testzone }}"
     register: result
-    failed_when: result.changed or result.failed
+    failed_when: result.changed or (result.failed and "SRV record does not contain" not in result.msg)
 
   - name: Ensurer '_sip._udp' SRV record has priority 2, weight 20
     ipadnsrecord:
@@ -1232,7 +1227,7 @@
       tlsa_matching_type: 0
       tlsa_rec: 3 1 1 9c0ad776dbeae8d9d55b0ad42899d30235c114d5f918fd69746e4279e47bdaa2
     register: result
-    failed_when: result.changed or result.failed
+    failed_when: result.changed or (result.failed and "TLSA record does not contain" not in result.msg)
 
   - name: Ensure that 'host04' TLSA record is absent.
     ipadnsrecord:

--- a/tests/dnsrecord/test_dnsrecord.yml
+++ b/tests/dnsrecord/test_dnsrecord.yml
@@ -432,6 +432,18 @@
       name: host04
       ip_address: "{{ ipv4_prefix }}.114"
       reverse: yes
+    register: result
+    failed_when: not result.changed or result.failed
+
+  - name: Ensure that 'host04' has a A record with reverse, for NS record, again.
+    ipadnsrecord:
+      ipaadmin_password: SomeADMINpassword
+      zone_name: "{{ testzone }}"
+      name: host04
+      ip_address: "{{ ipv4_prefix }}.114"
+      reverse: yes
+    register: result
+    failed_when: result.changed or result.failed
 
   - name: Ensure that 'host04' has NS record.
     ipadnsrecord:

--- a/tests/dnsrecord/test_dnsrecord.yml
+++ b/tests/dnsrecord/test_dnsrecord.yml
@@ -1374,6 +1374,7 @@
 
   - name: Verify if modification worked.
     ipadnsrecord:
+      ipaadmin_password: SomeADMINpassword
       zone_name: "{{ testzone }}"
       name: _ftp._tcp
       uri_rec: 10 1 ftp://ftp.host04.{{ testzone }}/public

--- a/tests/dnsrecord/test_dnsrecord.yml
+++ b/tests/dnsrecord/test_dnsrecord.yml
@@ -1374,6 +1374,8 @@
 
   - name: Verify if modification worked.
     ipadnsrecord:
+      zone_name: "{{ testzone }}"
+      name: _ftp._tcp
       uri_rec: 10 1 ftp://ftp.host04.{{ testzone }}/public
       state: absent
     register: result

--- a/tests/dnsrecord/test_dnsrecord.yml
+++ b/tests/dnsrecord/test_dnsrecord.yml
@@ -28,7 +28,7 @@
       record_type: AAAA
       record_value: ::1
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure that dns record 'host01' is present, again
     ipadnsrecord:
@@ -38,7 +38,7 @@
       record_type: AAAA
       record_value: ::1
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Ensure that dns record 'host02' is present
     ipadnsrecord:
@@ -48,7 +48,7 @@
       record_type: A
       record_value: "{{ ipv4_prefix }}.102"
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure that dns record 'host02' is present, again
     ipadnsrecord:
@@ -58,7 +58,7 @@
       record_type: A
       record_value: "{{ ipv4_prefix }}.102"
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Modify record 'host02' with multiple A and AAAA record.
     ipadnsrecord:
@@ -75,7 +75,7 @@
           record_type: AAAA
           record_value: ::1
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Modify record 'host02' with multiple A and AAAA record, again.
     ipadnsrecord:
@@ -92,7 +92,7 @@
           record_type: AAAA
           record_value: ::1
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Ensure 'host02' A6 record is present.
     ipadnsrecord:
@@ -101,7 +101,7 @@
       name: host02
       a6_data: ::1
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure 'host02' A6 record is present, again.
     ipadnsrecord:
@@ -110,7 +110,7 @@
       name: host02
       a6_rec: ::1
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Ensure 'host02' A6 record is absent.
     ipadnsrecord:
@@ -120,7 +120,7 @@
       a6_rec: ::1
       state: absent
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure 'host02' A6 record is absent, again.
     ipadnsrecord:
@@ -130,7 +130,7 @@
       a6_rec: ::1
       state: absent
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Ensure that dns record 'host03' is present, with reverse record.
     ipadnsrecord:
@@ -140,7 +140,7 @@
       a_ip_address: "{{ ipv4_prefix }}.103"
       a_create_reverse: yes
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure that dns record 'host03' is present, with reverse record, again
     ipadnsrecord:
@@ -151,7 +151,7 @@
       record_value: "{{ ipv4_prefix }}.103"
       create_reverse: yes
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Delete all entries associated with host03
     ipadnsrecord:
@@ -161,7 +161,7 @@
       del_all: yes
       state: absent
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Delete all entries associated with host03, again
     ipadnsrecord:
@@ -171,7 +171,7 @@
       del_all: yes
       state: absent
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Ensure that 'host04' has CNAME
     ipadnsrecord:
@@ -181,7 +181,7 @@
       record_type: CNAME
       record_value: "host04.{{ testzone }}"
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure that 'host04' has CNAME, again
     ipadnsrecord:
@@ -190,7 +190,7 @@
       name: host04
       cname_hostname: "host04.{{ testzone }}"
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Ensure that 'host04' CNAME is absent
     ipadnsrecord:
@@ -200,7 +200,7 @@
       cname_rec: "host04.{{ testzone }}"
       state: absent
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure that 'host04' CNAME is absent, again
     ipadnsrecord:
@@ -211,7 +211,7 @@
       record_value: "host04.{{ testzone }}"
       state: absent
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Ensure that 'host04' and 'host03' have CNAME, with cname_hostname
     ipadnsrecord:
@@ -223,7 +223,7 @@
         - name: host03
           cname_hostname: "host03.{{ testzone }}"
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure that 'host04' has CNAME, with cname_hostname, again
     ipadnsrecord:
@@ -232,7 +232,7 @@
       name: host04
       cname_hostname: "host04.{{ testzone }}"
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Ensure that 'host04' CNAME is absent.
     ipadnsrecord:
@@ -242,7 +242,7 @@
       cname_rec: "host04.{{ testzone }}"
       state: absent
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure that 'host04' has A record.
     ipadnsrecord:
@@ -251,7 +251,7 @@
       name: host04
       ip_address: "{{ ipv4_prefix }}.104"
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure that 'host04' has A record, again.
     ipadnsrecord:
@@ -260,7 +260,7 @@
       name: host04
       ip_address: "{{ ipv4_prefix }}.104"
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Ensure that 'host04' has the same A record with reverse.
     ipadnsrecord:
@@ -270,7 +270,7 @@
       a_rec: "{{ ipv4_prefix }}.104"
       reverse: yes
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure that 'host04' has the same A record with reverse, again.
     ipadnsrecord:
@@ -280,7 +280,7 @@
       a_rec: "{{ ipv4_prefix }}.104"
       reverse: yes
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Ensure that 'host04' has an A record with reverse, for NS record.
     ipadnsrecord:
@@ -298,7 +298,7 @@
       ip_address: "{{ ipv4_prefix }}.114"
       reverse: yes
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Ensure that 'host04' has AAAA record.
     ipadnsrecord:
@@ -308,7 +308,7 @@
       aaaa_ip_address: fd00::0004
       aaaa_create_reverse: yes
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure that 'host04' has AAAA record, again.
     ipadnsrecord:
@@ -318,7 +318,7 @@
       ip_address: fd00::0004
       reverse: yes
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Ensure that 'host04' has AAAA record, without reverse.
     ipadnsrecord:
@@ -327,7 +327,7 @@
       name: host04
       ip_address: fd00::0014
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure that 'host04' previous AAAA record, now has a reverse record.
     ipadnsrecord:
@@ -337,7 +337,7 @@
       aaaa_rec: fd00::0014
       reverse: yes
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure that 'host04' previous AAAA record, now has a reverse record, again.
     ipadnsrecord:
@@ -347,7 +347,7 @@
       aaaa_rec: fd00::0014
       reverse: yes
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Ensure that 'host04' has PTR record.
     ipadnsrecord:
@@ -356,7 +356,7 @@
       name: "124"
       ptr_hostname: "host04.{{ testzone }}"
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure that 'host04' has PTR record, again.
     ipadnsrecord:
@@ -365,7 +365,7 @@
       name: "124"
       ptr_hostname: "host04.{{ testzone }}"
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Ensure that 'host04' has PTR record is absent.
     ipadnsrecord:
@@ -375,7 +375,7 @@
       ptr_rec: "host04.{{ testzone }}"
       state: absent
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure that 'host04' has PTR record is absent, again.
     ipadnsrecord:
@@ -385,7 +385,7 @@
       ptr_rec: "host04.{{ testzone }}"
       state: absent
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Ensure that 'host04' has DNAME record.
     ipadnsrecord:
@@ -394,7 +394,7 @@
       name: host04
       dname_target: "ipa.{{ testzone }}"
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure that 'host04' has DNAME record, again.
     ipadnsrecord:
@@ -403,7 +403,7 @@
       name: host04
       dname_target: "ipa.{{ testzone }}"
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Ensure that 'host04' DNAME record is absent.
     ipadnsrecord:
@@ -413,7 +413,7 @@
       dname_rec: "ipa.{{ testzone }}"
       state: absent
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure that 'host04' DNAME record is absent, again.
     ipadnsrecord:
@@ -423,7 +423,7 @@
       dname_rec: "ipa.{{ testzone }}"
       state: absent
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Ensure that 'host04' has a A record with reverse, for NS record.
     ipadnsrecord:
@@ -452,7 +452,7 @@
       name: host04
       ns_hostname: host04
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure that 'host04' has NS record, again.
     ipadnsrecord:
@@ -461,7 +461,7 @@
       name: host04
       ns_hostname: host04
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Ensure that 'host04' NS record is absent.
     ipadnsrecord:
@@ -471,7 +471,7 @@
       ns_rec: host04
       state: absent
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure that 'host04' NS record is absent, again.
     ipadnsrecord:
@@ -481,7 +481,7 @@
       ns_rec: host04
       state: absent
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Ensure that 'host04' DLV record is present.
     ipadnsrecord:
@@ -578,7 +578,7 @@
       zone_name: "{{ safezone }}"
       ip_address: "{{ ansible_facts['default_ipv4'].address }}"
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure that NS record for "{{ safezone }}" is present
     ipadnsrecord:
@@ -587,7 +587,7 @@
       zone_name: "{{ safezone }}"
       ns_hostname: iron01
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure that 'iron01' DS record is present.
     ipadnsrecord:
@@ -600,7 +600,7 @@
       # digest is sha1sum of 'iron01."{{ safezone }}"'
       ds_digest: 84763786e4213cca9a6938dba5dacd64f87ec216
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure that 'iron01' DS record is present, again.
     ipadnsrecord:
@@ -612,7 +612,7 @@
       ds_digest_type: 1
       ds_digest: 84763786e4213cca9a6938dba5dacd64f87ec216
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Ensure that 'iron01' DS record is present, with a different key tag.
     ipadnsrecord:
@@ -622,7 +622,7 @@
       ds_key_tag: 54321
       ds_rec: 12345 3 1 84763786e4213cca9a6938dba5dacd64f87ec216
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure that 'iron01' DS record is present, with a different key tag, again.
     ipadnsrecord:
@@ -632,7 +632,7 @@
       ds_key_tag: 54321
       ds_rec: 12345 3 1 84763786e4213cca9a6938dba5dacd64f87ec216
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Ensure that 'iron01' DS record is absent.
     ipadnsrecord:
@@ -642,7 +642,7 @@
       ds_rec: 54321 3 1 84763786e4213cca9a6938dba5dacd64f87ec216
       state: absent
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure that 'iron01' DS record is absent, again.
     ipadnsrecord:
@@ -652,7 +652,7 @@
       ds_rec: 54321 3 1 84763786e4213cca9a6938dba5dacd64f87ec216
       state: absent
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Ensure that 'host04' AFSDB record is present.
     ipadnsrecord:
@@ -662,7 +662,7 @@
       afsdb_subtype: 1
       afsdb_hostname: "host04.{{ testzone }}"
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure that 'host04' AFSDB record is present, again.
     ipadnsrecord:
@@ -672,7 +672,7 @@
       afsdb_subtype: 1
       afsdb_hostname: "host04.{{ testzone }}"
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Ensure that 'host04' AFSDB record subtype is 2.
     ipadnsrecord:
@@ -682,7 +682,7 @@
       afsdb_subtype: 2
       afsdb_rec: "1 host04.{{ testzone }}"
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure that 'host04' AFSDB record subtype is 2, again.
     ipadnsrecord:
@@ -692,7 +692,7 @@
       afsdb_subtype: 2
       afsdb_rec: "1 host04.{{ testzone }}"
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Ensure that 'host04' AFSDB record is absent.
     ipadnsrecord:
@@ -702,7 +702,7 @@
       afsdb_rec: "2 host04.{{ testzone }}"
       state: absent
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure that 'host04' AFSDB record is absent, again.
     ipadnsrecord:
@@ -712,7 +712,7 @@
       afsdb_rec: "2 host04.{{ testzone }}"
       state: absent
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Ensure that 'host04' CERT record is present.
     ipadnsrecord:
@@ -724,7 +724,7 @@
       cert_algorithm: 3
       cert_certificate_or_crl: "{{ lookup('file', 'cert1.b64') }}"
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure that 'host04' CERT record is present, again.
     ipadnsrecord:
@@ -736,7 +736,7 @@
       cert_algorithm: 3
       cert_certificate_or_crl: "{{ lookup('file', 'cert1.b64') }}"
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Ensure that 'host04' CERT record is absent.
     ipadnsrecord:
@@ -746,7 +746,7 @@
       cert_rec: "1 1234 3 {{ lookup('file', 'cert1.b64') }}"
       state: absent
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure that 'host04' CERT record is absent, again.
     ipadnsrecord:
@@ -756,7 +756,7 @@
       cert_rec: 1 1234 3 "{{ lookup('file', 'cert1.b64') }}"
       state: absent
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Ensure that 'host04' KX record is present.
     ipadnsrecord:
@@ -766,7 +766,7 @@
       kx_preference: 10
       kx_exchanger: "keyex.{{ testzone }}"
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure that 'host04' KX record is present, again.
     ipadnsrecord:
@@ -776,7 +776,7 @@
       kx_preference: 10
       kx_exchanger: "keyex.{{ testzone }}"
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Ensure that 'host04' KX record is present with preference set to 20.
     ipadnsrecord:
@@ -786,7 +786,7 @@
       kx_preference: 20
       kx_rec: "10 keyex.{{ testzone }}"
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure that 'host04' KX record is present with preference set to 20, again.
     ipadnsrecord:
@@ -796,7 +796,7 @@
       kx_preference: 20
       kx_rec: "10 keyex.{{ testzone }}"
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Ensure that 'host04' KX record is present with preference set to 20, one more time.
     ipadnsrecord:
@@ -806,7 +806,7 @@
       kx_preference: 20
       kx_rec: "20 keyex.{{ testzone }}"
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Ensure that 'host04' KX record is absent.
     ipadnsrecord:
@@ -816,7 +816,7 @@
       kx_rec: "20 keyex.{{ testzone }}"
       state: absent
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure that 'host04' KX record is absent, again.
     ipadnsrecord:
@@ -826,7 +826,7 @@
       kx_rec: "20 keyex.{{ testzone }}"
       state: absent
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Ensure that 'host04' MX record is present.
     ipadnsrecord:
@@ -836,7 +836,7 @@
       mx_preference: 10
       mx_exchanger: "mail.{{ testzone }}"
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure that 'host04' MX record is present, again.
     ipadnsrecord:
@@ -846,7 +846,7 @@
       mx_preference: 10
       mx_exchanger: "mail.{{ testzone }}"
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Ensure that 'host04' MX record is present with preference set to 20.
     ipadnsrecord:
@@ -856,7 +856,7 @@
       mx_preference: 20
       mx_rec: "10 mail.{{ testzone }}"
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure that 'host04' MX record is absent.
     ipadnsrecord:
@@ -866,7 +866,7 @@
       mx_rec: "20 mail.{{ testzone }}"
       state: absent
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure that 'host04' MX record is absent, again.
     ipadnsrecord:
@@ -876,7 +876,7 @@
       mx_rec: "20 mail.{{ testzone }}"
       state: absent
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Ensure that 'host04' LOC record is present.
     ipadnsrecord:
@@ -896,7 +896,7 @@
       loc_h_precision: 10000
       loc_v_precision: 10
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure that 'host04' LOC record is present, again.
     ipadnsrecord:
@@ -916,7 +916,7 @@
       loc_h_precision: 10000
       loc_v_precision: 10
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Ensure that 'host04' LOC record is present, with loc_size 1.00.
     ipadnsrecord:
@@ -926,7 +926,7 @@
       loc_size: 1.00
       loc_rec: 52 22 23.000 N 4 53 32.000 E -2.00 0.00 10000.00 10.00
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure that 'host04' LOC record is absent.
     ipadnsrecord:
@@ -936,7 +936,7 @@
       loc_rec: 52 22 23.000 N 4 53 32.000 E -2.00 1.00 10000.00 10.00
       state: absent
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure that 'host04' LOC record is absent, again.
     ipadnsrecord:
@@ -946,7 +946,7 @@
       loc_rec: 52 22 23.000 N 4 53 32.000 E -2.00 1.00 10000.00 10.00
       state: absent
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Ensure that '_sip._udp' service has NAPTR record.
     ipadnsrecord:
@@ -1061,7 +1061,7 @@
       srv_port: 5060
       srv_target: "sip-server.{{ testzone }}"
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure that '_sip._udp' service has SRV record, again.
     ipadnsrecord:
@@ -1073,7 +1073,7 @@
       srv_port: 5060
       srv_target: "sip-server.{{ testzone }}"
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Ensure '_sip._udp' SRV record has priority equals to 4.
     ipadnsrecord:
@@ -1086,7 +1086,7 @@
       srv_target: "sip-server.{{ testzone }}"
       srv_rec: "10 10 5060 sip-server.{{ testzone }}"
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure '_sip._udp' SRV record has priority equals to 4, again.
     ipadnsrecord:
@@ -1099,7 +1099,7 @@
       srv_target: sip-server."{{ testzone }}"
       srv_rec: "10 10 5060 sip-server.{{ testzone }}"
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Ensurer '_sip._udp' SRV record has priority 2, weight 20
     ipadnsrecord:
@@ -1111,7 +1111,7 @@
       srv_port: 5060
       srv_target: "sip-server.{{ testzone }}"
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensurer '_sip._udp' SRV record has priority 2, weight 20, again.
     ipadnsrecord:
@@ -1123,7 +1123,7 @@
       srv_port: 5060
       srv_target: "sip-server.{{ testzone }}"
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Ensure that '_sip._udp' SRV record is absent.
     ipadnsrecord:
@@ -1133,7 +1133,7 @@
       srv_record: "2 20 5060 sip-server.{{ testzone }}"
       state: absent
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure that '_sip._udp' SRV record is absent, again.
     ipadnsrecord:
@@ -1143,7 +1143,7 @@
       srv_record: "2 20 5060 sip-server.{{ testzone }}"
       state: absent
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   # SSHFP fingerprint generated with `ssh-keygen -r host04."{{ testzone }}"`
   - name: Ensure that 'host04' has SSHFP record.
@@ -1155,7 +1155,7 @@
       sshfp_fp_type: 1
       sshfp_fingerprint: d21802c61733e055b8d16296cbce300efb8a167a
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure that 'host04' has SSHFP record, again.
     ipadnsrecord:
@@ -1166,7 +1166,7 @@
       sshfp_fp_type: 1
       sshfp_fingerprint: d21802c61733e055b8d16296cbce300efb8a167a
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Ensure that 'host04' SSHFP record is absent.
     ipadnsrecord:
@@ -1176,7 +1176,7 @@
       sshfp_rec: 1 1 d21802c61733e055b8d16296cbce300efb8a167a
       state: absent
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure that 'host04' SSHFP record is absent, again.
     ipadnsrecord:
@@ -1186,7 +1186,7 @@
       sshfp_rec: 1 1 d21802c61733e055b8d16296cbce300efb8a167a
       state: absent
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   # Data is sha356sum of 'Some Text to Test', it should be created from
   # a real certificate.
@@ -1200,7 +1200,7 @@
       tlsa_matching_type: 1
       tlsa_cert_association_data: 9c0ad776dbeae8d9d55b0ad42899d30235c114d5f918fd69746e4279e47bdaa2
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure that 'host04' has TLSA record present, again.
     ipadnsrecord:
@@ -1212,7 +1212,7 @@
       tlsa_matching_type: 1
       tlsa_cert_association_data: 9c0ad776dbeae8d9d55b0ad42899d30235c114d5f918fd69746e4279e47bdaa2
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Modify 'host04' has TLSA record.
     ipadnsrecord:
@@ -1222,7 +1222,7 @@
       tlsa_matching_type: 0
       tlsa_rec: 3 1 1 9c0ad776dbeae8d9d55b0ad42899d30235c114d5f918fd69746e4279e47bdaa2
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Modify 'host04' has TLSA record, again.
     ipadnsrecord:
@@ -1232,7 +1232,7 @@
       tlsa_matching_type: 0
       tlsa_rec: 3 1 1 9c0ad776dbeae8d9d55b0ad42899d30235c114d5f918fd69746e4279e47bdaa2
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Ensure that 'host04' TLSA record is absent.
     ipadnsrecord:
@@ -1242,7 +1242,7 @@
       tlsa_rec: 3 1 0 9c0ad776dbeae8d9d55b0ad42899d30235c114d5f918fd69746e4279e47bdaa2
       state: absent
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure that 'host04' TLSA record is absent, again.
     ipadnsrecord:
@@ -1252,7 +1252,7 @@
       tlsa_rec: 3 1 0 9c0ad776dbeae8d9d55b0ad42899d30235c114d5f918fd69746e4279e47bdaa2
       state: absent
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Ensure that 'host04' has TXT record present.
     ipadnsrecord:
@@ -1261,7 +1261,7 @@
       name: host04
       txt_data: Some Text
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   # - name: Ensure that 'host04' has TXT record present, again.
   #   ipadnsrecord:
@@ -1270,7 +1270,7 @@
   #     name: host04
   #     txt_data: Some Text
   #   register: result
-  #   failed_when: result.changed
+  #   failed_when: result.changed or result.failed
 
   - name: Change value of  'host04' TXT record.
     ipadnsrecord:
@@ -1280,7 +1280,7 @@
       txt_data: Some new Text
       txt_rec: Some Text
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Add a second TXT record to 'host04'.
     ipadnsrecord:
@@ -1289,7 +1289,7 @@
       name: host04
       txt_rec: Some Other Text
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Add a second TXT record to 'host04', again.
     ipadnsrecord:
@@ -1298,7 +1298,7 @@
       name: host04
       txt_rec: Some Other Text
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Ensure that one of 'host04' TXT record is absent.
     ipadnsrecord:
@@ -1308,7 +1308,7 @@
       txt_rec: Some new Text
       state: absent
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure that one of 'host04' TXT record is absent, again.
     ipadnsrecord:
@@ -1318,7 +1318,7 @@
       txt_rec: Some new Text
       state: absent
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Ensure that 'host04' TXT record are all absent.
     ipadnsrecord:
@@ -1330,7 +1330,7 @@
       - Some Other Text
       state: absent
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure that 'host04' TXT record are all absent, again.
     ipadnsrecord:
@@ -1342,7 +1342,7 @@
       - Some Other Text
       state: absent
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Ensure that '_ftp._tcp' has URI record.
     ipadnsrecord:
@@ -1353,7 +1353,7 @@
       uri_weight: 1
       uri_target: ftp://ftp.host04.{{ testzone }}/public
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure that '_ftp._tcp' has URI record, again
     ipadnsrecord:
@@ -1364,7 +1364,7 @@
       uri_weight: 1
       uri_target: ftp://ftp.host04.{{ testzone }}/public
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Change '_ftp._tcp' URI record weight to 3 and priority to 5.
     ipadnsrecord:
@@ -1375,14 +1375,14 @@
       uri_weight: 3
       uri_rec: 10 1 "ftp://ftp.host04.{{ testzone }}/public"
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Verify if modification worked.
     ipadnsrecord:
       uri_rec: 10 1 ftp://ftp.host04.{{ testzone }}/public
       state: absent
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
 
   - name: Change '_ftp._tcp' URI record weight to 3 and priority to 5, again.
@@ -1394,7 +1394,7 @@
       uri_weight: 3
       uri_rec: 5 3 "ftp://ftp.host04.{{ testzone }}/public"
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Ensure that '_ftp._tcp' URI record is absent.
     ipadnsrecord:
@@ -1404,7 +1404,7 @@
       uri_rec: 5 3 "ftp://ftp.host04.{{ testzone }}/public"
       state: absent
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure that '_ftp._tcp' URI record is absent, again.
     ipadnsrecord:
@@ -1414,7 +1414,7 @@
       uri_rec: 5 3 "ftp://ftp.host04.{{ testzone }}/public"
       state: absent
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   # cleanup
   - name: Cleanup test environment.

--- a/tests/dnsrecord/test_dnsrecord.yml
+++ b/tests/dnsrecord/test_dnsrecord.yml
@@ -282,7 +282,7 @@
     register: result
     failed_when: result.changed or result.failed
 
-  - name: Ensure that 'host04' has an A record with reverse, for NS record.
+  - name: Ensure that 'host04' has another A record with reverse.
     ipadnsrecord:
       ipaadmin_password: SomeADMINpassword
       zone_name: "{{ testzone }}"
@@ -291,7 +291,7 @@
       reverse: yes
     failed_when: result.changed or result.failed
 
-  - name: Ensure that 'host04' has an A record with reverse, again.
+  - name: Ensure that 'host04' has another A record with reverse, again.
     ipadnsrecord:
       ipaadmin_password: SomeADMINpassword
       zone_name: "{{ testzone }}"

--- a/tests/dnsrecord/test_dnsrecord_full_records.yml
+++ b/tests/dnsrecord/test_dnsrecord_full_records.yml
@@ -18,7 +18,7 @@
       zone_name: "{{ testzone }}"
       a_rec: 192.168.122.101
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure that dns A record for 'host01' is present, again
     ipadnsrecord:
@@ -27,7 +27,7 @@
       zone_name: "{{ testzone }}"
       a_rec: 192.168.122.101
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Ensure that dns A records for 'host01' are present
     ipadnsrecord:
@@ -39,7 +39,7 @@
       - 192.168.122.102
       - 192.168.122.103
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure that dns A records for 'host01' are present, again
     ipadnsrecord:
@@ -51,7 +51,7 @@
       - 192.168.122.102
       - 192.168.122.103
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Ensure that dns A records for 'host01' are absent
     ipadnsrecord:
@@ -63,7 +63,7 @@
       - 192.168.122.102
       state: absent
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure that dns A records for 'host01' are absent, again
     ipadnsrecord:
@@ -75,7 +75,7 @@
       - 192.168.122.102
       state: absent
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   ####
 
@@ -86,7 +86,7 @@
       zone_name: "{{ testzone }}"
       aaaa_rec: fd00::0001
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure that dns AAAA record for 'host01' is present, again
     ipadnsrecord:
@@ -95,7 +95,7 @@
       zone_name: "{{ testzone }}"
       aaaa_rec: fd00::0001
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Ensure that dns AAAA records for 'host01' are present
     ipadnsrecord:
@@ -107,7 +107,7 @@
       - fd00::0011
       - fd00::0021
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure that dns AAAAA records for 'host01' are present, again
     ipadnsrecord:
@@ -119,7 +119,7 @@
       - fd00::0011
       - fd00::0021
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Ensure that dns AAAAA records for 'host01' are absent
     ipadnsrecord:
@@ -131,7 +131,7 @@
       - fd00::0011
       state: absent
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure that dns AAAAA records for 'host01' are absent, again
     ipadnsrecord:
@@ -143,7 +143,7 @@
       - fd00::0011
       state: absent
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   # Cleanup
   - name: Cleanup test environment.

--- a/tests/dnszone/test_dnszone.yml
+++ b/tests/dnszone/test_dnszone.yml
@@ -17,7 +17,7 @@
       name: testzone.local
       state: present
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure zone is present, again.
     ipadnszone:
@@ -25,7 +25,7 @@
       name: testzone.local
       state: present
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Ensure zone is disabled.
     ipadnszone:
@@ -33,7 +33,7 @@
       name: testzone.local
       state: disabled
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure zone is disabled, again.
     ipadnszone:
@@ -41,7 +41,7 @@
       name: testzone.local
       state: disabled
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Ensure zone is enabled.
     ipadnszone:
@@ -49,7 +49,7 @@
       name: testzone.local
       state: enabled
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure zone is enabled, again.
     ipadnszone:
@@ -57,7 +57,7 @@
       name: testzone.local
       state: enabled
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Ensure forward_policy is none.
     ipadnszone:
@@ -65,7 +65,7 @@
       name: testzone.local
       forward_policy: none
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure forward_policy is none, again.
     ipadnszone:
@@ -73,7 +73,7 @@
       name: testzone.local
       forward_policy: none
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Ensure forward_policy is first.
     ipadnszone:
@@ -81,7 +81,7 @@
       name: testzone.local
       forward_policy: first
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure forward_policy is first, again.
     ipadnszone:
@@ -89,7 +89,7 @@
       name: testzone.local
       forward_policy: first
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Ensure first forwarder is set.
     ipadnszone:
@@ -99,7 +99,7 @@
         - ip_address: 8.8.8.8
           port: 53
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure first and second forwarder are set.
     ipadnszone:
@@ -110,7 +110,7 @@
           port: 53
         - ip_address: 2001:4860:4860::8888
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure first and second forwarder are set, again.
     ipadnszone:
@@ -121,7 +121,7 @@
           port: 53
         - ip_address: 2001:4860:4860::8888
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Ensure only second forwarder is set.
     ipadnszone:
@@ -130,14 +130,14 @@
       forwarders:
         - ip_address: 2001:4860:4860::8888
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Nothing changes.
     ipadnszone:
       ipaadmin_password: SomeADMINpassword
       name: testzone.local
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Ensure no forwarders are set.
     ipadnszone:
@@ -145,7 +145,7 @@
       name: testzone.local
       forwarders: []
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Create zones test1
     ipadnszone:
@@ -198,7 +198,7 @@
         - test3.testzone.local
       state: absent
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure multiple zones are absent, again
     ipadnszone:
@@ -209,7 +209,7 @@
         - test3.testzone.local
       state: absent
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   # Teardown
   - name: Teardown testing environment

--- a/tests/dnszone/test_dnszone.yml
+++ b/tests/dnszone/test_dnszone.yml
@@ -151,16 +151,43 @@
     ipadnszone:
       ipaadmin_password: SomeADMINpassword
       name: test1.testzone.local
+    register: result
+    failed_when: not result.changed or result.failed
+
+  - name: Create zones test1, again
+    ipadnszone:
+      ipaadmin_password: SomeADMINpassword
+      name: test1.testzone.local
+    register: result
+    failed_when: result.changed or result.failed
 
   - name: Create zones test2
     ipadnszone:
       ipaadmin_password: SomeADMINpassword
       name: test2.testzone.local
+    register: result
+    failed_when: not result.changed or result.failed
+
+  - name: Create zones test2, again
+    ipadnszone:
+      ipaadmin_password: SomeADMINpassword
+      name: test2.testzone.local
+    register: result
+    failed_when: result.changed or result.failed
 
   - name: Create zones test3
     ipadnszone:
       ipaadmin_password: SomeADMINpassword
       name: test3.testzone.local
+    register: result
+    failed_when: not result.changed or result.failed
+
+  - name: Create zones test3, again
+    ipadnszone:
+      ipaadmin_password: SomeADMINpassword
+      name: test3.testzone.local
+    register: result
+    failed_when: result.changed or result.failed
 
   - name: Ensure multiple zones are absent
     ipadnszone:

--- a/tests/dnszone/test_dnszone_mod.yml
+++ b/tests/dnszone/test_dnszone_mod.yml
@@ -111,7 +111,7 @@
       nsec3param_rec: "1 7 100 abcd"
       state: present
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Set serial to 1234, again.
     ipadnszone:
@@ -119,7 +119,7 @@
       name: testzone.local
       serial: 1234
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Set different nsec3param_rec.
     ipadnszone:
@@ -127,7 +127,7 @@
       name: testzone.local
       nsec3param_rec: "2 8 200 abcd"
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Set same nsec3param_rec.
     ipadnszone:
@@ -135,7 +135,7 @@
       name: testzone.local
       nsec3param_rec: "2 8 200 abcd"
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Set default_ttl to 1200
     ipadnszone:
@@ -143,7 +143,7 @@
       name: testzone.local
       default_ttl: 1200
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Set default_ttl to 1200, again
     ipadnszone:
@@ -151,7 +151,7 @@
       name: testzone.local
       default_ttl: 1200
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Set ttl to 900
     ipadnszone:
@@ -159,7 +159,7 @@
       name: testzone.local
       ttl: 900
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Set ttl to 900, again
     ipadnszone:
@@ -167,7 +167,7 @@
       name: testzone.local
       ttl: 900
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Set minimum to 1000
     ipadnszone:
@@ -175,7 +175,7 @@
       name: testzone.local
       minimum: 1000
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Set minimum to 1000, again
     ipadnszone:
@@ -183,7 +183,7 @@
       name: testzone.local
       minimum: 1000
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Set expire to 1209601
     ipadnszone:
@@ -191,7 +191,7 @@
       name: testzone.local
       expire: 1209601
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Set expire to 1209601, again
     ipadnszone:
@@ -199,7 +199,7 @@
       name: testzone.local
       expire: 1209601
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Set retry to 1200.
     ipadnszone:
@@ -207,7 +207,7 @@
       name: testzone.local
       retry: 1200
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Set retry to 1200, again.
     ipadnszone:
@@ -215,7 +215,7 @@
       name: testzone.local
       retry: 1200
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Set refresh to 4000.
     ipadnszone:
@@ -223,7 +223,7 @@
       name: testzone.local
       refresh: 4000
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Set refresh to 4000, again.
     ipadnszone:
@@ -231,7 +231,7 @@
       name: testzone.local
       refresh: 4000
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Set serial to 12345.
     ipadnszone:
@@ -239,7 +239,7 @@
       name: testzone.local
       serial: 12345
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Set serial to 12345, again.
     ipadnszone:
@@ -247,7 +247,7 @@
       name: testzone.local
       serial: 12345
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Set dnssec to false.
     ipadnszone:
@@ -255,7 +255,7 @@
       name: testzone.local
       dnssec: false
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Set dnssec to false, again.
     ipadnszone:
@@ -263,7 +263,7 @@
       name: testzone.local
       dnssec: false
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Set allow_sync_ptr to false.
     ipadnszone:
@@ -271,7 +271,7 @@
       name: testzone.local
       allow_sync_ptr: false
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Set allow_sync_ptr to false, again.
     ipadnszone:
@@ -279,7 +279,7 @@
       name: testzone.local
       allow_sync_ptr: false
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Set dynamic_update to false.
     ipadnszone:
@@ -287,7 +287,7 @@
       name: testzone.local
       dynamic_update: false
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Set dynamic_update to false, again.
     ipadnszone:
@@ -295,7 +295,7 @@
       name: testzone.local
       dynamic_update: false
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Update allow_transfer.
     ipadnszone:
@@ -306,7 +306,7 @@
         - 2.2.2.2
         - 3.3.3.3
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Update allow_transfer, again.
     ipadnszone:
@@ -317,7 +317,7 @@
         - 2.2.2.2
         - 3.3.3.3
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Remove allow transfer.
     ipadnszone:
@@ -325,7 +325,7 @@
       name: testzone.local
       allow_transfer: []
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Remove allow transfer, again.
     ipadnszone:
@@ -333,7 +333,7 @@
       name: testzone.local
       allow_transfer: []
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Update allow_query.
     ipadnszone:
@@ -344,7 +344,7 @@
         - 2.2.2.2
         - 3.3.3.3
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Update allow_query, again.
     ipadnszone:
@@ -355,7 +355,7 @@
         - 2.2.2.2
         - 3.3.3.3
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Ensure allow query is empty.
     ipadnszone:
@@ -363,7 +363,7 @@
       name: testzone.local
       allow_query: []
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure allow query is empty, again.
     ipadnszone:
@@ -371,7 +371,7 @@
       name: testzone.local
       allow_query: []
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Update admin email.
     ipadnszone:
@@ -379,7 +379,7 @@
       name: testzone.local
       admin_email: admin2@example.com
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Update admin email, again.
     ipadnszone:
@@ -387,7 +387,7 @@
       name: testzone.local
       admin_email: admin2@example.com
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   # Teardown
   - name: Teardown testing environment

--- a/tests/dnszone/test_dnszone_name_from_ip.yml
+++ b/tests/dnszone/test_dnszone_name_from_ip.yml
@@ -38,7 +38,7 @@
       name_from_ip: 192.0.2.3/24
       default_ttl: 1234
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Modify existing zone, using `name_from_ip`, again.
     ipadnszone:
@@ -70,14 +70,14 @@
       ipaadmin_password: SomeADMINpassword
       name_from_ip: fd00::0001
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Ensure second ipv6 zone exists for reverse IPv6.
     ipadnszone:
       ipaadmin_password: SomeADMINpassword
       name_from_ip: 2001:db8:cafe:1::1
     register: ipv6_sec_zone
-    failed_when: not ipv6_sec_zone.changed or ipv6_zone.failed
+    failed_when: not ipv6_sec_zone.changed or ipv6_zone.failed or ipv6_sec_zone.failed
 
   - name: Ensure second ipv6 zone was created.
     ipadnszone:
@@ -91,7 +91,7 @@
       ipaadmin_password: SomeADMINpassword
       name_from_ip: 2001:db8:cafe:1::1
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   # Teardown
   - name: Teardown testing environment

--- a/tests/group/test_group.yml
+++ b/tests/group/test_group.yml
@@ -31,49 +31,49 @@
         first: user3
         last: Last
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure group1 is present
     ipagroup:
       ipaadmin_password: SomeADMINpassword
       name: group1
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure group1 is present again
     ipagroup:
       ipaadmin_password: SomeADMINpassword
       name: group1
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Ensure group2 is present
     ipagroup:
       ipaadmin_password: SomeADMINpassword
       name: group2
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure group2 is present again
     ipagroup:
       ipaadmin_password: SomeADMINpassword
       name: group2
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Ensure group3 is present
     ipagroup:
       ipaadmin_password: SomeADMINpassword
       name: group3
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure group3 is present again
     ipagroup:
       ipaadmin_password: SomeADMINpassword
       name: group3
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Ensure groups group2 and group3 are present in group group1
     ipagroup:
@@ -84,7 +84,7 @@
       - group3
       action: member
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure groups group2 and group3 are present in group group1 again
     ipagroup:
@@ -95,7 +95,7 @@
       - group3
       action: member
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Ensure group3 ia present in group group1
     ipagroup:
@@ -105,7 +105,7 @@
       - group3
       action: member
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Ensure users user1, user2 and user3 are present in group group1
     ipagroup:
@@ -117,7 +117,7 @@
       - user3
       action: member
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure users user1, user2 and user3 are present in group group1 again
     ipagroup:
@@ -129,7 +129,7 @@
       - user3
       action: member
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   #- ipagroup:
   #    ipaadmin_password: SomeADMINpassword
@@ -147,7 +147,7 @@
       action: member
       state: absent
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Ensure group group4 is absent
     ipagroup:
@@ -155,7 +155,7 @@
       name: group4
       state: absent
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Ensure group group3, group2 and group1 are absent
     ipagroup:
@@ -163,7 +163,7 @@
       name: group3,group2,group1
       state: absent
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure users user1, user2 and user3 are absent
     ipauser:
@@ -171,5 +171,5 @@
       name: user1,user2,user3
       state: absent
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 

--- a/tests/group/test_group_membermanager.yml
+++ b/tests/group/test_group_membermanager.yml
@@ -32,28 +32,28 @@
             first: manageruser2
             last: Last2
         register: result
-        failed_when: not result.changed
+        failed_when: not result.changed or result.failed
 
       - name: Ensure testgroup is present
         ipagroup:
           ipaadmin_password: SomeADMINpassword
           name: testgroup
         register: result
-        failed_when: not result.changed
+        failed_when: not result.changed or result.failed
 
       - name: Ensure managergroup1 is present
         ipagroup:
           ipaadmin_password: SomeADMINpassword
           name: managergroup1
         register: result
-        failed_when: not result.changed
+        failed_when: not result.changed or result.failed
 
       - name: Ensure managergroup2 is present
         ipagroup:
           ipaadmin_password: SomeADMINpassword
           name: managergroup2
         register: result
-        failed_when: not result.changed
+        failed_when: not result.changed or result.failed
 
       - name: Ensure membermanager user1 is present for testgroup
         ipagroup:
@@ -61,7 +61,7 @@
           name: testgroup
           membermanager_user: manageruser1
         register: result
-        failed_when: not result.changed
+        failed_when: not result.changed or result.failed
 
       - name: Ensure membermanager user1 is present for testgroup again
         ipagroup:
@@ -69,7 +69,7 @@
           name: testgroup
           membermanager_user: manageruser1
         register: result
-        failed_when: result.changed
+        failed_when: result.changed or result.failed
 
       - name: Ensure membermanager group1 is present for testgroup
         ipagroup:
@@ -77,7 +77,7 @@
           name: testgroup
           membermanager_group: managergroup1
         register: result
-        failed_when: not result.changed
+        failed_when: not result.changed or result.failed
 
       - name: Ensure membermanager group1 is present for testgroup again
         ipagroup:
@@ -85,7 +85,7 @@
           name: testgroup
           membermanager_group: managergroup1
         register: result
-        failed_when: result.changed
+        failed_when: result.changed or result.failed
 
       - name: Ensure membermanager user2 and group2 members are present for testgroup
         ipagroup:
@@ -95,7 +95,7 @@
           membermanager_group: managergroup2
           action: member
         register: result
-        failed_when: not result.changed
+        failed_when: not result.changed or result.failed
 
       - name: Ensure membermanager user2 and group2 members are present for testgroup again
         ipagroup:
@@ -105,7 +105,7 @@
           membermanager_group: managergroup2
           action: member
         register: result
-        failed_when: result.changed
+        failed_when: result.changed or result.failed
 
       - name: Ensure membermanager user and group members are present for testgroup again
         ipagroup:
@@ -115,7 +115,7 @@
           membermanager_group: managergroup1,managergroup2
           action: member
         register: result
-        failed_when: result.changed
+        failed_when: result.changed or result.failed
 
       - name: Ensure membermanager user1 and group1 members are absent for testgroup
         ipagroup:
@@ -126,7 +126,7 @@
           action: member
           state: absent
         register: result
-        failed_when: not result.changed
+        failed_when: not result.changed or result.failed
 
       - name: Ensure membermanager user1 and group1 members are absent for testgroup again
         ipagroup:
@@ -137,7 +137,7 @@
           action: member
           state: absent
         register: result
-        failed_when: result.changed
+        failed_when: result.changed or result.failed
 
       - name: Ensure membermanager user1 and group1 members are present for testgroup
         ipagroup:
@@ -147,7 +147,7 @@
           membermanager_group: managergroup1
           action: member
         register: result
-        failed_when: not result.changed
+        failed_when: not result.changed or result.failed
 
       - name: Ensure membermanager user1 and group1 members are present for testgroup again
         ipagroup:
@@ -157,7 +157,7 @@
           membermanager_group: managergroup1
           action: member
         register: result
-        failed_when: result.changed
+        failed_when: result.changed or result.failed
 
       - name: Ensure membermanager user and group members are absent for testgroup
         ipagroup:
@@ -168,7 +168,7 @@
           action: member
           state: absent
         register: result
-        failed_when: not result.changed
+        failed_when: not result.changed or result.failed
 
       - name: Ensure membermanager user and group members are absent for testgroup again
         ipagroup:
@@ -179,7 +179,7 @@
           action: member
           state: absent
         register: result
-        failed_when: result.changed
+        failed_when: result.changed or result.failed
 
       - name: Ensure user manangeruser1 and manageruser2 is absent
         ipauser:
@@ -187,7 +187,7 @@
           name: manageruser1,manageruser2
           state: absent
         register: result
-        failed_when: not result.changed
+        failed_when: not result.changed or result.failed
 
       - name: Ensure unknown membermanager_user member failure
         ipagroup:
@@ -196,7 +196,7 @@
           membermanager_user: unknown_user
           action: member
         register: result
-        failed_when: result.changed or "no such entry" not in result.msg
+        failed_when: result.changed or "no such entry" not in result.msg or not result.failed
 
       - name: Ensure group testgroup, managergroup1 and managergroup2 are absent
         ipagroup:
@@ -204,6 +204,6 @@
           name: testgroup,managergroup1,managergroup2
           state: absent
         register: result
-        failed_when: not result.changed
+        failed_when: not result.changed or result.failed
 
     when: ipa_version is version('4.8.4', '>=')

--- a/tests/hbacrule/test_hbacrule.yml
+++ b/tests/hbacrule/test_hbacrule.yml
@@ -66,35 +66,35 @@
       - name: "{{ 'testhost04.' + ipaserver_domain }}"
         force: yes
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure host-group testhostgroup01 is present
     ipahostgroup:
       ipaadmin_password: SomeADMINpassword
       name: testhostgroup01
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure host-group testhostgroup02 is present
     ipahostgroup:
       ipaadmin_password: SomeADMINpassword
       name: testhostgroup02
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure host-group testhostgroup03 is present
     ipahostgroup:
       ipaadmin_password: SomeADMINpassword
       name: testhostgroup03
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure host-group testhostgroup04 is present
     ipahostgroup:
       ipaadmin_password: SomeADMINpassword
       name: testhostgroup04
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure testusers are present
     ipauser:
@@ -113,91 +113,91 @@
         first: test
         last: user04
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure user group testgroup01 is present
     ipagroup:
       ipaadmin_password: SomeADMINpassword
       name: testgroup01
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure user group testgroup02 is present
     ipagroup:
       ipaadmin_password: SomeADMINpassword
       name: testgroup02
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure user group testgroup03 is present
     ipagroup:
       ipaadmin_password: SomeADMINpassword
       name: testgroup03
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure user group testgroup04 is present
     ipagroup:
       ipaadmin_password: SomeADMINpassword
       name: testgroup04
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure HBAC Service testhbacsvc01 is present
     ipahbacsvc:
       ipaadmin_password: SomeADMINpassword
       name: testhbacsvc01
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure HBAC Service testhbacsvc02 is present
     ipahbacsvc:
       ipaadmin_password: SomeADMINpassword
       name: testhbacsvc02
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure HBAC Service testhbacsvc03 is present
     ipahbacsvc:
       ipaadmin_password: SomeADMINpassword
       name: testhbacsvc03
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure HBAC Service testhbacsvc04 is present
     ipahbacsvc:
       ipaadmin_password: SomeADMINpassword
       name: testhbacsvc04
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure HBAC Service Group testhbacsvcgroup01 is present
     ipahbacsvcgroup:
       ipaadmin_password: SomeADMINpassword
       name: testhbacsvcgroup01
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure HBAC Service Group testhbacsvcgroup02 is present
     ipahbacsvcgroup:
       ipaadmin_password: SomeADMINpassword
       name: testhbacsvcgroup02
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure HBAC Service Group testhbacsvcgroup03 is present
     ipahbacsvcgroup:
       ipaadmin_password: SomeADMINpassword
       name: testhbacsvcgroup03
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure HBAC Service Group testhbacsvcgroup04 is present
     ipahbacsvcgroup:
       ipaadmin_password: SomeADMINpassword
       name: testhbacsvcgroup04
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure test HBAC rule hbacrule01 is absent
     ipahbacrule:
@@ -212,14 +212,14 @@
       ipaadmin_password: SomeADMINpassword
       name: hbacrule01
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure HBAC rule hbacrule01 is present again
     ipahbacrule:
       ipaadmin_password: SomeADMINpassword
       name: hbacrule01
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   # CHANGE HBACRULE WITH ALL MEMBERS
 
@@ -236,7 +236,7 @@
       hbacsvc: testhbacsvc01,testhbacsvc02
       hbacsvcgroup: testhbacsvcgroup01,testhbacsvcgroup02
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure HBAC rule hbacrule01 is present with hosts, hostgroups, users, groups, hbassvcs and hbacsvcgroups again
     ipahbacrule:
@@ -251,7 +251,7 @@
       hbacsvc: testhbacsvc01,testhbacsvc02
       hbacsvcgroup: testhbacsvcgroup01,testhbacsvcgroup02
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   # REMOVE MEMBERS ONE BY ONE
 
@@ -265,7 +265,7 @@
       state: absent
       action: member
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure test HBAC rule hbacrule01 host members are absent again
     ipahbacrule:
@@ -277,7 +277,7 @@
       state: absent
       action: member
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Ensure test HBAC rule hbacrule01 hostgroup members are absent
     ipahbacrule:
@@ -287,7 +287,7 @@
       state: absent
       action: member
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure test HBAC rule hbacrule01 hostgroup members are absent again
     ipahbacrule:
@@ -297,7 +297,7 @@
       state: absent
       action: member
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Ensure test HBAC rule hbacrule01 user members are absent
     ipahbacrule:
@@ -307,7 +307,7 @@
       state: absent
       action: member
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure test HBAC rule hbacrule01 user members are absent again
     ipahbacrule:
@@ -317,7 +317,7 @@
       state: absent
       action: member
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Ensure test HBAC rule hbacrule01 user group members are absent
     ipahbacrule:
@@ -327,7 +327,7 @@
       state: absent
       action: member
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure test HBAC rule hbacrule01 user group members are absent again
     ipahbacrule:
@@ -337,7 +337,7 @@
       state: absent
       action: member
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Ensure test HBAC rule hbacrule01 hbacsvc members are absent
     ipahbacrule:
@@ -347,7 +347,7 @@
       state: absent
       action: member
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure test HBAC rule hbacrule01 hbacsvc members are absent again
     ipahbacrule:
@@ -357,7 +357,7 @@
       state: absent
       action: member
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Ensure test HBAC rule hbacrule01 hbacsvcgroup members are absent
     ipahbacrule:
@@ -367,7 +367,7 @@
       state: absent
       action: member
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure test HBAC rule hbacrule01 hbacsvcgroup members are absent again
     ipahbacrule:
@@ -377,7 +377,7 @@
       state: absent
       action: member
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   # ADD MEMBERS BACK
 
@@ -390,7 +390,7 @@
       - "{{ 'testhost02.' + ipaserver_domain }}"
       action: member
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure test HBAC rule hbacrule01 host members are present again
     ipahbacrule:
@@ -401,7 +401,7 @@
       - "{{ 'testhost02.' + ipaserver_domain }}"
       action: member
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Ensure test HBAC rule hbacrule01 hostgroup members are present
     ipahbacrule:
@@ -410,7 +410,7 @@
       hostgroup: testhostgroup01,testhostgroup02
       action: member
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure test HBAC rule hbacrule01 hostgroup members are present again
     ipahbacrule:
@@ -419,7 +419,7 @@
       hostgroup: testhostgroup01,testhostgroup02
       action: member
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Ensure test HBAC rule hbacrule01 user members are present
     ipahbacrule:
@@ -428,7 +428,7 @@
       user: testuser01,testuser02
       action: member
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure test HBAC rule hbacrule01 user members are present again
     ipahbacrule:
@@ -437,7 +437,7 @@
       user: testuser01,testuser02
       action: member
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Ensure test HBAC rule hbacrule01 user group members are present
     ipahbacrule:
@@ -446,7 +446,7 @@
       group: testgroup01,testgroup02
       action: member
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure test HBAC rule hbacrule01 user group members are present again
     ipahbacrule:
@@ -455,7 +455,7 @@
       group: testgroup01,testgroup02
       action: member
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Ensure test HBAC rule hbacrule01 hbacsvc members are present
     ipahbacrule:
@@ -464,7 +464,7 @@
       hbacsvc: testhbacsvc01,testhbacsvc02
       action: member
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure test HBAC rule hbacrule01 hbacsvc members are present again
     ipahbacrule:
@@ -473,7 +473,7 @@
       hbacsvc: testhbacsvc01,testhbacsvc02
       action: member
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Ensure test HBAC rule hbacrule01 hbacsvcgroup members are present
     ipahbacrule:
@@ -482,7 +482,7 @@
       hbacsvcgroup: testhbacsvcgroup01,testhbacsvcgroup02
       action: member
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure test HBAC rule hbacrule01 hbacsvcgroup members are present again
     ipahbacrule:
@@ -491,7 +491,7 @@
       hbacsvcgroup: testhbacsvcgroup01,testhbacsvcgroup02
       action: member
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   # CHANGE TO DIFFERENT MEMBERS
 
@@ -508,7 +508,7 @@
       hbacsvc: testhbacsvc03,testhbacsvc04
       hbacsvcgroup: testhbacsvcgroup03,testhbacsvcgroup04
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure HBAC rule hbacrule01 is present with different hosts, hostgroups, users, groups, hbassvcs and hbacsvcgroups again
     ipahbacrule:
@@ -523,7 +523,7 @@
       hbacsvc: testhbacsvc03,testhbacsvc04
       hbacsvcgroup: testhbacsvcgroup03,testhbacsvcgroup04
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   # ENSURE OLD TEST MEMBERS ARE ABSENT
 
@@ -542,7 +542,7 @@
       state: absent
       action: member
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   # ENSURE NEW TEST MEMBERS ARE ABSENT
 
@@ -561,7 +561,7 @@
       state: absent
       action: member
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure HBAC rule hbacrule01 members are absent again
     ipahbacrule:
@@ -578,7 +578,7 @@
       state: absent
       action: member
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   # CLEANUP TEST ITEMS
 

--- a/tests/hbacrule/test_hbacrule_categories.yml
+++ b/tests/hbacrule/test_hbacrule_categories.yml
@@ -19,7 +19,7 @@
       name: testrule
       usercategory: all
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure HBAC rule is present, with usercategory 'all', again.
     ipahbacrule:
@@ -27,7 +27,7 @@
       name: testrule
       usercategory: all
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Ensure HBAC rule is present, with no usercategory.
     ipahbacrule:
@@ -35,7 +35,7 @@
       name: testrule
       usercategory: ""
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure HBAC rule is present, with no usercategory, again.
     ipahbacrule:
@@ -43,7 +43,7 @@
       name: testrule
       usercategory: ""
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Ensure HBAC rule is present, with hostcategory 'all'
     ipahbacrule:
@@ -51,7 +51,7 @@
       name: testrule
       hostcategory: all
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure HBAC rule is present, with hostcategory 'all', again.
     ipahbacrule:
@@ -59,7 +59,7 @@
       name: testrule
       hostcategory: all
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Ensure HBAC rule is present, with no hostcategory.
     ipahbacrule:
@@ -67,7 +67,7 @@
       name: testrule
       hostcategory: ""
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure HBAC rule is present, with no hostcategory, again.
     ipahbacrule:
@@ -75,7 +75,7 @@
       name: testrule
       hostcategory: ""
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Ensure HBAC rule is present, with servicecategory 'all'
     ipahbacrule:
@@ -83,7 +83,7 @@
       name: testrule
       servicecategory: all
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure HBAC rule is present, with servicecategory 'all', again.
     ipahbacrule:
@@ -91,7 +91,7 @@
       name: testrule
       servicecategory: all
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Ensure HBAC rule is present, with no servicecategory.
     ipahbacrule:
@@ -99,7 +99,7 @@
       name: testrule
       servicecategory: ""
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure HBAC rule is present, with no servicecategory, again.
     ipahbacrule:
@@ -107,7 +107,7 @@
       name: testrule
       servicecategory: ""
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Ensure `user` cannot be added if usercategory is `all`.
     ipahbacrule:

--- a/tests/hbacsvc/test_hbacsvc.yml
+++ b/tests/hbacsvc/test_hbacsvc.yml
@@ -16,14 +16,14 @@
       ipaadmin_password: SomeADMINpassword
       name: http
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure HBAC Service for http is present again
     ipahbacsvc:
       ipaadmin_password: SomeADMINpassword
       name: http
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Ensure HBAC Service for tftp is present
     ipahbacsvc:
@@ -31,7 +31,7 @@
       name: tftp
       description: TFTP service
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure HBAC Service for tftp is present again
     ipahbacsvc:
@@ -39,7 +39,7 @@
       name: tftp
       description: TFTP service
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Ensure HBAC Services for http and tftp are absent
     ipahbacsvc:
@@ -47,7 +47,7 @@
       name: http,tftp
       state: absent
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure HBAC Services for http and tftp are absent again
     ipahbacsvc:
@@ -55,4 +55,4 @@
       name: http,tftp
       state: absent
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed

--- a/tests/hbacsvcgroup/test_hbacsvcgroup.yml
+++ b/tests/hbacsvcgroup/test_hbacsvcgroup.yml
@@ -21,14 +21,14 @@
       ipaadmin_password: SomeADMINpassword
       name: login
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure HBAC Service Group login is present again
     ipahbacsvcgroup:
       ipaadmin_password: SomeADMINpassword
       name: login
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Ensure HBAC Service sshd is present in HBAC Service Group login
     ipahbacsvcgroup:
@@ -38,7 +38,7 @@
       - sshd
       action: member
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure HBAC Service sshd is present in HBAC Service Group login again
     ipahbacsvcgroup:
@@ -48,7 +48,7 @@
       - sshd
       action: member
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Ensure HBAC Services sshd and foo are absent in HBAC Service Group login
     ipahbacsvcgroup:
@@ -60,7 +60,7 @@
       action: member
       state: absent
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure HBAC Services sshd and foo are absent in HBAC Service Group login again
     ipahbacsvcgroup:
@@ -72,7 +72,7 @@
       action: member
       state: absent
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Ensure HBAC Service Group login is absent
     ipahbacsvcgroup:
@@ -80,7 +80,7 @@
       name: login
       state: absent
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure HBAC Service Group login is absent again
     ipahbacsvcgroup:
@@ -88,4 +88,4 @@
       name: login
       state: absent
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed

--- a/tests/host/certificate/test_host_certificate.yml
+++ b/tests/host/certificate/test_host_certificate.yml
@@ -31,7 +31,7 @@
       name: "{{ 'test.' + ipaserver_domain }}"
       force: yes
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Host test cert members present
     ipahost:
@@ -43,7 +43,7 @@
         - "{{ lookup('file', 'cert3.b64', rstrip=False) }}"
       action: member
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Host test cert members present again
     ipahost:
@@ -55,7 +55,7 @@
         - "{{ lookup('file', 'cert3.b64', rstrip=False) }}"
       action: member
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Host test cert members absent
     ipahost:
@@ -68,7 +68,7 @@
       state: absent
       action: member
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Host test cert members absent again
     ipahost:
@@ -81,7 +81,7 @@
       state: absent
       action: member
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Host test absent
     ipahost:
@@ -89,7 +89,7 @@
       name: "{{ 'test.' + ipaserver_domain }}"
       state: absent
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Host test absent again
     ipahost:
@@ -97,7 +97,7 @@
       name: "{{ 'test.' + ipaserver_domain }}"
       state: absent
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Remove certificate files.
     shell:

--- a/tests/host/certificate/test_hosts_certificate.yml
+++ b/tests/host/certificate/test_hosts_certificate.yml
@@ -23,7 +23,7 @@
       - name: "{{ 'test.' + ipaserver_domain }}"
         force: yes
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Generate self-signed certificates.
     shell:
@@ -46,7 +46,7 @@
         - "{{ lookup('file', 'cert3.b64', rstrip=False) }}"
       action: member
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Host test cert members present again
     ipahost:
@@ -59,7 +59,7 @@
         - "{{ lookup('file', 'cert3.b64', rstrip=False) }}"
       action: member
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Host test cert members absent
     ipahost:
@@ -73,7 +73,7 @@
       state: absent
       action: member
     #register: result
-    #failed_when: not result.changed
+    #failed_when: not result.changed or result.failed
 
   - name: Host test cert members absent again
     ipahost:
@@ -87,7 +87,7 @@
       state: absent
       action: member
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Host test absent
     ipahost:
@@ -96,7 +96,7 @@
       - name: "{{ 'test.' + ipaserver_domain }}"
       state: absent
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Remove certificate files.
     shell:

--- a/tests/host/test_host.yml
+++ b/tests/host/test_host.yml
@@ -44,7 +44,7 @@
       update_dns: yes
       reverse: no
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Host "{{ host1_fqdn }}" present again
     ipahost:
@@ -54,7 +54,7 @@
       update_dns: yes
       reverse: no
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Host "{{ host2_fqdn }}" present
     ipahost:
@@ -64,7 +64,7 @@
       update_dns: yes
       reverse: no
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Host "{{ host2_fqdn }}" present again
     ipahost:
@@ -74,7 +74,7 @@
       update_dns: yes
       reverse: no
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Host "{{ host3_fqdn }}" present
     ipahost:
@@ -84,7 +84,7 @@
       update_dns: yes
       reverse: no
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Host "{{ host3_fqdn }}" present again
     ipahost:
@@ -94,7 +94,7 @@
       update_dns: yes
       reverse: no
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Host "{{ host4_fqdn }}" present
     ipahost:
@@ -104,7 +104,7 @@
       update_dns: yes
       reverse: no
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Host "{{ host4_fqdn }}" present again
     ipahost:
@@ -114,7 +114,7 @@
       update_dns: yes
       reverse: no
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Host "{{ host5_fqdn }}" present
     ipahost:
@@ -124,7 +124,7 @@
       update_dns: yes
       reverse: no
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Host "{{ host5_fqdn }}" present again
     ipahost:
@@ -134,7 +134,7 @@
       update_dns: yes
       reverse: no
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Host "{{ host6_fqdn }}" present
     ipahost:
@@ -144,7 +144,7 @@
       update_dns: yes
       reverse: no
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Host "{{ host6_fqdn }}" present again
     ipahost:
@@ -154,7 +154,7 @@
       update_dns: yes
       reverse: no
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   # disabled can only be checked with enabled hosts, all hosts above are
   # not enabled.
@@ -170,7 +170,7 @@
   #    - "{{ host6_fqdn }}"
   #    state: disabled
   #  register: result
-  #  failed_when: not result.changed
+  #  failed_when: not result.changed or result.failed
   #
   #- name: Hosts host1..host6 disabled again
   #  ipahost:
@@ -184,7 +184,7 @@
   #    - "{{ host6_fqdn }}"
   #    state: disabled
   #  register: result
-  #  failed_when: result.changed
+  #  failed_when: result.changed or result.failed
 
   - name: Hosts host1..host6 absent
     ipahost:
@@ -199,7 +199,7 @@
       update_dns: yes
       state: absent
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Hosts host1..host6 absent again
     ipahost:
@@ -214,5 +214,5 @@
       update_dns: yes
       state: absent
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 

--- a/tests/host/test_host_allow_create_keytab.yml
+++ b/tests/host/test_host_allow_create_keytab.yml
@@ -58,7 +58,7 @@
       - name: "{{ host3_fqdn }}"
         force: yes
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure host-group hostgroup1 present
     ipahostgroup:
@@ -66,7 +66,7 @@
       name: hostgroup1
       state: present
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure host-group hostgroup2 present
     ipahostgroup:
@@ -74,7 +74,7 @@
       name: hostgroup2
       state: present
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure users user1 and user2 present
     ipauser:
@@ -87,21 +87,21 @@
         first: First2
         last: Last2
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure group1 present
     ipagroup:
       ipaadmin_password: SomeADMINpassword
       name: group1
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure group2 present
     ipagroup:
       ipaadmin_password: SomeADMINpassword
       name: group2
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Host host1... present with allow_create_keytab users,groups,hosts and hostgroups
     ipahost:
@@ -121,7 +121,7 @@
       - hostgroup2
       force: yes
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Host host1... present with allow_create_keytab users,groups,hosts and hostgroups again
     ipahost:
@@ -141,7 +141,7 @@
       - hostgroup2
       force: yes
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Host host1... absent
     ipahost:
@@ -156,7 +156,7 @@
       name: "{{ host1_fqdn }}"
       force: yes
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Host host1... ensure allow_create_keytab users,groups,hosts and hostgroups present
     ipahost:
@@ -176,7 +176,7 @@
       - hostgroup2
       action: member
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Host host1... ensure allow_create_keytab users,groups,hosts and hostgroups present again
     ipahost:
@@ -196,7 +196,7 @@
       - hostgroup2
       action: member
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Host host1... ensure allow_create_keytab users,groups,hosts and hostgroups absent
     ipahost:
@@ -217,7 +217,7 @@
       action: member
       state: absent
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Host host1... ensure allow_create_keytab users,groups,hosts and hostgroups absent again
     ipahost:
@@ -238,7 +238,7 @@
       action: member
       state: absent
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Host host1..., host2... and host3... absent
     ipahost:
@@ -249,7 +249,7 @@
       - "{{ host3_fqdn }}"
       state: absent
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure host-groups hostgroup1 and hostgroup2 absent
     ipahostgroup:
@@ -257,7 +257,7 @@
       name: hostgroup1,hostgroup2
       state: absent
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure users user1 and user2 absent
     ipauser:
@@ -267,7 +267,7 @@
       - name: user2
       state: absent
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure group1 and group2 absent
     ipagroup:
@@ -275,4 +275,4 @@
       name: group1,group2
       state: absent
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed

--- a/tests/host/test_host_allow_retrieve_keytab.yml
+++ b/tests/host/test_host_allow_retrieve_keytab.yml
@@ -58,7 +58,7 @@
       - name: "{{ host3_fqdn }}"
         force: yes
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure host-group hostgroup1 present
     ipahostgroup:
@@ -66,7 +66,7 @@
       name: hostgroup1
       state: present
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure host-group hostgroup2 present
     ipahostgroup:
@@ -74,7 +74,7 @@
       name: hostgroup2
       state: present
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure users user1 and user2 present
     ipauser:
@@ -87,21 +87,21 @@
         first: First2
         last: Last2
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure group1 present
     ipagroup:
       ipaadmin_password: SomeADMINpassword
       name: group1
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure group2 present
     ipagroup:
       ipaadmin_password: SomeADMINpassword
       name: group2
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Host host1... present with allow_retrieve_keytab users,groups,hosts and hostgroups
     ipahost:
@@ -121,7 +121,7 @@
       - hostgroup2
       force: yes
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Host host1... present with allow_retrieve_keytab users,groups,hosts and hostgroups again
     ipahost:
@@ -141,7 +141,7 @@
       - hostgroup2
       force: yes
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Host host1... absent
     ipahost:
@@ -156,7 +156,7 @@
       name: "{{ host1_fqdn }}"
       force: yes
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Host host1... ensure allow_retrieve_keytab users,groups,hosts and hostgroups present
     ipahost:
@@ -176,7 +176,7 @@
       - hostgroup2
       action: member
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Host host1... ensure allow_retrieve_keytab users,groups,hosts and hostgroups present again
     ipahost:
@@ -196,7 +196,7 @@
       - hostgroup2
       action: member
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Host host1... ensure allow_retrieve_keytab users,groups,hosts and hostgroups absent
     ipahost:
@@ -217,7 +217,7 @@
       action: member
       state: absent
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Host host1... ensure allow_retrieve_keytab users,groups,hosts and hostgroups absent again
     ipahost:
@@ -238,7 +238,7 @@
       action: member
       state: absent
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Host host1..., host2... and host3... absent
     ipahost:
@@ -249,7 +249,7 @@
       - "{{ host3_fqdn }}"
       state: absent
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure host-groups hostgroup1 and hostgroup2 absent
     ipahostgroup:
@@ -257,7 +257,7 @@
       name: hostgroup1,hostgroup2
       state: absent
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure users user1 and user2 absent
     ipauser:
@@ -267,7 +267,7 @@
       - name: user2
       state: absent
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure group1 and group2 absent
     ipagroup:
@@ -275,4 +275,4 @@
       name: group1,group2
       state: absent
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed

--- a/tests/host/test_host_bool_params.yml
+++ b/tests/host/test_host_bool_params.yml
@@ -30,7 +30,7 @@
       ok_as_delegate: yes
       ok_to_auth_as_delegate: yes
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Host "{{ host1_fqdn }}" present with requires_pre_auth, ok_as_delegate and ok_to_auth_as_delegate again
     ipahost:
@@ -40,7 +40,7 @@
       ok_as_delegate: yes
       ok_to_auth_as_delegate: yes
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Host "{{ host1_fqdn }}" present with requires_pre_auth, ok_as_delegate and ok_to_auth_as_delegate set to no
     ipahost:
@@ -50,7 +50,7 @@
       ok_as_delegate: no
       ok_to_auth_as_delegate: no
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Host "{{ host1_fqdn }}" present with requires_pre_auth, ok_as_delegate and ok_to_auth_as_delegate set to no again
     ipahost:
@@ -60,7 +60,7 @@
       ok_as_delegate: no
       ok_to_auth_as_delegate: no
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Host "{{ host1_fqdn }}" present with requires_pre_auth
     ipahost:
@@ -68,7 +68,7 @@
       name: "{{ host1_fqdn }}"
       requires_pre_auth: yes
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Host "{{ host1_fqdn }}" present with requires_pre_auth again
     ipahost:
@@ -76,7 +76,7 @@
       name: "{{ host1_fqdn }}"
       requires_pre_auth: yes
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Host "{{ host1_fqdn }}" present with ok_as_delegate
     ipahost:
@@ -84,7 +84,7 @@
       name: "{{ host1_fqdn }}"
       ok_as_delegate: yes
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Host "{{ host1_fqdn }}" present with ok_as_delegate again
     ipahost:
@@ -92,7 +92,7 @@
       name: "{{ host1_fqdn }}"
       ok_as_delegate: yes
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Host "{{ host1_fqdn }}" present with ok_to_auth_as_delegate
     ipahost:
@@ -100,7 +100,7 @@
       name: "{{ host1_fqdn }}"
       ok_to_auth_as_delegate: yes
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Host "{{ host1_fqdn }}" present with ok_to_auth_as_delegate again
     ipahost:
@@ -108,7 +108,7 @@
       name: "{{ host1_fqdn }}"
       ok_to_auth_as_delegate: yes
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Host absent
     ipahost:

--- a/tests/host/test_host_ipaddresses.yml
+++ b/tests/host/test_host_ipaddresses.yml
@@ -40,7 +40,7 @@
       update_dns: yes
       reverse: no
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Host "{{ host1_fqdn }}" present again
     ipahost:
@@ -52,7 +52,7 @@
       update_dns: yes
       reverse: no
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Host "{{ host1_fqdn }}" present again with new IP address
     ipahost:
@@ -66,7 +66,7 @@
       update_dns: yes
       reverse: no
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Host "{{ host1_fqdn }}" present again with new IP address again
     ipahost:
@@ -80,7 +80,7 @@
       update_dns: yes
       reverse: no
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Host "{{ host1_fqdn }}" member IPv4 address present
     ipahost:
@@ -89,7 +89,7 @@
       ip_address: "{{ ipv4_prefix + '.201' }}"
       action: member
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Host "{{ host1_fqdn }}" member IPv4 address present again
     ipahost:
@@ -98,7 +98,7 @@
       ip_address: "{{ ipv4_prefix + '.201' }}"
       action: member
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Host "{{ host1_fqdn }}" member IPv4 address absent
     ipahost:
@@ -108,7 +108,7 @@
       action: member
       state: absent
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Host "{{ host1_fqdn }}" member IPv4 address absent again
     ipahost:
@@ -118,7 +118,7 @@
       action: member
       state: absent
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Host "{{ host1_fqdn }}" member IPv6 address present
     ipahost:
@@ -127,7 +127,7 @@
       ip_address: fe80::20c:29ff:fe02:a1b2
       action: member
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Host "{{ host1_fqdn }}" member IPv6 address present again
     ipahost:
@@ -136,7 +136,7 @@
       ip_address: fe80::20c:29ff:fe02:a1b2
       action: member
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Host "{{ host1_fqdn }}" member IPv6 address absent
     ipahost:
@@ -146,7 +146,7 @@
       action: member
       state: absent
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Host "{{ host1_fqdn }}" member IPv6 address absent again
     ipahost:
@@ -156,6 +156,7 @@
       action: member
       state: absent
     register: result
+    failed_when: result.changed or result.failed
 
   - name: Host "{{ host1_fqdn }}" member all ip-addresses absent
     ipahost:
@@ -169,7 +170,7 @@
       action: member
       state: absent
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Host "{{ host1_fqdn }}" all member ip-addresses absent again
     ipahost:
@@ -183,7 +184,7 @@
       action: member
       state: absent
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Hosts "{{ host1_fqdn }}" and "{{ host2_fqdn }}" present with same IP addresses
     ipahost:
@@ -202,7 +203,7 @@
         - "{{ ipv4_prefix + '.221' }}"
         - fe80::20c:29ff:fe02:a1b4
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Hosts "{{ host1_fqdn }}" and "{{ host2_fqdn }}" present with same IP addresses again
     ipahost:
@@ -221,7 +222,7 @@
         - "{{ ipv4_prefix + '.221' }}"
         - fe80::20c:29ff:fe02:a1b4
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Hosts "{{ host3_fqdn }}" present with same IP addresses
     ipahost:
@@ -234,7 +235,7 @@
         - "{{ ipv4_prefix + '.221' }}"
         - fe80::20c:29ff:fe02:a1b4
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Hosts "{{ host3_fqdn }}" present with same IP addresses again
     ipahost:
@@ -247,7 +248,7 @@
         - "{{ ipv4_prefix + '.221' }}"
         - fe80::20c:29ff:fe02:a1b4
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Host "{{ host3_fqdn }}" present with differnt IP addresses
     ipahost:
@@ -260,7 +261,7 @@
         - "{{ ipv4_prefix + '.121' }}"
         - fe80::20c:29ff:fe02:a1b2
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Host "{{ host3_fqdn }}" present with different IP addresses again
     ipahost:
@@ -273,7 +274,7 @@
         - "{{ ipv4_prefix + '.121' }}"
         - fe80::20c:29ff:fe02:a1b2
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Host "{{ host3_fqdn }}" present with old IP addresses
     ipahost:
@@ -286,7 +287,7 @@
         - "{{ ipv4_prefix + '.221' }}"
         - fe80::20c:29ff:fe02:a1b4
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Host "{{ host3_fqdn }}" present with old IP addresses again
     ipahost:
@@ -299,7 +300,7 @@
         - "{{ ipv4_prefix + '.221' }}"
         - fe80::20c:29ff:fe02:a1b4
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Absent host01.ihavenodns.info test
     ipahost:
@@ -308,7 +309,7 @@
       - name: host01.ihavenodns.info
       state: absent
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Host absent
     ipahost:

--- a/tests/host/test_host_managedby_host.yml
+++ b/tests/host/test_host_managedby_host.yml
@@ -29,7 +29,7 @@
       name: "{{ host1_fqdn }}"
       force: yes
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Host "{{ host2_fqdn }}" present
     ipahost:
@@ -37,7 +37,7 @@
       name: "{{ host2_fqdn }}"
       force: yes
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Host "{{ host1_fqdn }}" managed by "{{ 'host2.' + ipaserver_domain }}"
     ipahost:
@@ -45,7 +45,7 @@
       name: "{{ host1_fqdn }}"
       managedby_host: "{{ host2_fqdn }}"
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Host "{{ host1_fqdn }}" managed by "{{ 'host2.' + ipaserver_domain }}" again
     ipahost:
@@ -53,7 +53,7 @@
       name: "{{ host1_fqdn }}"
       managedby_host: "{{ host2_fqdn }}"
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Host "{{ host1_fqdn }}" managed by "{{ ansible_facts['fqdn'] }}"
     ipahost:
@@ -62,7 +62,7 @@
       managedby_host: "{{ ansible_facts['fqdn'] }}"
       action: member
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Host "{{ host1_fqdn }}" managed by "{{ ansible_facts['fqdn'] }}" again
     ipahost:
@@ -71,7 +71,7 @@
       managedby_host: "{{ ansible_facts['fqdn'] }}"
       action: member
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Host "{{ host1_fqdn }}" not managed by "{{ ansible_facts['fqdn'] }}"
     ipahost:
@@ -81,7 +81,7 @@
       action: member
       state: absent
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Host "{{ host1_fqdn }}" not managed by "{{ ansible_facts['fqdn'] }}" again
     ipahost:
@@ -91,7 +91,7 @@
       action: member
       state: absent
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Host "{{ host1_fqdn }}" not managed by "{{ 'host2.' + ipaserver_domain }}"
     ipahost:
@@ -101,7 +101,7 @@
       state: absent
       action: member
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Host "{{ host1_fqdn }}" not managed by "{{ 'host2.' + ipaserver_domain }}" again
     ipahost:
@@ -111,7 +111,7 @@
       action: member
       state: absent
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Host absent
     ipahost:
@@ -122,4 +122,4 @@
       update_dns: yes
       state: absent
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed

--- a/tests/host/test_host_principal.yml
+++ b/tests/host/test_host_principal.yml
@@ -34,7 +34,7 @@
       - "{{ 'host/testhost1.' + ipaserver_domain + '@' + ipaserver_realm }}" 
       force: yes
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Host host1... principal host/host1... present (existing already)
     ipahost:
@@ -44,7 +44,7 @@
       - "{{ 'host/host1.' + ipaserver_domain + '@' + ipaserver_realm }}"
       action: member
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Host host1... principal host/testhost1... present again
     ipahost:
@@ -53,7 +53,7 @@
       principal: "{{ 'host/testhost1.' + ipaserver_domain + '@' + ipaserver_realm }}"
       action: member
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Host host1... principal host/testhost1... absent
     ipahost:
@@ -63,7 +63,7 @@
       action: member
       state: absent
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Host host1... principal host/testhost1... absent again
     ipahost:
@@ -73,7 +73,7 @@
       action: member
       state: absent
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Host host1... principal host/testhost1... and host/myhost1... present
     ipahost:
@@ -84,7 +84,7 @@
       - "{{ 'host/myhost1.' + ipaserver_domain + '@' + ipaserver_realm }}"
       action: member
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Host host1... principal host/testhost1... and host/myhost1... present again
     ipahost:
@@ -95,7 +95,7 @@
       - "{{ 'host/myhost1.' + ipaserver_domain + '@' + ipaserver_realm }}"
       action: member
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Host host1... principal host/testhost1... and host/myhost1... absent
     ipahost:
@@ -107,7 +107,7 @@
       action: member
       state: absent
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Host host1... principal host/testhost1... and host/myhost1... absent again
     ipahost:
@@ -119,7 +119,7 @@
       action: member
       state: absent
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Host host1... absent
     ipahost:

--- a/tests/host/test_host_random.yml
+++ b/tests/host/test_host_random.yml
@@ -31,7 +31,7 @@
       force: yes
       update_password: on_create
     register: ipahost
-    failed_when: not ipahost.changed
+    failed_when: not ipahost.changed or ipahost.failed
 
   - assert:
       that:
@@ -60,7 +60,7 @@
         force: yes
       update_password: on_create
     register: ipahost
-    failed_when: not ipahost.changed
+    failed_when: not ipahost.changed or ipahost.failed
 
   - assert:
       that:
@@ -85,7 +85,7 @@
         random: yes
       update_password: always
     register: ipahost
-    failed_when: ipahost.changed
+    failed_when: ipahost.changed or not ipahost.failed
 
   - assert:
       that:

--- a/tests/host/test_host_reverse.yml
+++ b/tests/host/test_host_reverse.yml
@@ -57,7 +57,7 @@
       update_dns: yes
       reverse: yes
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Host "{{ host1_fqdn }}" present, again.
     ipahost:
@@ -67,7 +67,7 @@
       update_dns: yes
       reverse: yes
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Hosts host1 absent
     ipahost:
@@ -77,7 +77,7 @@
       update_dns: yes
       state: absent
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Host "{{ host1_fqdn }}" present with IPv6
     ipahost:
@@ -87,7 +87,7 @@
       update_dns: yes
       reverse: yes
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Host "{{ host1_fqdn }}" present with IPv6, again.
     ipahost:
@@ -97,7 +97,7 @@
       update_dns: yes
       reverse: yes
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Hosts host1 absent
     ipahost:
@@ -107,7 +107,7 @@
       update_dns: yes
       state: absent
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Delete zone for reverse address.
     ipadnszone:

--- a/tests/host/test_hosts.yml
+++ b/tests/host/test_hosts.yml
@@ -47,7 +47,7 @@
       - name: "{{ host6_fqdn }}"
         force: yes
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Hosts host1..host6 present again
     ipahost:
@@ -66,7 +66,7 @@
       - name: "{{ host6_fqdn }}"
         force: yes
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Hosts host1..host6 absent
     ipahost:
@@ -80,7 +80,7 @@
       - name: "{{ host6_fqdn }}"
       state: absent
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Hosts host1..host6 absent again
     ipahost:
@@ -94,8 +94,10 @@
       - name: "{{ host6_fqdn }}"
       state: absent
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
+  # Use failed_when: not result.failed as this test needs to fail because a
+  # host is added two times in the same task
   - name: Duplicate names in hosts failure test
     ipahost:
       ipaadmin_password: SomeADMINpassword
@@ -109,4 +111,4 @@
       - name: "{{ host3_fqdn }}"
         force: yes
     register: result
-    failed_when: result.changed or "is used more than once" not in result.msg
+    failed_when: result.changed or not result.failed or "is used more than once" not in result.msg

--- a/tests/host/test_hosts_managedby_host.yml
+++ b/tests/host/test_hosts_managedby_host.yml
@@ -35,7 +35,7 @@
       name: "{{ host5_fqdn }}"
       force: yes
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Hosts "{{ host1_fqdn }}" .. "{{ 'host5.' + ipaserver_domain }}" present and managed by "{{ 'host5.' + ipaserver_domain }}"
     ipahost:
@@ -57,7 +57,7 @@
         managedby_host: "{{ host5_fqdn }}"
         force: yes
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Hosts "{{ host1_fqdn }}" .. "{{ 'host5.' + ipaserver_domain }}" present and managed by "{{ 'host5.' + ipaserver_domain }}" again
     ipahost:
@@ -79,7 +79,7 @@
         managedby_host: "{{ host5_fqdn }}"
         force: yes
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Hosts "{{ host1_fqdn }}" .. "{{ 'host5.' + ipaserver_domain }}" managed by "{{ 'host5.' + ipaserver_domain }}"
     ipahost:
@@ -97,7 +97,7 @@
         managedby_host: "{{ host5_fqdn }}"
       action: member
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Hosts "{{ host1_fqdn }}" .. "{{ 'host5.' + ipaserver_domain }}" not managed by "{{ 'host5.' + ipaserver_domain }}"
     ipahost:
@@ -116,7 +116,7 @@
       action: member
       state: absent
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Hosts "{{ host1_fqdn }}" .. "{{ 'host5.' + ipaserver_domain }}" not managed by "{{ 'host5.' + ipaserver_domain }}" again
     ipahost:
@@ -135,7 +135,7 @@
       action: member
       state: absent
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Hosts "{{ host1_fqdn }}" .. "{{ 'host5.' + ipaserver_domain }}" absent
     ipahost:
@@ -148,4 +148,4 @@
       - name: "{{ host5_fqdn }}"
       state: absent
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed

--- a/tests/host/test_hosts_principal.yml
+++ b/tests/host/test_hosts_principal.yml
@@ -41,7 +41,7 @@
         - "{{ 'host/testhost2.' + ipaserver_domain + '@' + ipaserver_realm }}" 
         force: yes
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Host hostX... principal 'host/hostX... present (existing already) X=[1,2]
     ipahost:
@@ -55,7 +55,7 @@
         - "{{ 'host/host2.' + ipaserver_domain + '@' + ipaserver_realm }}"
       action: member
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Host hostX... principal host/testhostX... present again X=[1,2]
     ipahost:
@@ -69,7 +69,7 @@
         - "{{ 'host/testhost2.' + ipaserver_domain + '@' + ipaserver_realm }}"
       action: member
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Host hostX.. principal host/testhostX... absent X=[1,2]
     ipahost:
@@ -84,7 +84,7 @@
       action: member
       state: absent
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Host hostX... principal host/testhostX... absent again X=[1,2]
     ipahost:
@@ -99,7 +99,7 @@
       action: member
       state: absent
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Host hostX... principal host/testhostX... and host/myhostX... present X=[1,2]
     ipahost:
@@ -115,7 +115,7 @@
         - "{{ 'host/myhost2.' + ipaserver_domain + '@' + ipaserver_realm }}"
       action: member
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Host hostX... principal host/testhostX... and host/myhostX... present again X=[1,2]
     ipahost:
@@ -131,7 +131,7 @@
         - "{{ 'host/myhost2.' + ipaserver_domain + '@' + ipaserver_realm }}"
       action: member
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Host hostX... principal host/testhostX... and host/myhostX... absent X=[1,2]
     ipahost:
@@ -148,7 +148,7 @@
       action: member
       state: absent
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Host hostX... principal host/testhostX... and host/myhostX... absent again X=[1,2]
     ipahost:
@@ -165,7 +165,7 @@
       action: member
       state: absent
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Hosts host1... and host2... absent
     ipahost:

--- a/tests/hostgroup/test_hostgroup.yml
+++ b/tests/hostgroup/test_hostgroup.yml
@@ -33,7 +33,7 @@
       name: "{{ 'db1.' + ipaserver_domain }}"
       force: yes
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Host "{{ 'db2.' + ipaserver_domain }}" present
     ipahost:
@@ -41,7 +41,7 @@
       name: "{{ 'db2.' + ipaserver_domain }}"
       force: yes
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure host-group mysql-server is present
     ipahostgroup:
@@ -49,7 +49,7 @@
       name: mysql-server
       state: present
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure host-group mysql-server is present again
     ipahostgroup:
@@ -57,7 +57,7 @@
       name: mysql-server
       state: present
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Ensure host-group oracle-server is present
     ipahostgroup:
@@ -65,7 +65,7 @@
       name: oracle-server
       state: present
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure host-group oracle-server is present again
     ipahostgroup:
@@ -73,7 +73,7 @@
       name: oracle-server
       state: present
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Ensure host-group databases is present
     ipahostgroup:
@@ -85,7 +85,7 @@
       hostgroup:
       - oracle-server
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure host-group databases is present again
     ipahostgroup:
@@ -97,7 +97,7 @@
       hostgroup:
       - oracle-server
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Ensure host db2 is member of host-group databases
     ipahostgroup:
@@ -108,7 +108,7 @@
       - "{{ 'db2.' + ipaserver_domain }}"
       action: member
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure host db2 is member of host-group databases again
     ipahostgroup:
@@ -119,7 +119,7 @@
       - "{{ 'db2.' + ipaserver_domain }}"
       action: member
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Ensure host-group mysql-server is member of host-group databases
     ipahostgroup:
@@ -130,7 +130,7 @@
       - mysql-server
       action: member
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure host-group mysql-server is member of host-group databases again
     ipahostgroup:
@@ -141,7 +141,7 @@
       - mysql-server
       action: member
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Ensure host-group oracle-server is member of host-group databases (again)
     ipahostgroup:
@@ -152,7 +152,7 @@
       - oracle-server
       action: member
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Ensure host-group databases, mysql-server and oracle-server are absent
     ipahostgroup:
@@ -163,7 +163,7 @@
       - oracle-server
       state: absent
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure host-group databases, mysql-server and oracle-server are absent again
     ipahostgroup:
@@ -174,7 +174,7 @@
       - oracle-server
       state: absent
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Test hosts db1 and db2 absent
     ipahost:

--- a/tests/hostgroup/test_hostgroup_membermanager.yml
+++ b/tests/hostgroup/test_hostgroup_membermanager.yml
@@ -45,21 +45,21 @@
             first: manageruser2
             last: Last2
         register: result
-        failed_when: not result.changed
+        failed_when: not result.changed or result.failed
 
       - name: Ensure managergroup1 is present
         ipagroup:
           ipaadmin_password: SomeADMINpassword
           name: managergroup1
         register: result
-        failed_when: not result.changed
+        failed_when: not result.changed or result.failed
 
       - name: Ensure managergroup2 is present
         ipagroup:
           ipaadmin_password: SomeADMINpassword
           name: managergroup2
         register: result
-        failed_when: not result.changed
+        failed_when: not result.changed or result.failed
 
       - name: Ensure membermanager user1 is present for testhostgroup
         ipahostgroup:
@@ -67,7 +67,7 @@
           name: testhostgroup
           membermanager_user: manageruser1
         register: result
-        failed_when: not result.changed
+        failed_when: not result.changed or result.failed
 
       - name: Ensure membermanager user1 is present for testhostgroup again
         ipahostgroup:
@@ -75,7 +75,7 @@
           name: testhostgroup
           membermanager_user: manageruser1
         register: result
-        failed_when: result.changed
+        failed_when: result.changed or result.failed
 
       - name: Ensure membermanager group1 is present for testhostgroup
         ipahostgroup:
@@ -83,7 +83,7 @@
           name: testhostgroup
           membermanager_group: managergroup1
         register: result
-        failed_when: not result.changed
+        failed_when: not result.changed or result.failed
 
       - name: Ensure membermanager group1 is present for testhostgroup again
         ipahostgroup:
@@ -91,7 +91,7 @@
           name: testhostgroup
           membermanager_group: managergroup1
         register: result
-        failed_when: result.changed
+        failed_when: result.changed or result.failed
 
       - name: Ensure membermanager user2 and group2 members are present for testhostgroup
         ipahostgroup:
@@ -101,7 +101,7 @@
           membermanager_group: managergroup2
           action: member
         register: result
-        failed_when: not result.changed
+        failed_when: not result.changed or result.failed
 
       - name: Ensure membermanager user2 and group2 members are present for testhostgroup again
         ipahostgroup:
@@ -111,7 +111,7 @@
           membermanager_group: managergroup2
           action: member
         register: result
-        failed_when: result.changed
+        failed_when: result.changed or result.failed
 
       - name: Ensure membermanager user and group members are present for testhostgroup again
         ipahostgroup:
@@ -121,7 +121,7 @@
           membermanager_group: managergroup1,managergroup2
           action: member
         register: result
-        failed_when: result.changed
+        failed_when: result.changed or result.failed
 
       - name: Ensure membermanager user1 and group1 members are absent for testhostgroup
         ipahostgroup:
@@ -132,7 +132,7 @@
           action: member
           state: absent
         register: result
-        failed_when: not result.changed
+        failed_when: not result.changed or result.failed
 
       - name: Ensure membermanager user1 and group1 members are absent for testhostgroup again
         ipahostgroup:
@@ -143,7 +143,7 @@
           action: member
           state: absent
         register: result
-        failed_when: result.changed
+        failed_when: result.changed or result.failed
 
 
       - name: Ensure membermanager user1 and group1 members are present for testhostgroup
@@ -154,7 +154,7 @@
           membermanager_group: managergroup1
           action: member
         register: result
-        failed_when: not result.changed
+        failed_when: not result.changed or result.failed
 
       - name: Ensure membermanager user1 and group1 members are present for testhostgroup again
         ipahostgroup:
@@ -164,7 +164,7 @@
           membermanager_group: managergroup1
           action: member
         register: result
-        failed_when: result.changed
+        failed_when: result.changed or result.failed
 
       - name: Ensure membermanager user and group members are absent for testhostgroup
         ipahostgroup:
@@ -175,7 +175,7 @@
           action: member
           state: absent
         register: result
-        failed_when: not result.changed
+        failed_when: not result.changed or result.failed
 
       - name: Ensure membermanager user and group members are absent for testhostgroup again
         ipahostgroup:
@@ -186,7 +186,7 @@
           action: member
           state: absent
         register: result
-        failed_when: result.changed
+        failed_when: result.changed or result.failed
 
       - name: Ensure user manangeruser1 and manageruser2 is absent
         ipauser:
@@ -194,7 +194,7 @@
           name: manageruser1,manageruser2
           state: absent
         register: result
-        failed_when: not result.changed
+        failed_when: not result.changed or result.failed
 
       - name: Ensure group managergroup1 and managergroup2 are absent
         ipagroup:
@@ -202,8 +202,10 @@
           name: managergroup1,managergroup2
           state: absent
         register: result
-        failed_when: not result.changed
+        failed_when: not result.changed or result.failed
 
+      # Do not add failed_when result.failed, as this test needs to fail
+      # due to using an unknown user
       - name: Ensure unknown membermanager_user member failure
         ipahostgroup:
           ipaadmin_password: SomeADMINpassword
@@ -220,5 +222,5 @@
           - testhostgroup
           state: absent
         register: result
-        failed_when: not result.changed
+        failed_when: not result.changed or result.failed
     when: ipa_version is version('4.8.4', '>=')

--- a/tests/hostgroup/test_hostgroup_rename.yml
+++ b/tests/hostgroup/test_hostgroup_rename.yml
@@ -24,7 +24,7 @@
           name: databases
           state: present
         register: result
-        failed_when: not result.changed
+        failed_when: not result.changed or result.failed
 
       - name: Rename host-group from `databases` to `datalake`
         ipahostgroup:
@@ -33,7 +33,7 @@
           rename: datalake
           state: renamed
         register: result
-        failed_when: not result.changed
+        failed_when: not result.changed or result.failed
 
       - name: Ensure host-group database was already absent
         ipahostgroup:
@@ -41,7 +41,7 @@
           name: database
           state: absent
         register: result
-        failed_when: result.changed
+        failed_when: result.changed or result.failed
 
       - name: Rename host-group from `databases` to `datalake`, again
         ipahostgroup:
@@ -59,7 +59,7 @@
           rename: datalake
           state: renamed
         register: result
-        failed_when: result.changed
+        failed_when: result.changed or result.failed
 
       - name: Ensure testing hostgroups do not exist.
         ipahostgroup:

--- a/tests/pwpolicy/test_pwpolicy.yml
+++ b/tests/pwpolicy/test_pwpolicy.yml
@@ -28,7 +28,7 @@
       name: ops
       state: present
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure presence of pwpolicies for group ops
     ipapwpolicy:
@@ -44,7 +44,7 @@
       maxfail: 3
       failinterval: 5
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure presence of pwpolicies for group ops again
     ipapwpolicy:
@@ -60,21 +60,21 @@
       maxfail: 3
       failinterval: 5
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Ensure maxlife of 49 for global_policy
     ipapwpolicy:
       ipaadmin_password: SomeADMINpassword
       maxlife: 49
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure maxlife of 49 for global_policy again
     ipapwpolicy:
       ipaadmin_password: SomeADMINpassword
       maxlife: 49
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Ensure absence of pwpoliciy global_policy will fail
     ipapwpolicy:
@@ -82,7 +82,7 @@
       state: absent
     register: result
     ignore_errors: True
-    failed_when: result is defined and result
+    failed_when: (result is defined and result) or result.failed
 
   - name: Ensure absence of pwpolicies for group ops
     ipapwpolicy:
@@ -90,14 +90,14 @@
       name: ops
       state: absent
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure maxlife of 90 for global_policy
     ipapwpolicy:
       ipaadmin_password: SomeADMINpassword
       maxlife: 90
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure absence of pwpolicies for group ops
     ipapwpolicy:
@@ -105,4 +105,4 @@
       name: ops
       state: absent
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed

--- a/tests/role/test_role.yml
+++ b/tests/role/test_role.yml
@@ -18,7 +18,7 @@
       name: renamerole
       description: A role in IPA.
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure role is present, again.
     iparole:
@@ -26,7 +26,7 @@
       name: renamerole
       description: A role in IPA.
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Rename role.
     iparole:
@@ -34,8 +34,10 @@
       name: renamerole
       rename: testrole
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
+  # Do not test result.failed, this task will fail as there is no role to
+  # be renamed.
   - name: Rename role, again.
     iparole:
       ipaadmin_password: SomeADMINpassword
@@ -53,7 +55,7 @@
       - Host Administrators
       action: member
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure role has member has privileges, again.
     iparole:
@@ -64,7 +66,7 @@
       - Host Administrators
       action: member
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Ensure role has less privileges.
     iparole:
@@ -75,7 +77,7 @@
       action: member
       state: absent
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure role has less privileges, again.
     iparole:
@@ -86,7 +88,7 @@
       action: member
       state: absent
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Ensure role has member has privileges restored.
     iparole:
@@ -97,7 +99,7 @@
       - Host Administrators
       action: member
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure role has member has privileges restored, again.
     iparole:
@@ -108,7 +110,7 @@
       - Host Administrators
       action: member
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Ensure role member privileges are absent.
     iparole:
@@ -120,7 +122,7 @@
       action: member
       state: absent
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure role member privileges are absent, again.
     iparole:
@@ -132,7 +134,7 @@
       action: member
       state: absent
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Ensure invalid privileged is not assigned to role.
     iparole:
@@ -151,7 +153,7 @@
       - user01
       action: member
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure role has member user present, again.
     iparole:
@@ -161,7 +163,7 @@
       - user01
       action: member
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Ensure role has member user absent.
     iparole:
@@ -172,7 +174,7 @@
       action: member
       state: absent
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure role has member user absent, again.
     iparole:
@@ -183,7 +185,7 @@
       action: member
       state: absent
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Ensure role has member group present.
     iparole:
@@ -193,7 +195,7 @@
       - group01
       action: member
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure role has member group present, again.
     iparole:
@@ -203,7 +205,7 @@
       - group01
       action: member
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Ensure role has member group absent.
     iparole:
@@ -214,7 +216,7 @@
       action: member
       state: absent
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure role has member group absent, again.
     iparole:
@@ -225,7 +227,7 @@
       action: member
       state: absent
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Ensure role has member host present.
     iparole:
@@ -235,7 +237,7 @@
       - "{{ host1_fqdn }}"
       action: member
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure role has member host present, again.
     iparole:
@@ -245,7 +247,7 @@
       - "{{ host1_fqdn }}"
       action: member
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Ensure role has member host absent.
     iparole:
@@ -256,7 +258,7 @@
       action: member
       state: absent
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure role has member host absent, again.
     iparole:
@@ -267,7 +269,7 @@
       action: member
       state: absent
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Ensure role has member hostgroup present.
     iparole:
@@ -277,7 +279,7 @@
       - hostgroup01
       action: member
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure role has member hostgroup present, again.
     iparole:
@@ -287,7 +289,7 @@
       - hostgroup01
       action: member
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Ensure role has member hostgroup absent.
     iparole:
@@ -298,7 +300,7 @@
       action: member
       state: absent
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure role has member hostgroup absent, again.
     iparole:
@@ -309,7 +311,7 @@
       action: member
       state: absent
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Ensure role is absent.
     iparole:
@@ -317,7 +319,7 @@
       name: testrole
       state: absent
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure role is absent, again.
     iparole:
@@ -325,7 +327,7 @@
       name: testrole
       state: absent
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Ensure role with members is present.
     iparole:
@@ -345,7 +347,7 @@
       service:
       - "service01/{{ host1_fqdn }}"
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure role with members is present, again.
     iparole:
@@ -365,7 +367,7 @@
       service:
       - "service01/{{ host1_fqdn }}"
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Ensure role is absent.
     iparole:
@@ -373,7 +375,7 @@
       name: testrole
       state: absent
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure role is absent, again.
     iparole:
@@ -381,7 +383,7 @@
       name: testrole
       state: absent
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   # cleanup
   - name: Cleanup environment.

--- a/tests/role/test_role_service_member.yml
+++ b/tests/role/test_role_service_member.yml
@@ -20,7 +20,7 @@
       service:
       - "service01/{{ host1_fqdn }}"
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure role with member service is present, again.
     iparole:
@@ -30,7 +30,7 @@
       - "service01/{{ host1_fqdn }}"
       action: member
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Ensure role has member service absent.
     iparole:
@@ -41,7 +41,7 @@
       action: member
       state: absent
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure role has member service absent, again.
     iparole:
@@ -52,7 +52,7 @@
       action: member
       state: absent
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Ensure role has member service with principal name.
     iparole:
@@ -62,7 +62,7 @@
       - "service01/{{ host1_fqdn }}@{{ ipaserver_realm }}"
       action: member
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure role has member service with principal name, again.
     iparole:
@@ -72,7 +72,7 @@
       - "service01/{{ host1_fqdn }}@{{ ipaserver_realm }}"
       action: member
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Ensure role is absent.
     iparole:
@@ -80,7 +80,7 @@
       name: testrole
       state: absent
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure role is absent, again.
     iparole:
@@ -88,7 +88,7 @@
       name: testrole
       state: absent
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   # cleanup
   - name: Cleanup environment.

--- a/tests/sudocmd/test_sudocmd.yml
+++ b/tests/sudocmd/test_sudocmd.yml
@@ -21,7 +21,7 @@
       name: /usr/bin/su
       state: present
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure sudocmd is present again
     ipasudocmd:
@@ -29,7 +29,7 @@
       name: /usr/bin/su
       state: present
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Ensure sudocmd is absent
     ipasudocmd:
@@ -37,7 +37,7 @@
       name: /usr/bin/su
       state: absent
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure sudocmd is absent again
     ipasudocmd:
@@ -45,7 +45,7 @@
       name: /usr/bin/su
       state: absent
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Ensure multiple sudocmd are present
     ipasudocmd:
@@ -55,7 +55,7 @@
       - /usr/sbin/iwlist
       state: present
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure multiple sudocmd are present again
     ipasudocmd:
@@ -65,7 +65,7 @@
       - /usr/sbin/iwlist
       state: present
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Ensure multiple sudocmd are absent
     ipasudocmd:
@@ -75,7 +75,7 @@
       - /usr/sbin/iwlist
       state: absent
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure multiple sudocmd are absent again
     ipasudocmd:
@@ -85,7 +85,8 @@
       - /usr/sbin/iwlist
       state: absent
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
+
   - name: Ensure sudocmds are absent
     ipasudocmd:
       ipaadmin_password: SomeADMINpassword
@@ -117,4 +118,4 @@
       - /usr/sbin/iwlist
       state: absent
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed

--- a/tests/sudocmdgroup/test_sudocmdgroup.yml
+++ b/tests/sudocmdgroup/test_sudocmdgroup.yml
@@ -26,7 +26,7 @@
       name: network
       state: present
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure sudocmdgroup is present again
     ipasudocmdgroup:
@@ -34,7 +34,7 @@
       name: network
       state: present
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Ensure sudocmdgroup is absent
     ipasudocmdgroup:
@@ -42,7 +42,7 @@
       name: network
       state: absent
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure sudocmdgroup is absent again
     ipasudocmdgroup:
@@ -50,7 +50,7 @@
       name: network
       state: absent
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Ensure sudocmdgroup is present, with sudocmds.
     ipasudocmdgroup:
@@ -61,7 +61,7 @@
       - /usr/sbin/iwlist
       state: present
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure sudocmdgroup is present, with sudocmds, again.
     ipasudocmdgroup:
@@ -72,7 +72,7 @@
       - /usr/sbin/iwlist
       state: present
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Verify sudocmdgroup creation with sudocmds
     shell: |
@@ -88,7 +88,7 @@
       name: network
       state: absent
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure sudocmdgroup, with sudocmds, is absent again
     ipasudocmdgroup:
@@ -96,7 +96,7 @@
       name: network
       state: absent
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Ensure testing sudocmdgroup is present
     ipasudocmdgroup:
@@ -104,7 +104,7 @@
       name: network
       state: present
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure sudo commands are present in existing sudocmdgroup
     ipasudocmdgroup:
@@ -115,7 +115,7 @@
       - /usr/sbin/iwlist
       action: member
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure sudo commands are present in existing sudocmdgroup, again
     ipasudocmdgroup:
@@ -126,7 +126,7 @@
       - /usr/sbin/iwlist
       action: member
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Ensure sudo commands are absent in existing sudocmdgroup
     ipasudocmdgroup:
@@ -138,7 +138,7 @@
       action: member
       state: absent
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure sudo commands are absent in existing sudocmdgroup, again
     ipasudocmdgroup:
@@ -150,7 +150,7 @@
       action: member
       state: absent
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Ensure sudo commands are present in sudocmdgroup
     ipasudocmdgroup:
@@ -162,7 +162,7 @@
       action: member
       state: present
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure one sudo command is not present in sudocmdgroup
     ipasudocmdgroup:
@@ -173,7 +173,7 @@
       action: member
       state: absent
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure one sudo command is present in sudocmdgroup
     ipasudocmdgroup:
@@ -184,7 +184,7 @@
       action: member
       state: present
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure the other sudo command is not present in sudocmdgroup
     ipasudocmdgroup:
@@ -195,7 +195,7 @@
       action: member
       state: absent
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure the other sudo commandsis not present in sudocmdgroup, again
     ipasudocmdgroup:
@@ -206,4 +206,4 @@
       action: member
       state: absent
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed

--- a/tests/sudorule/test_sudorule.yml
+++ b/tests/sudorule/test_sudorule.yml
@@ -279,6 +279,8 @@
       ipaadmin_password: SomeADMINpassword
       name: testrule1
       state: disabled
+    register: result
+    failed_when: not result.changed or result.failed
 
   - name: Ensure sudorule is disabled, again
     ipasudorule:

--- a/tests/sudorule/test_sudorule.yml
+++ b/tests/sudorule/test_sudorule.yml
@@ -77,14 +77,14 @@
       ipaadmin_password: SomeADMINpassword
       name: testrule1
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure sudorule is present again
     ipasudorule:
       ipaadmin_password: SomeADMINpassword
       name: testrule1
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Ensure user01 is on the list of users sudorule execute as.
     ipasudorule:
@@ -94,7 +94,7 @@
         - user01
       action: member
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure user01 is on the list of users sudorule execute as, again.
     ipasudorule:
@@ -104,7 +104,7 @@
         - user01
       action: member
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Ensure user01 is not on the list of users sudorule execute as.
     ipasudorule:
@@ -115,7 +115,7 @@
       action: member
       state: absent
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure user01 is not on the list of users sudorule execute as, again.
     ipasudorule:
@@ -126,7 +126,7 @@
       action: member
       state: absent
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Ensure group01 is on the list of group sudorule execute as.
     ipasudorule:
@@ -136,7 +136,7 @@
         - group01
       action: member
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure group01 is on the list of group sudorule execute as, again.
     ipasudorule:
@@ -146,7 +146,7 @@
         - group01
       action: member
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Ensure group01 is not on the list of group sudorule execute as.
     ipasudorule:
@@ -157,7 +157,7 @@
       action: member
       state: absent
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure group01 is not on the list of groups sudorule execute as, again.
     ipasudorule:
@@ -168,7 +168,7 @@
       action: member
       state: absent
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Ensure sudorule is present, with usercategory 'all'
     ipasudorule:
@@ -176,7 +176,7 @@
       name: allusers
       usercategory: all
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure sudorule is present, with usercategory 'all', again
     ipasudorule:
@@ -184,7 +184,7 @@
       name: allusers
       usercategory: all
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Ensure sudorule is with usercategory 'all' is absent
     ipasudorule:
@@ -192,7 +192,7 @@
       name: allusers
       state: absent
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure sudorule is present, with runasusercategory 'all'.
     ipasudorule:
@@ -200,7 +200,7 @@
       name: allusers
       runasusercategory: all
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure sudorule is present, with runasusercategory 'all', again.
     ipasudorule:
@@ -208,7 +208,7 @@
       name: allusers
       runasusercategory: all
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Ensure sudorule is with runasusercategory 'all' is absent
     ipasudorule:
@@ -216,7 +216,7 @@
       name: allusers
       state: absent
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure sudorule is present, with runasgroupcategory 'all'.
     ipasudorule:
@@ -224,7 +224,7 @@
       name: allusers
       runasgroupcategory: all
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure sudorule is present, with runasgroupcategory 'all', again.
     ipasudorule:
@@ -232,7 +232,7 @@
       name: allusers
       runasgroupcategory: all
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Ensure sudorule is with runasgroupcategory 'all' is absent
     ipasudorule:
@@ -240,7 +240,7 @@
       name: allusers
       state: absent
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure sudorule is present, with usercategory 'all'.
     ipasudorule:
@@ -248,7 +248,7 @@
       name: allusers
       usercategory: all
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure sudorule is present, with usercategory 'all', again.
     ipasudorule:
@@ -256,7 +256,7 @@
       name: allusers
       usercategory: all
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Ensure sudorule is present, with hostategory 'all'
     ipasudorule:
@@ -264,7 +264,7 @@
       name: allhosts
       hostcategory: all
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure sudorule is present, with hostategory 'all', again
     ipasudorule:
@@ -272,7 +272,7 @@
       name: allhosts
       hostcategory: all
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Ensure sudorule is disabled
     ipasudorule:
@@ -288,7 +288,7 @@
       name: testrule1
       state: disabled
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Ensure sudorule is enabled
     ipasudorule:
@@ -296,7 +296,7 @@
       name: testrule1
       state: enabled
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure sudorule is enabled, again
     ipasudorule:
@@ -304,7 +304,7 @@
       name: testrule1
       state: enabled
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Ensure user is present in sudorule.
     ipasudorule:
@@ -313,7 +313,7 @@
       user: user01
       action: member
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure user is present in sudorule, again.
     ipasudorule:
@@ -322,7 +322,7 @@
       user: user01
       action: member
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Ensure user is absent from sudorule.
     ipasudorule:
@@ -332,7 +332,7 @@
       action: member
       state: absent
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure user is absent from sudorule, again.
     ipasudorule:
@@ -342,7 +342,7 @@
       action: member
       state: absent
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Ensure group is present in sudorule.
     ipasudorule:
@@ -351,7 +351,7 @@
       group: group01
       action: member
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure group is present in sudorule, again.
     ipasudorule:
@@ -360,7 +360,7 @@
       group: group01
       action: member
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Ensure group is absent from sudorule.
     ipasudorule:
@@ -370,7 +370,7 @@
       action: member
       state: absent
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure group is absent from sudorule, again.
     ipasudorule:
@@ -380,7 +380,7 @@
       action: member
       state: absent
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Ensure sudorule has a sudooption.
     ipasudorule:
@@ -389,7 +389,7 @@
       sudooption: '!authenticate'
       action: member
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure sudorule has a sudooption, again.
     ipasudorule:
@@ -398,7 +398,7 @@
       sudooption: '!authenticate'
       action: member
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Ensure sudorule has an order.
     ipasudorule:
@@ -406,7 +406,7 @@
       name: testrule1
       order: 1
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure sudorule has an order, again.
     ipasudorule:
@@ -414,7 +414,7 @@
       name: testrule1
       order: 1
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Ensure sudorule has another order.
     ipasudorule:
@@ -422,7 +422,7 @@
       name: testrule1
       order: 10
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure sudorule is present and some sudocmd are allowed.
     ipasudorule:
@@ -432,7 +432,7 @@
       - /sbin/ifconfig
       action: member
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure sudorule is present and some sudocmd are allowed, again.
     ipasudorule:
@@ -442,7 +442,7 @@
       - /sbin/ifconfig
       action: member
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Ensure sudorule is present and some sudocmd are denyed.
     ipasudorule:
@@ -452,7 +452,7 @@
       - /usr/bin/vim
       action: member
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure sudorule is present and some sudocmd are denyed, again.
     ipasudorule:
@@ -462,7 +462,7 @@
       - /usr/bin/vim
       action: member
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Ensure sudorule is present and, sudocmds are absent.
     ipasudorule:
@@ -473,7 +473,7 @@
       action: member
       state: absent
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure sudorule is present and, sudocmds are absent, again.
     ipasudorule:
@@ -484,7 +484,7 @@
       action: member
       state: absent
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Ensure sudorule is present with cmdcategory 'all'.
     ipasudorule:
@@ -492,7 +492,7 @@
       name: allcommands
       cmdcategory: all
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure sudorule is present with cmdcategory 'all', again.
     ipasudorule:
@@ -500,7 +500,7 @@
       name: allcommands
       cmdcategory: all
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Ensure host "{{ ansible_facts['fqdn'] }}" is present in sudorule.
     ipasudorule:
@@ -509,7 +509,7 @@
       host: "{{ ansible_facts['fqdn'] }}"
       action: member
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure host "{{ ansible_facts['fqdn'] }}" is present in sudorule, again.
     ipasudorule:
@@ -518,7 +518,7 @@
       host: "{{ ansible_facts['fqdn'] }}"
       action: member
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Ensure hostgroup is present in sudorule.
     ipasudorule:
@@ -527,7 +527,7 @@
       hostgroup: cluster
       action: member
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure hostgroup is present in sudorule, again.
     ipasudorule:
@@ -536,7 +536,7 @@
       hostgroup: cluster
       action: member
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Ensure sudorule is present, with an allow_sudocmdgroup.
     ipasudorule:
@@ -545,7 +545,7 @@
       allow_sudocmdgroup: test_sudorule
       state: present
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure sudorule is present, with an allow_sudocmdgroup, again.
     ipasudorule:
@@ -554,7 +554,7 @@
       allow_sudocmdgroup: test_sudorule
       state: present
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Ensure sudorule is present, but allow_sudocmdgroup is absent.
     ipasudorule:
@@ -564,7 +564,7 @@
       action: member
       state: absent
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure sudorule is present, but allow_sudocmdgroup is absent.
     ipasudorule:
@@ -574,7 +574,7 @@
       action: member
       state: absent
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Ensure sudorule is present, with an deny_sudocmdgroup.
     ipasudorule:
@@ -583,7 +583,7 @@
       deny_sudocmdgroup: test_sudorule
       state: present
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure sudorule is present, with an deny_sudocmdgroup, again.
     ipasudorule:
@@ -592,7 +592,7 @@
       deny_sudocmdgroup: test_sudorule
       state: present
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Ensure sudorule is present, but deny_sudocmdgroup is absent.
     ipasudorule:
@@ -602,7 +602,7 @@
       action: member
       state: absent
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure sudorule is present, but deny_sudocmdgroup is absent, again.
     ipasudorule:
@@ -612,7 +612,7 @@
       action: member
       state: absent
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Ensure sudorule is absent
     ipasudorule:
@@ -620,7 +620,7 @@
       name: testrule1
       state: absent
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure sudorule is absent, again.
     ipasudorule:
@@ -628,7 +628,7 @@
       name: testrule1
       state: absent
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Ensure sudorule allhosts is absent
     ipasudorule:
@@ -636,7 +636,7 @@
       name: allhosts
       state: absent
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure sudorule allhosts is absent, again
     ipasudorule:
@@ -644,7 +644,7 @@
       name: allhosts
       state: absent
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Ensure sudorule allusers is absent
     ipasudorule:
@@ -652,7 +652,7 @@
       name: allusers
       state: absent
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure sudorule allusers is absent, again
     ipasudorule:
@@ -660,7 +660,7 @@
       name: allusers
       state: absent
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Ensure sudorule allcommands is absent
     ipasudorule:
@@ -668,7 +668,7 @@
       name: allcommands
       state: absent
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure sudorule allcommands is absent, again
     ipasudorule:
@@ -676,7 +676,7 @@
       name: allcommands
       state: absent
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   # cleanup
   - name : Ensure sudocmdgroup is absent

--- a/tests/sudorule/test_sudorule_categories.yml
+++ b/tests/sudorule/test_sudorule_categories.yml
@@ -22,7 +22,7 @@
       name: allusers
       usercategory: all
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure sudorule is present, with usercategory 'all', again.
     ipasudorule:
@@ -30,7 +30,7 @@
       name: allusers
       usercategory: all
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Ensure sudorule is present, with no usercategory.
     ipasudorule:
@@ -38,7 +38,7 @@
       name: allusers
       usercategory: ""
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure sudorule is present, with no usercategory, again.
     ipasudorule:
@@ -46,7 +46,7 @@
       name: allusers
       usercategory: ""
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Ensure sudorule is present, with hostcategory 'all'
     ipasudorule:
@@ -54,7 +54,7 @@
       name: allusers
       hostcategory: all
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure sudorule is present, with hostcategory 'all', again.
     ipasudorule:
@@ -62,7 +62,7 @@
       name: allusers
       hostcategory: all
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Ensure sudorule is present, with no usercategory.
     ipasudorule:
@@ -70,7 +70,7 @@
       name: allusers
       hostcategory: ""
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure sudorule is present, with no hostcategory, again.
     ipasudorule:
@@ -78,7 +78,7 @@
       name: allusers
       hostcategory: ""
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Ensure sudorule is present, with cmdcategory 'all'
     ipasudorule:
@@ -86,7 +86,7 @@
       name: allusers
       cmdcategory: all
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure sudorule is present, with cmdcategory 'all', again.
     ipasudorule:
@@ -94,7 +94,7 @@
       name: allusers
       cmdcategory: all
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Ensure sudorule is present, with no cmdcategory.
     ipasudorule:
@@ -102,7 +102,7 @@
       name: allusers
       cmdcategory: ""
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure sudorule is present, with no cmdcategory, again.
     ipasudorule:
@@ -110,7 +110,7 @@
       name: allusers
       cmdcategory: ""
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Ensure sudorule is present, with runasusercategory 'all'
     ipasudorule:
@@ -118,7 +118,7 @@
       name: allusers
       runasusercategory: all
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure sudorule is present, with runasusercategory 'all', again.
     ipasudorule:
@@ -126,7 +126,7 @@
       name: allusers
       runasusercategory: all
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Ensure sudorule is present, with no runasusercategory.
     ipasudorule:
@@ -134,7 +134,7 @@
       name: allusers
       runasusercategory: ""
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure sudorule is present, with no runasusercategory, again.
     ipasudorule:
@@ -142,7 +142,7 @@
       name: allusers
       runasusercategory: ""
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Ensure sudorule is present, with runasgroupcategory 'all'
     ipasudorule:
@@ -150,7 +150,7 @@
       name: allusers
       runasgroupcategory: all
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure sudorule is present, with runasgroupcategory 'all', again.
     ipasudorule:
@@ -158,7 +158,7 @@
       name: allusers
       runasgroupcategory: all
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Ensure sudorule is present, with no runasgroupcategory.
     ipasudorule:
@@ -166,7 +166,7 @@
       name: allusers
       runasgroupcategory: ""
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure sudorule is present, with no runasgroupcategory, again.
     ipasudorule:
@@ -174,7 +174,7 @@
       name: allusers
       runasgroupcategory: ""
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Ensure sudorules are absent
     ipasudorule:
@@ -183,7 +183,7 @@
       - allusers
       state: absent
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure `host` cannot be added if hostcategory is `all`.
     ipasudorule:

--- a/tests/user/certificate/test_user_certificate.yml
+++ b/tests/user/certificate/test_user_certificate.yml
@@ -32,21 +32,19 @@
       - "{{ lookup('file', 'cert3.b64', rstrip=False) }}"
       action: member
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: User test cert members present again
     ipauser:
       ipaadmin_password: SomeADMINpassword
       name: test
-      first: test
-      last: test
       certificate:
       - "{{ lookup('file', 'cert1.b64', rstrip=False) }}"
       - "{{ lookup('file', 'cert2.b64', rstrip=False) }}"
       - "{{ lookup('file', 'cert3.b64', rstrip=False) }}"
       action: member
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: User test cert members absent
     ipauser:
@@ -59,7 +57,7 @@
       state: absent
       action: member
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: User test cert members absent again
     ipauser:
@@ -72,7 +70,7 @@
       state: absent
       action: member
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: User test absent
     ipauser:
@@ -80,7 +78,7 @@
       name: test
       state: absent
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Remove certificate files.
     shell:

--- a/tests/user/certificate/test_users_certificate.yml
+++ b/tests/user/certificate/test_users_certificate.yml
@@ -41,7 +41,7 @@
         - "{{ lookup('file', 'cert3.b64', rstrip=False) }}"
       action: member
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: User test cert members present again
     ipauser:
@@ -54,7 +54,7 @@
         - "{{ lookup('file', 'cert3.b64', rstrip=False) }}"
       action: member
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: User test cert members absent
     ipauser:
@@ -68,7 +68,7 @@
       state: absent
       action: member
     #register: result
-    #failed_when: not result.changed
+    #failed_when: not result.changed or result.failed
 
   - name: User test cert members absent again
     ipauser:
@@ -82,7 +82,7 @@
       state: absent
       action: member
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: User test absent
     ipauser:
@@ -91,7 +91,7 @@
       - name: test
       state: absent
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Remove certificate files.
     shell:

--- a/tests/user/certmapdata/test_user_certmapdata.yml
+++ b/tests/user/certmapdata/test_user_certmapdata.yml
@@ -28,7 +28,7 @@
       first: test
       last: test
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: User test certmapdata members present
     ipauser:
@@ -40,7 +40,7 @@
         - certificate: "{{ lookup('file', 'cert3.b64', rstrip=False) }}"
       action: member
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: User test certmapdata members present again
     ipauser:
@@ -52,7 +52,7 @@
         - certificate: "{{ lookup('file', 'cert3.b64', rstrip=False) }}"
       action: member
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: User test certmapdata members absent
     ipauser:
@@ -65,7 +65,7 @@
       action: member
       state: absent
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: User test certmapdata members absent again
     ipauser:
@@ -78,7 +78,7 @@
       action: member
       state: absent
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: User test certmapdata members present
     ipauser:
@@ -93,7 +93,7 @@
         subject: CN=subject3
       action: member
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: User test certmapdata members present again
     ipauser:
@@ -108,7 +108,7 @@
         subject: CN=subject3
       action: member
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: User test certmapdata members absent
     ipauser:
@@ -122,7 +122,7 @@
       action: member
       state: absent
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: User test certmapdata members absent again
     ipauser:
@@ -136,7 +136,7 @@
       action: member
       state: absent
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: User test certmapdata members absent
     ipauser:
@@ -148,7 +148,7 @@
       action: member
       state: absent
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: User test certmapdata members absent again
     ipauser:
@@ -160,7 +160,7 @@
       action: member
       state: absent
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: User test certmapdata member present
     ipauser:
@@ -171,7 +171,7 @@
         subject: CN=test,dc=example,dc=com
       action: member
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: User test certmapdata member present again
     ipauser:
@@ -182,7 +182,7 @@
         subject: CN=test,dc=example,dc=com
       action: member
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: User test certmapdata member (data) present again
     ipauser:
@@ -192,7 +192,7 @@
       - data: X509:<I>dc=com,dc=example,CN=ca<S>dc=com,dc=example,CN=test
       action: member
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: User test certmapdata member absent
     ipauser:
@@ -204,7 +204,7 @@
       action: member
       state: absent
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: User test certmapdata member (data) absent again
     ipauser:
@@ -215,7 +215,7 @@
       action: member
       state: absent
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: User test absent
     ipauser:
@@ -223,7 +223,7 @@
       name: test
       state: absent
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Remove certificate files.
     shell:

--- a/tests/user/certmapdata/test_user_certmapdata_issuer_subject.yml
+++ b/tests/user/certmapdata/test_user_certmapdata_issuer_subject.yml
@@ -18,7 +18,7 @@
       first: test
       last: test
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: User test certmapdata members present
     ipauser:
@@ -33,7 +33,7 @@
         subject: CN=subject3
       action: member
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: User test certmapdata members present again
     ipauser:
@@ -48,7 +48,7 @@
         subject: CN=subject3
       action: member
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: User test certmapdata members absent
     ipauser:
@@ -64,7 +64,7 @@
       action: member
       state: absent
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: User test certmapdata members absent again
     ipauser:
@@ -80,7 +80,7 @@
       action: member
       state: absent
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: User test absent
     ipauser:
@@ -88,4 +88,4 @@
       name: test
       state: absent
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed

--- a/tests/user/certmapdata/test_users_certmapdata.yml
+++ b/tests/user/certmapdata/test_users_certmapdata.yml
@@ -30,7 +30,7 @@
         first: test
         last: test
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: User test certmapdata members present
     ipauser:
@@ -43,7 +43,7 @@
         - certificate: "{{ lookup('file', 'cert3.b64', rstrip=False) }}"
       action: member
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: User test certmapdata members present again
     ipauser:
@@ -56,7 +56,7 @@
         - certificate: "{{ lookup('file', 'cert3.b64', rstrip=False) }}"
       action: member
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: User test certmapdata members absent
     ipauser:
@@ -70,7 +70,7 @@
       action: member
       state: absent
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: User test certmapdata members absent again
     ipauser:
@@ -84,7 +84,7 @@
       action: member
       state: absent
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: User test certmapdata members present
     ipauser:
@@ -100,7 +100,7 @@
           subject: CN=subject3
       action: member
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: User test certmapdata members present again
     ipauser:
@@ -116,7 +116,7 @@
           subject: CN=subject3
       action: member
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: User test certmapdata members absent
     ipauser:
@@ -133,7 +133,7 @@
       action: member
       state: absent
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: User test certmapdata members absent again
     ipauser:
@@ -150,7 +150,7 @@
       action: member
       state: absent
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: User test absent
     ipauser:
@@ -159,7 +159,7 @@
       - name: test
       state: absent
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Remove certificate files.
     shell:

--- a/tests/user/test_user.yml
+++ b/tests/user/test_user.yml
@@ -18,7 +18,7 @@
       first: Manager
       last: One
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: User manager2 present
     ipauser:
@@ -27,7 +27,7 @@
       first: Manager
       last: One
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: User manager3 present
     ipauser:
@@ -36,7 +36,7 @@
       first: Manager
       last: One
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: User pinky present
     ipauser:
@@ -79,7 +79,7 @@
       #issuer: PinkyIssuer
       #subject: PinkySubject
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: User pinky present with changed settings
     ipauser:
@@ -93,7 +93,7 @@
       - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCqmVDpEX5gnSjKuv97AyzOhaUMMKz8ahOA3GY77tVC4o68KNgMCmDSEG1/kOIaElngNLaCha3p/2iAcU9Bi1tLKUlm2bbO5NHNwHfRxY/3cJtq+/7D1vxJzqThYwI4F9vr1WxyY2+mMTv3pXbfAJoR8Mu06XaEY5PDetlDKjHLuNWF+/O7ZU8PsULTa1dJZFrtXeFpmUoLoGxQBvlrlcPI1zDciCSU24t27Zan5Py2l5QchyI7yhCyMM77KDtj5+AFVpmkb9+zq50rYJAyFVeyUvwjzErvQrKJzYpA0NyBp7vskWbt36M16/M/LxEK7HA6mkcakO3ESWx5MT1LAjvdlnxbWG3787MxweHXuB8CZU+9bZPFBaJ+VQtOfJ7I8eH0S16moPC4ak8FlcFvOH8ERDPWLFDqfy09yaZ7bVIF0//5ZI7Nf3YDe3S7GrBX5ieYuECyP6UNkTx9BRsAQeVvXEc6otzB7iCSnYBMGUGzCqeigoAWaVQUONsSR3Uatks= pinky@ipaserver.el81.local
       - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDc8MIjaSrxLYHvu+hduoF4m6NUFSlXZWzYbd3BK4L47/U4eiXoOS6dcfuZJDjmLfOipc7XVp7NADwAgA1yBOAjbeVpXr2tC8w8saZibl75WBOEjDfNroiOh/f/ojrwwHg05QTVSZHs27sU1HBPyCQM/FHVM6EnRfmyiBkEBA/3ca0PJ9UJhWb2XisCaz6y6QcTh4gQnvHzgmEmK31GwiKnmBSEQuj8P5NGCO8RlN3cq3zpRpMDEoBRCjQYicllf/5P43r5OGvS1LhTiAMfyqE37URezNQa7aozBpH1GhIwAmjAtm84jXQjxUgZPYC0aSLuADYErScOP4792r6koH9t/DM5/M+jG2c4PNWynDczUw6Eaxl5E3hU0Ee9UN0Oee7iBnVenS/QMeZNyo5lMA/HXT5lrYiJGTYM0shRjGXXYBbJZhWerguSWDAdUd1gvuGP1nb7/+/Cvb46+HX7zYouS5Ojo0yPzMZ07X142jnKAfx9LnKdMUCwBJzbtoJ91Zc= pinky@ipaserver.el81.local
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: User pinky add manager manager1
     ipauser:
@@ -102,7 +102,7 @@
       manager: manager1
       action: member
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: User pinky add manager manager1 again
     ipauser:
@@ -111,7 +111,7 @@
       manager: manager1
       action: member
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: User pinky add manager manager2, manager3
     ipauser:
@@ -120,7 +120,7 @@
       manager: manager2,manager3
       action: member
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: User pinky add manager manager2, manager3 again
     ipauser:
@@ -129,7 +129,7 @@
       manager: manager2,manager3
       action: member
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: User pinky remove manager manager1
     ipauser:
@@ -139,7 +139,7 @@
       action: member
       state: absent
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: User pinky remove manager manager1 again
     ipauser:
@@ -149,7 +149,7 @@
       action: member
       state: absent
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: User pinky add principal pa
     ipauser:
@@ -158,7 +158,7 @@
       principal: pa
       action: member
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: User pinky add principal pa again
     ipauser:
@@ -167,7 +167,7 @@
       principal: pa
       action: member
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: User pinky add principal pa1
     ipauser:
@@ -176,7 +176,7 @@
       principal: pa1
       action: member
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: User pinky remove principal pa1
     ipauser:
@@ -186,7 +186,7 @@
       action: member
       state: absent
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: User pinky remove principal pa1 again
     ipauser:
@@ -196,7 +196,7 @@
       action: member
       state: absent
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: User pinky remove principal pa
     ipauser:
@@ -206,7 +206,7 @@
       action: member
       state: absent
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: User pinky remove principal non-existing pa2
     ipauser:
@@ -216,7 +216,7 @@
       action: member
       state: absent
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: User pinky absent and preserved
     ipauser:
@@ -225,7 +225,7 @@
       preserve: yes
       state: absent
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: User pinky undeleted (preserved before)
     ipauser:
@@ -233,7 +233,7 @@
       name: pinky
       state: undeleted
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Users pinky disabled
     ipauser:
@@ -241,7 +241,7 @@
       name: pinky
       state: disabled
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: User pinky enabled
     ipauser:
@@ -249,7 +249,7 @@
       name: pinky
       state: enabled
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Remove test users
     ipauser:

--- a/tests/user/test_user_random.yml
+++ b/tests/user/test_user_random.yml
@@ -22,7 +22,8 @@
       update_password: on_create
     register: ipauser
     failed_when: not ipauser.changed or
-                 ipauser.user.randompassword is not defined
+                 ipauser.user.randompassword is not defined or
+                 ipauser.failed
 
   - name: Print generated random password
     debug:
@@ -35,7 +36,7 @@
       - user1
       state: absent
 
-  - name: Users user1 and user1 present with random password
+  - name: Users user1 and user2 present with random password
     ipauser:
       ipaadmin_password: SomeADMINpassword
       users:
@@ -51,7 +52,8 @@
     register: ipauser
     failed_when: not ipauser.changed or
                  ipauser.user.user1.randompassword is not defined or
-                 ipauser.user.user2.randompassword is not defined
+                 ipauser.user.user2.randompassword is not defined or
+                 ipauser.failed
 
   - name: Print generated random password for user1
     debug:

--- a/tests/user/test_users.yml
+++ b/tests/user/test_users.yml
@@ -46,7 +46,7 @@
         first: user10
         last: Last
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Users user1..10 present
     ipauser:
@@ -83,8 +83,11 @@
         first: user10
         last: Last
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
+  # failed_when: not result.failed has been added as this test needs to
+  # fail because two users with the same name should be added in the same
+  # task.
   - name: Duplicate names in users failure test
     ipauser:
       ipaadmin_password: SomeADMINpassword
@@ -102,7 +105,7 @@
         first: user3
         last: Last
     register: result
-    failed_when: result.changed or "is used more than once" not in result.msg
+    failed_when: result.changed or not result.failed or "is used more than once" not in result.msg
 
   - name: Remove test users
     ipauser:
@@ -130,7 +133,7 @@
         first: Manager3
         last: One3
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: User pinky present
     ipauser:
@@ -173,7 +176,7 @@
       #issuer: PinkyIssuer
       #subject: PinkySubject
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Same user pinky present again
     ipauser:
@@ -216,7 +219,7 @@
       #issuer: PinkyIssuer
       #subject: PinkySubject
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: User pinky present with changed settings
     ipauser:
@@ -230,7 +233,7 @@
       - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCqmVDpEX5gnSjKuv97AyzOhaUMMKz8ahOA3GY77tVC4o68KNgMCmDSEG1/kOIaElngNLaCha3p/2iAcU9Bi1tLKUlm2bbO5NHNwHfRxY/3cJtq+/7D1vxJzqThYwI4F9vr1WxyY2+mMTv3pXbfAJoR8Mu06XaEY5PDetlDKjHLuNWF+/O7ZU8PsULTa1dJZFrtXeFpmUoLoGxQBvlrlcPI1zDciCSU24t27Zan5Py2l5QchyI7yhCyMM77KDtj5+AFVpmkb9+zq50rYJAyFVeyUvwjzErvQrKJzYpA0NyBp7vskWbt36M16/M/LxEK7HA6mkcakO3ESWx5MT1LAjvdlnxbWG3787MxweHXuB8CZU+9bZPFBaJ+VQtOfJ7I8eH0S16moPC4ak8FlcFvOH8ERDPWLFDqfy09yaZ7bVIF0//5ZI7Nf3YDe3S7GrBX5ieYuECyP6UNkTx9BRsAQeVvXEc6otzB7iCSnYBMGUGzCqeigoAWaVQUONsSR3Uatks= pinky@ipaserver.el81.local
       - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDc8MIjaSrxLYHvu+hduoF4m6NUFSlXZWzYbd3BK4L47/U4eiXoOS6dcfuZJDjmLfOipc7XVp7NADwAgA1yBOAjbeVpXr2tC8w8saZibl75WBOEjDfNroiOh/f/ojrwwHg05QTVSZHs27sU1HBPyCQM/FHVM6EnRfmyiBkEBA/3ca0PJ9UJhWb2XisCaz6y6QcTh4gQnvHzgmEmK31GwiKnmBSEQuj8P5NGCO8RlN3cq3zpRpMDEoBRCjQYicllf/5P43r5OGvS1LhTiAMfyqE37URezNQa7aozBpH1GhIwAmjAtm84jXQjxUgZPYC0aSLuADYErScOP4792r6koH9t/DM5/M+jG2c4PNWynDczUw6Eaxl5E3hU0Ee9UN0Oee7iBnVenS/QMeZNyo5lMA/HXT5lrYiJGTYM0shRjGXXYBbJZhWerguSWDAdUd1gvuGP1nb7/+/Cvb46+HX7zYouS5Ojo0yPzMZ07X142jnKAfx9LnKdMUCwBJzbtoJ91Zc= pinky@ipaserver.el81.local
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: User pinky add manager manager1
     ipauser:
@@ -239,7 +242,7 @@
       manager: manager1
       action: member
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: User pinky add manager manager1 again
     ipauser:
@@ -248,7 +251,7 @@
       manager: manager1
       action: member
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: User pinky add manager manager2, manager3
     ipauser:
@@ -257,7 +260,7 @@
       manager: manager2,manager3
       action: member
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: User pinky add manager manager2, manager3 again
     ipauser:
@@ -266,7 +269,7 @@
       manager: manager2,manager3
       action: member
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: User pinky remove manager manager1
     ipauser:
@@ -276,7 +279,7 @@
       action: member
       state: absent
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: User pinky remove manager manager1 again
     ipauser:
@@ -286,7 +289,7 @@
       action: member
       state: absent
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: User pinky add principal pa
     ipauser:
@@ -295,7 +298,7 @@
       principal: pa
       action: member
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: User pinky add principal pa again
     ipauser:
@@ -304,7 +307,7 @@
       principal: pa
       action: member
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: User pinky add principal pa1
     ipauser:
@@ -313,7 +316,7 @@
       principal: pa1
       action: member
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: User pinky remove principal pa1
     ipauser:
@@ -323,7 +326,7 @@
       action: member
       state: absent
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: User pinky remove principal pa1 again
     ipauser:
@@ -333,7 +336,7 @@
       action: member
       state: absent
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: User pinky remove principal pa
     ipauser:
@@ -343,7 +346,7 @@
       action: member
       state: absent
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: User pinky remove principal non-existing pa2
     ipauser:
@@ -353,7 +356,7 @@
       action: member
       state: absent
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: User pinky absent and preserved
     ipauser:
@@ -362,7 +365,7 @@
       preserve: yes
       state: absent
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: User pinky undeleted (preserved before)
     ipauser:
@@ -370,7 +373,7 @@
       name: pinky
       state: undeleted
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Users pinky disabled
     ipauser:
@@ -378,7 +381,7 @@
       name: pinky
       state: disabled
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: User pinky enabled
     ipauser:
@@ -386,7 +389,7 @@
       name: pinky
       state: enabled
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Remove test users
     ipauser:

--- a/tests/user/test_users_invalid_cert.yml
+++ b/tests/user/test_users_invalid_cert.yml
@@ -39,7 +39,7 @@
         - "{{ lookup('file', 'cert1.b64', rstrip=False) }}"
       action: member
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: User test cert members absent
     ipauser:
@@ -52,7 +52,7 @@
       state: absent
       action: member
     #register: result
-    #failed_when: not result.changed
+    #failed_when: not result.changed or result.failed
 
   - name: Remove certificate files.
     shell:

--- a/tests/vault/tasks_vault_members.yml
+++ b/tests/vault/tasks_vault_members.yml
@@ -9,7 +9,7 @@
       name: "{{vault.name}}"
       vault_type: "{{vault.vault_type}}"
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
     when: vault.vault_type == 'standard'
 
   - name: Ensure vault is present
@@ -19,7 +19,7 @@
       vault_password: SomeVAULTpassword
       vault_type: "{{vault.vault_type}}"
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
     when: vault.vault_type == 'symmetric'
 
   - name: Ensure vault is present
@@ -29,7 +29,7 @@
       vault_type: "{{ vault.vault_type }}"
       public_key: "{{lookup('file', 'A_private.b64')}}"
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
     when: vault.vault_type == 'asymmetric'
 
   - name: Ensure vault member user is present.
@@ -40,7 +40,7 @@
       users:
       - user02
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure vault member user is present, again.
     ipavault:
@@ -50,7 +50,7 @@
       users:
       - user02
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Ensure more vault member users are present.
     ipavault:
@@ -61,7 +61,7 @@
       - admin
       - user02
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure vault member user is still present.
     ipavault:
@@ -71,7 +71,7 @@
       users:
       - user02
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Ensure vault users are absent.
     ipavault:
@@ -83,7 +83,7 @@
       - user02
       state: absent
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure vault users are absent, again.
     ipavault:
@@ -95,7 +95,7 @@
       - user02
       state: absent
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Ensure vault user is absent, once more.
     ipavault:
@@ -106,7 +106,7 @@
       - admin
       state: absent
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Ensure vault member group is present.
     ipavault:
@@ -115,7 +115,7 @@
       action: member
       groups: vaultgroup
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure vault member group is present, again.
     ipavault:
@@ -124,7 +124,7 @@
       action: member
       groups: vaultgroup
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Ensure vault member group is absent.
     ipavault:
@@ -134,7 +134,7 @@
       groups: vaultgroup
       state: absent
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure vault member group is absent, again.
     ipavault:
@@ -144,7 +144,7 @@
       groups: vaultgroup
       state: absent
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Ensure vault member service is present.
     ipavault:
@@ -153,7 +153,7 @@
       action: member
       services: "HTTP/{{ ansible_facts['fqdn'] }}"
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure vault member service is present, again.
     ipavault:
@@ -162,7 +162,7 @@
       action: member
       services: "HTTP/{{ ansible_facts['fqdn'] }}"
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Ensure vault member service is absent.
     ipavault:
@@ -172,7 +172,7 @@
       services: "HTTP/{{ ansible_facts['fqdn'] }}"
       state: absent
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure vault member service is absent, again.
     ipavault:
@@ -182,7 +182,7 @@
       services: "HTTP/{{ ansible_facts['fqdn'] }}"
       state: absent
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Ensure user03 is an owner of vault.
     ipavault:
@@ -191,7 +191,7 @@
       owners: user03
       action: member
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure user03 is an owner of vault, again.
     ipavault:
@@ -200,7 +200,7 @@
       owners: user03
       action: member
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Ensure user03 is not owner of vault.
     ipavault:
@@ -210,7 +210,7 @@
       state: absent
       action: member
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure user03 is not owner of vault, again.
     ipavault:
@@ -220,7 +220,7 @@
       state: absent
       action: member
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Ensure vaultgroup is an ownergroup of vault.
     ipavault:
@@ -229,7 +229,7 @@
       ownergroups: vaultgroup
       action: member
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure vaultgroup is an ownergroup of vault, again.
     ipavault:
@@ -238,7 +238,7 @@
       ownergroups: vaultgroup
       action: member
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Ensure vaultgroup is not ownergroup of vault.
     ipavault:
@@ -248,7 +248,7 @@
       state: absent
       action: member
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure vaultgroup is not ownergroup of vault, again.
     ipavault:
@@ -258,7 +258,7 @@
       state: absent
       action: member
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Ensure service is an owner of vault.
     ipavault:
@@ -267,7 +267,7 @@
       ownerservices: "HTTP/{{ ansible_facts['fqdn'] }}"
       action: member
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure service is an owner of vault, again.
     ipavault:
@@ -276,7 +276,7 @@
       ownerservices: "HTTP/{{ ansible_facts['fqdn'] }}"
       action: member
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Ensure service is not owner of vault.
     ipavault:
@@ -286,7 +286,7 @@
       state: absent
       action: member
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure service is not owner of vault, again.
     ipavault:
@@ -296,7 +296,7 @@
       state: absent
       action: member
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Ensure {{vault.vault_type}} vault is absent
     ipavault:
@@ -304,7 +304,7 @@
       name: "{{vault.name}}"
       state: absent
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure {{vault.vault_type}} vault is absent, again
     ipavault:
@@ -312,7 +312,7 @@
       name: "{{vault.name}}"
       state: absent
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Cleanup testing environment.
     import_tasks: env_cleanup.yml

--- a/tests/vault/test_vault_asymmetric.yml
+++ b/tests/vault/test_vault_asymmetric.yml
@@ -126,7 +126,7 @@
       name: asymvault
       vault_data: SomeADMINpassword
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Retrieve data from asymmetric vault.
     ipavault:
@@ -135,7 +135,7 @@
       private_key: "{{ lookup('file', 'B_private.b64') }}"
       state: retrieved
     register: result
-    failed_when: result.vault.data != 'SomeADMINpassword' or result.changed
+    failed_when: result.vault.data != 'SomeADMINpassword' or result.changed or result.failed
 
   - name: Change data in asymmetric vault
     ipavault:
@@ -143,7 +143,7 @@
       name: asymvault
       data: Hello World.
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Retrieve changed data from asymmetric vault.
     ipavault:
@@ -152,7 +152,7 @@
       private_key: "{{ lookup('file', 'B_private.b64') }}"
       state: retrieved
     register: result
-    failed_when: result.vault.data != 'Hello World.' or result.changed
+    failed_when: result.vault.data != 'Hello World.' or result.changed or result.failed
 
   - name: Retrieve data from asymmetric vault into file {{ ansible_facts['env'].HOME }}/data.txt.
     ipavault:
@@ -176,7 +176,7 @@
       name: asymvault
       data: The world of π is half rounded.
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Retrieve data from asymmetric vault.
     ipavault:
@@ -185,7 +185,7 @@
       private_key: "{{ lookup('file', 'B_private.b64') }}"
       state: retrieved
     register: result
-    failed_when: result.vault.data != 'The world of π is half rounded.' or result.changed
+    failed_when: result.vault.data != 'The world of π is half rounded.' or result.changed or result.failed
 
   - name: Archive data in asymmetric vault, from file.
     ipavault:
@@ -194,7 +194,7 @@
       vault_type: asymmetric
       in: "{{ ansible_facts['env'].HOME }}/in.txt"
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Retrieve data from asymmetric vault.
     ipavault:
@@ -203,7 +203,7 @@
       private_key: "{{ lookup('file', 'B_private.b64') }}"
       state: retrieved
     register: result
-    failed_when: result.vault.data != 'Another World.' or result.changed
+    failed_when: result.vault.data != 'Another World.' or result.changed or result.failed
 
   - name: Archive data with single character to asymmetric vault
     ipavault:
@@ -211,7 +211,7 @@
       name: asymvault
       data: c
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Retrieve data from asymmetric vault.
     ipavault:
@@ -220,7 +220,7 @@
       private_key: "{{ lookup('file', 'B_private.b64') }}"
       state: retrieved
     register: result
-    failed_when: result.vault.data != 'c' or result.changed
+    failed_when: result.vault.data != 'c' or result.changed or result.failed
 
   - name: Ensure asymmetric vault is absent
     ipavault:
@@ -228,7 +228,7 @@
       name: asymvault
       state: absent
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure asymmetric vault is absent, again
     ipavault:
@@ -236,7 +236,7 @@
       name: asymvault
       state: absent
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Ensure asymmetric vault is present, with public key from file.
     ipavault:
@@ -245,7 +245,7 @@
       public_key_file: "{{ ansible_facts['env'].HOME }}/B_public.pem"
       vault_type: asymmetric
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure asymmetric vault is present, with password from file, again.
     ipavault:
@@ -254,7 +254,7 @@
       public_key_file: "{{ ansible_facts['env'].HOME }}/B_public.pem"
       vault_type: asymmetric
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Archive data to asymmetric vault
     ipavault:
@@ -262,7 +262,7 @@
       name: asymvault
       data: Hello World.
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Retrieve data from asymmetric vault.
     ipavault:
@@ -271,7 +271,7 @@
       private_key: "{{ lookup('file', 'B_private.b64') }}"
       state: retrieved
     register: result
-    failed_when: result.vault.data != 'Hello World.' or result.changed
+    failed_when: result.vault.data != 'Hello World.' or result.changed or result.failed
 
   - name: Retrieve data from asymmetric vault, with password file.
     ipavault:
@@ -280,7 +280,7 @@
       private_key_file: "{{ ansible_facts['env'].HOME }}/B_private.pem"
       state: retrieved
     register: result
-    failed_when: result.vault.data != 'Hello World.' or result.changed
+    failed_when: result.vault.data != 'Hello World.' or result.changed or result.failed
 
   - name: Ensure asymmetric vault is absent
     ipavault:
@@ -288,7 +288,7 @@
       name: asymvault
       state: absent
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure asymmetric vault is absent, again
     ipavault:
@@ -296,7 +296,7 @@
       name: asymvault
       state: absent
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Cleanup testing environment.
     import_tasks: env_cleanup.yml

--- a/tests/vault/test_vault_standard.yml
+++ b/tests/vault/test_vault_standard.yml
@@ -15,7 +15,7 @@
       name: stdvault
       vault_type: standard
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure standard vault is present, again
     ipavault:
@@ -23,7 +23,7 @@
       name: stdvault
       vault_type: standard
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Archive data to standard vault, matching `no_log` field.
     ipavault:
@@ -31,7 +31,7 @@
       name: stdvault
       vault_data: SomeADMINpassword
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Retrieve data from standard vault.
     ipavault:
@@ -39,7 +39,7 @@
       name: stdvault
       state: retrieved
     register: result
-    failed_when: result.vault.data != 'SomeADMINpassword' or result.changed
+    failed_when: result.vault.data != 'SomeADMINpassword' or result.changed or result.failed
 
   - name: Archive data to standard vault
     ipavault:
@@ -47,7 +47,7 @@
       name: stdvault
       vault_data: Hello World.
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Retrieve data from standard vault.
     ipavault:
@@ -55,7 +55,7 @@
       name: stdvault
       state: retrieved
     register: result
-    failed_when: result.vault.data != 'Hello World.' or result.changed
+    failed_when: result.vault.data != 'Hello World.' or result.changed or result.failed
 
   - name: Retrieve data from standard vault into file {{ ansible_facts['env'].HOME }}/data.txt.
     ipavault:
@@ -78,7 +78,7 @@
       name: stdvault
       vault_data: The world of π is half rounded.
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Retrieve data from standard vault.
     ipavault:
@@ -86,7 +86,7 @@
       name: stdvault
       state: retrieved
     register: result
-    failed_when: result.vault.data != 'The world of π is half rounded.' or result.changed
+    failed_when: result.vault.data != 'The world of π is half rounded.' or result.changed or result.failed
 
   - name: Archive data in standard vault, from file.
     ipavault:
@@ -95,7 +95,7 @@
       vault_type: standard
       in: "{{ ansible_facts['env'].HOME }}/in.txt"
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Retrieve data from standard vault.
     ipavault:
@@ -103,7 +103,7 @@
       name: stdvault
       state: retrieved
     register: result
-    failed_when: result.vault.data != 'Another World.' or result.changed
+    failed_when: result.vault.data != 'Another World.' or result.changed or result.failed
 
   - name: Archive data with single character to standard vault
     ipavault:
@@ -111,7 +111,7 @@
       name: stdvault
       vault_data: c
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Retrieve data from standard vault.
     ipavault:
@@ -119,7 +119,7 @@
       name: stdvault
       state: retrieved
     register: result
-    failed_when: result.vault.data != 'c' or result.changed
+    failed_when: result.vault.data != 'c' or result.changed or result.failed
 
   - name: Ensure standard vault is absent
     ipavault:
@@ -127,7 +127,7 @@
       name: stdvault
       state: absent
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure standard vault is absent, again
     ipavault:
@@ -135,7 +135,7 @@
       name: stdvault
       state: absent
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Cleanup testing environment.
     import_tasks: env_cleanup.yml

--- a/tests/vault/test_vault_symmetric.yml
+++ b/tests/vault/test_vault_symmetric.yml
@@ -16,7 +16,7 @@
       vault_type: symmetric
       password: SomeVAULTpassword
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Ensure symmetric vault is present, again
     ipavault:
@@ -25,7 +25,7 @@
       vault_type: symmetric
       password: SomeVAULTpassword
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or result.failed
 
   - name: Archive data to symmetric vault, matching `no_log` field.
     ipavault:
@@ -34,7 +34,7 @@
       vault_data: SomeADMINpassword
       password: SomeVAULTpassword
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Retrieve data from symmetric vault.
     ipavault:
@@ -52,7 +52,7 @@
       vault_data: Hello World.
       password: SomeVAULTpassword
     register: result
-    failed_when: not result.changed
+    failed_when: not result.changed or result.failed
 
   - name: Retrieve data from symmetric vault.
     ipavault:


### PR DESCRIPTION
In some module tests failed_when usage is missing for essential tasks.
In some others repeated tasks for idempotency testing  is missing.
In lots of tests result.failed is not used with failed_when.