### PR TITLE
user: Fix no modifications to be performed error

### DIFF
--- a/plugins/modules/ipauser.py
+++ b/plugins/modules/ipauser.py
@@ -1115,8 +1115,13 @@ def main():
                         # For all settings is args, check if there are
                         # different settings in the find result.
                         # If yes: modify
-                        if not compare_args_ipa(ansible_module, args,
-                                                res_find):
+                        # The nomembers parameter is added to args for the
+                        # api command. But no_members is never part of
+                        # res_find from user-show, therefore this parameter
+                        # needs to be ignored in compare_args_ipa.
+                        if not compare_args_ipa(
+                                ansible_module, args, res_find,
+                                ignore=["no_members"]):
                             commands.append([name, "user_mod", args])
 
                     else:


### PR DESCRIPTION
The nomembers parameter is added to args for the api command. But
no_members is never part of res_find from user-show, therefore this
resulted in an error in the idempotency test where a user is ensured
again with the same settings.

As a workaround no_members is copied from args to res_find for the
update case to make sure that compare_args_ipa is working properly.