### PR TITLE
dnszone: Fix no modifications to be performed for serial

### DIFF
--- a/plugins/modules/ipadnszone.py
+++ b/plugins/modules/ipadnszone.py
@@ -492,7 +492,13 @@ class DNSZoneModule(FreeIPABaseModule):
             # See:
             #   - https://pagure.io/freeipa/issue/8227
             #   - https://pagure.io/freeipa/issue/8489
-            if set_serial:
+            # Only set SOA Serial if it is not set already.
+            if (set_serial and
+                (zone is None
+                 or "idnssoaserial" not in zone
+                 or zone["idnssoaserial"] is None
+                 or zone["idnssoaserial"][0] != str(self.ipa_params.serial)
+                 )):
                 args = {
                     "idnssoaserial": self.ipa_params.serial,
                 }


### PR DESCRIPTION
A dnszone_mod call is always made to set the serial for a zone even if
this serial is set already.

A check is added to make sure that the serial is only set with
dnszone_mod if there is no serial set or if the serial is different.