### PR TITLE
contributing: Testing modules with podman containers.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,6 @@
 # ignore virtual environments
 /.tox/
 /.venv/
+/.ansible-freeipa-tests/
 
 tests/logs/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -90,6 +90,9 @@ enabled.
 The tests run automatically on every pull request, using Fedora, CentOS 7,
 and CentOS 8 environments.
 
+While developing modules, you can run the tests locally, with [podman].
+See [Testing ansible-freeipa modules with podman].
+
 See the document [Running the tests] and also the section `Preparing the
 development environment`, to prepare your environment.
 
@@ -119,3 +122,5 @@ examples of commonly performed tasks.
 [pre-commit]: https://pre-commit.com
 [Running the tests]: tests/README.md
 [tests]: tests/
+[podman]: https://podman.io
+[Testing ansible-freeipa modules with podman]: tests/README-podman.md

--- a/tests/README-podman.md
+++ b/tests/README-podman.md
@@ -1,0 +1,100 @@
+# Testing ansible-freeipa modules with podman
+
+> This document describe the rationale, design and usage of `utils/ansible-freeipa-test.sh`.<br>
+> For the impatient, if you have [podman] installed, run `utils/ansible-freeipa-test.sh -m config` from the project root directory.
+
+## Introduction
+
+`ansible-freeipa` relies on two types of tests to verify the behavior is consistent with the modules design. There are pytest tests and Ansible playbook tests. All modules must provide a series of tasks in one or more Ansible playbook to test module behavior and idempotence verification, to be considered for inclusion.
+
+Each pull request triggers the execution of all registered tests, for all modules, given the environment is available, so it is possible to verify that the changes do not break existing behavior. The tests also run on different versions of FreeIPA, namely, the available versions for CentOS 7, CentOS 8, and the latest Fedora version.
+
+The problem is that, when executed in parallel, it takes about an hour to execute all tests in the current CI environment (as of May 2020), and it is not practical to wait so long to test minor modifications.
+
+An alternative to running tests in the CI is to have a FreeIPA server installation in a virtual machine (e.g. with libvirt), as use the development workstation as an Ansible controller to that server, to verify the module behavior. It works very well, as is a recommended setup for testing, as it allows for different Linux distributions, different FreeIPA versions, etc.
+
+Although the recommended way of testing `ansible-freeipa` is with a virtual machine, it also has some drawbacks, as requiring a virtual machine to be set, and having the available resources to run the virtualization along with the development environment.
+
+Using containers is a lightweight version of the setup with a virtual machine, and, although it shows some limitations, it is a fast and easier to configure way of testing `ansible-freeipa` modules.
+
+> NOTE: Tests with podman have only been tested under Fedora, but we'd like to hear about the experience in other environments.
+
+## Prerequisites
+
+The current size of the testing container is 1.4GB. FreeIPA requires about 2GB of free RAM.
+
+If you have [podman] installed and working on your environment, and the available hardware requirements, `ansible-freeipa-test.sh` should work. Please, [open an issue] if it doesn't (don't forget to detail your environment and issues).
+
+You will also need Python available, and in your `PATH`, and network connection allowing you to download data from https://quay.io.
+
+## Using `ansible-freeipa-test.sh`
+
+`ansible-freeipa-test.sh` is used to run playbook tests for `ansible-freeipa`. The tests are executed using a podman container as the FreeIPA server, and the almost all software infrastructure is installed in a Python virtual environment, using `pip`. This way, the environment is somewhat isolated from the development machine.
+
+There are two options to prepare your testing environment, it is suggested that you take the easier path, which is described here. The hardest path is to create the containers and virtual environment yourself, where you have more flexibility, but are on your own.
+
+There are a few options for `ansible-freeipa-test.sh`, here is the output of its usage message (displayed when using `-h`):
+
+```
+usage: ansbile-freeipa-test.sh [-v...] [-h] [-p CONTAINER] [-e VENV]
+			                   [-m MODULE] [TEST...]
+
+Run ansible-freeipa tests in a podman container, using a virtual environment.
+
+position arguments:
+  TEST                A list of playbook tests to be executed.
+                      Either a TEST or a MODULE must be provided.
+
+optional arguments:
+  -h                  display this help message and exit.
+  -v                  verbose mode (You may use -vvv or -vvvvv for
+                      increased information.)
+  -p CONTAINER        use the container with name/id CONTAINER.
+                      default: dev-test-master
+  -C                  If container did not exist, do not stop and
+                      remove created container at exit.
+  -e VENV             use the virtual environment VENV
+                      default: asible-freeipa-tests
+  -m MODULE           Add all tests for the MODULE (e.g.: -m config).
+  -x                  Stop on first test failure.
+```
+
+You can use it to run single specific tests, or all tests for a module (all `test_*` found, recursively, in `tests/<MODULE>`). By issuing `utils/ansible-freeipa-test.sh tests/group/test_group.yml`, the selected playook will be executed, but if you use `utils/ansible-freeipa-test.sh -m dnszone`, all tests in `tests/dnszone` will be executed (`test_dnszone.yml`, `test_dnszone_mod.yml` and `test_dnszone_name_from_ip.yml`).
+
+When you provide a set of tests (or modules) for `ansible-freeipa-test.sh`, it will create a container within [podman], based on `ansible-freeipa` CI's Fedora image. It will also create a Python virtual environment, where all the required tools will be installed. Neither your system installation, nor your user configuration is modified to install the used tools.
+
+After the selected tests are executed, the container is stopped and removed (unles `-C` is used), but the image is kept. This prevents downloading the same image again. Your local image will be updated by `ansible-freeipa-test.sh`, if, when executing it, it finds that the upstream CI images has been updated.
+
+Regular `podman` commands can be used to manage the container and images.
+
+## Issues
+
+While testing `ansible-freeipa` modules with [podman] and [Ansible] provides a very good baseline to check for development status of the module, some issues are still present. This list is not exaustive, but contain some common behaviors you will encounter when using `ansible-freeipa-test.sh`.
+
+### Ansible warning messages
+
+Currently there are some Ansible warning messages that can be safely ignored and will be fixed in the future.
+
+> ```
+[WARNING]: Unhandled error in Python interpreter discovery for host dev-test-
+master: Expecting value: line 1 column 1 (char 0)```
+
+This message has only been seen when running the Ansible playbooks with podman. It looks like an Ansible limitation, and does not interfere with tests, as far the script has been tested.
+
+>```[WARNING]: Platform linux on host dev-test-master is using the discovered
+Python interpreter at /usr/bin/python, but future installation of another
+Python interpreter could change this. See https://docs.ansible.com/ansible/2.9/
+reference_appendices/interpreter_discovery.html for more information.```
+
+This message is shown on every Ansible execution, and will be removed in a future release of `ansilbe-freeipa`.
+
+### Container is (or is not) removed.
+
+When a test container does not exist, the default behavior is for `ansible-freeipa-test.sh` to create a new container and remove it after executing tests. If a test fails, the container is not removed, and this is on purpose. You may inspect container status with `podman exec -it <container_name> bash`.
+
+If you want the container to be available, even if tests pass, use the `-C` option.
+
+
+[ansible]: https://ansible.com
+[podman]: https://podman.io
+[open an issue]: https://github.com/freeipa/ansible-freeipa/issues/new

--- a/utils/ansible-freeipa-test.sh
+++ b/utils/ansible-freeipa-test.sh
@@ -1,0 +1,181 @@
+#!/bin/sh
+
+trap interrupt_exception SIGINT
+
+WHITE="\033[37;1m"
+YELLOW="\033[33;1m"
+RED="\033[31;1m"
+CYAN="\033[36;1m"
+GREEN="\033[32;1m"
+MAGENTA="\033[35;1m"
+RST="\033[0m"
+
+die() {
+	echo $*
+	exit 1
+}
+
+quiet() {
+	 "$@" >/dev/null 2>&1
+}
+
+interrupt_exception() {
+	die -e "${YELLOW}WARNING: User interrupted test execution.${RST}"
+	exit 1
+}
+
+in_python_virtualenv() {
+	read -r -d "" script <<'EOS'
+import sys;
+base = getattr(sys, "base_prefix", None) or getattr(sys, "real_prefix", None) or sys.prefix
+print('yes' if sys.prefix != base else 'no')
+EOS
+    test "`python -c "${script}"`" == "yes"
+}
+
+usage() {
+	cat << EOF
+usage: ansbile-freeipa-test.sh [-v...] [-h] [-p CONTAINER] [-e VENV]
+                               [-m MODULE] [TEST...]
+
+Run ansible-freeipa tests in a podman container, using a virtual environment.
+
+position arguments:
+  TEST                A list of playbook tests to be executed.
+                      Either a TEST or a MODULE must be provided.
+
+optional arguments:
+  -h                  display this help message and exit.
+  -v                  verbose mode (You may use -vvv or -vvvvv for
+                      increased information.)
+  -p CONTAINER        use the container with name/id CONTAINER.
+                      default: dev-test-master
+  -C                  If container did not exist, do not stop and
+                      remove created container at exit.
+  -e VENV             use the virtual environment VENV
+                      default: asible-freeipa-tests
+  -m MODULE           Add all tests for the MODULE (e.g.: -m config).
+  -x                  Stop on first test failure.
+EOF
+}
+
+TOPDIR="`dirname $0`/.."
+
+TEST_SET=()
+STOP_CONTAINER=1
+CONTINUE_ON_ERROR="no"
+scenario="dev-test-master"
+unset verbose
+unset STOP_VIRTUALENV
+
+while getopts ":e:vhp:Cm:x" opt
+do
+	case "${opt}" in
+		v) verbose=${verbose:--}${opt} ;;
+		h) usage && exit 0;;
+		p) scenario="${OPTARG}" ;;
+		e) TESTENV_DIR="${OPTARG}" ;;
+		C) STOP_CONTAINER=0 ;;
+		m) TEST_SET+=(`find ${TOPDIR}/tests/${OPTARG} -name 'test_*'`) ;;
+		x) unset CONTINUE_ON_ERROR ;;
+		*) break ;;
+	esac
+done
+
+TEST_SET+=(${@:$OPTIND})
+
+[ ${#TEST_SET[@]} -gt 0 ] || die -e "${RED}ERROR: No test defined.${RST}"
+
+inventory=`mktemp /tmp/ansible-freeipa-test-inventory.XXXXXXXX`
+cat << EOF > "${inventory}"
+[ipaserver]
+${scenario}  ansible_connection=podman
+EOF
+
+echo -e "${MAGENTA}INFO: Inventory file: ${inventory}"
+cat << EOF
+[ipaserver]
+${scenario}  ansible_connection=podman
+EOF
+echo -e "${RST}"
+
+# prepare virtual environment
+if ! in_python_virtualenv
+then
+	test_env="${TESTENV_DIR:-.ansible-freeipa-tests}"
+
+	echo -e "${GREEN}Preparing virtual environment: ${test_env}${RST}"
+	[ ! -d "${test_env}" ] || python3 -m venv "${test_env}"
+	if [ -f "${test_env}/bin/activate" ]
+	then
+		echo -e "${CYAN}Starting virtual environment: ${test_env}${RST}"
+		. "${test_env}/bin/activate"
+		STOP_VIRTUALENV="yes"
+	else
+		die "Cannot activate environment."
+	fi
+	echo -e "${WHITE}Installing required tools.${RST}"
+	echo -e "${WHITE}Upgrading:${RST} pip setuptools wheel"
+	pip install --quiet --upgrade pip setuptools wheel
+	echo -e "${WHITE}Installing:${RST} testinfra ansible(2.9)"
+	pip install --quiet "testinfra" "ansible>=2.9,<2.10"
+	echo -e "${WHITE}Installing ansible-freeipa test requirements...${RST}"
+	pip install --quiet -r requirements-tests.txt
+
+fi
+
+# configure Ansible paths to roles and modules.
+ANSIBLE_ROLES_PATH="${TOPDIR}/roles"
+ANSIBLE_LIBRARY="${TOPDIR}/plugins/modules:${TOPDIR}/molecule"
+ANSIBLE_MODULE_UTILS="${TOPDIR}/plugins/module_utils"
+
+# Retrieve and start podman image
+
+echo -e "${WHITE}Checking podman '${scenario}' container.${RST}"
+if ! podman container exists "${scenario}"
+then
+	hostname="ipaserver.test.local"
+
+	echo "Pulling FreeIPA master Fedora latest image..."
+	img_id=`podman pull quay.io/ansible-freeipa/upstream-tests:fedora-latest`
+	echo "Creating '${scenario}' container..."
+	CONFIG="--hostname='${hostname}' --name='${scenario}'"
+	container_id=`podman create ${CONFIG} "${img_id}"`
+else
+	STOP_CONTAINER=0
+fi
+
+podman start "${scenario}"
+
+# run tests
+RESULT=0
+for test in "${TEST_SET[@]}"
+do
+	echo -e "\n${WHITE}Running:${RST} ${test#utils/../}"
+    ansible-playbook ${verbose} -i "${inventory}" "${test}" || RESULT=2
+	if [ -z "${CONTINUE_ON_ERROR}" -a $RESULT -ne 0 ]
+	then
+		die "Stopping on test failure."
+	fi
+done
+
+# cleanup
+
+if [ "${STOP_CONTAINER}" == "1" ]
+then
+	echo "Stopping container..."
+	quiet podman stop "${scenario}"
+	echo "Removing container..."
+	quiet podman rm "${scenario}"
+fi
+
+rm "${inventory}"
+
+if [ ! -z "${STOP_VIRTUALENV}" ]
+then
+	echo "Deactivating virtual environment"
+	deactivate
+fi
+
+# Return 2 if any test has failed.
+exit ${RESULT}


### PR DESCRIPTION
This patch provides a way to run ansible-freeipa test playbooks
with podman containers and software tools installed in a virtual
environment.

The script is designed to run on the developer's workstation,
using the same image as is used in `fedora-latest` test for the
project CI envirnment.