### PR TITLE
Fix usage of ipalib errors.

### DIFF
--- a/plugins/modules/ipaconfig.py
+++ b/plugins/modules/ipaconfig.py
@@ -254,8 +254,7 @@ config:
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.ansible_freeipa_module import temp_kinit, \
     temp_kdestroy, valid_creds, api_connect, api_command_no_name, \
-    compare_args_ipa, module_params_get
-import ipalib.errors
+    compare_args_ipa, module_params_get, ipalib_errors
 
 
 def config_show(module):
@@ -464,7 +463,7 @@ def main():
                         exit_args[k] = (v[0] == "TRUE")
                     else:
                         exit_args[k] = v
-    except ipalib.errors.EmptyModlist:
+    except ipalib_errors.EmptyModlist:
         changed = False
     except Exception as e:
         ansible_module.fail_json(msg="%s %s" % (params, str(e)))

--- a/plugins/modules/ipadnsrecord.py
+++ b/plugins/modules/ipadnsrecord.py
@@ -868,10 +868,10 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils._text import to_text
 from ansible.module_utils.ansible_freeipa_module import temp_kinit, \
     temp_kdestroy, valid_creds, api_connect, api_command, module_params_get, \
-    is_ipv4_addr, is_ipv6_addr
+    is_ipv4_addr, is_ipv6_addr, ipalib_errors
 import dns.reversename
 import dns.resolver
-import ipalib.errors
+
 import six
 
 
@@ -1150,7 +1150,7 @@ def find_dnsrecord(module, dnszone, name):
     try:
         _result = api_command(
             module, "dnsrecord_show", to_text(dnszone), _args)
-    except ipalib.errors.NotFound:
+    except ipalib_errors.NotFound:
         return None
 
     return _result["result"]
@@ -1509,9 +1509,9 @@ def main():
                 else:
                     changed = True
 
-            except ipalib.errors.EmptyModlist:
+            except ipalib_errors.EmptyModlist:
                 continue
-            except ipalib.errors.DuplicateEntry:
+            except ipalib_errors.DuplicateEntry:
                 continue
             except Exception as e:
                 error_message = str(e)

--- a/plugins/modules/ipadnszone.py
+++ b/plugins/modules/ipadnszone.py
@@ -212,9 +212,9 @@ from ansible.module_utils.ansible_freeipa_module import (
     FreeIPABaseModule,
     is_ip_address,
     is_ip_network_address,
-    is_valid_port
+    is_valid_port,
+    ipalib_errors
 )  # noqa: E402
-import ipalib.errors
 import netaddr
 import six
 
@@ -414,7 +414,7 @@ class DNSZoneModule(FreeIPABaseModule):
 
         try:
             response = self.api_command("dnszone_show", args=get_zone_args)
-        except ipalib.errors.NotFound:
+        except ipalib_errors.NotFound:
             zone = None
             is_zone_active = False
         else:

--- a/plugins/modules/ipaservice.py
+++ b/plugins/modules/ipaservice.py
@@ -230,8 +230,7 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.ansible_freeipa_module import temp_kinit, \
     temp_kdestroy, valid_creds, api_connect, api_command, compare_args_ipa, \
     encode_certificate, gen_add_del_lists, module_params_get, to_text, \
-    api_check_param
-import ipalib.errors
+    api_check_param, ipalib_errors
 
 
 def find_service(module, name, netbiosname):
@@ -251,7 +250,7 @@ def find_service(module, name, netbiosname):
 
     try:
         _result = api_command(module, "service_show", to_text(name), _args)
-    except ipalib.errors.NotFound:
+    except ipalib_errors.NotFound:
         return None
 
     if "result" in _result:

--- a/plugins/modules/ipasudocmdgroup.py
+++ b/plugins/modules/ipasudocmdgroup.py
@@ -107,9 +107,7 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils._text import to_text
 from ansible.module_utils.ansible_freeipa_module import temp_kinit, \
     temp_kdestroy, valid_creds, api_connect, api_command, compare_args_ipa, \
-    gen_add_del_lists
-
-import ipalib
+    gen_add_del_lists, ipalib_errors
 
 
 def find_sudocmdgroup(module, name):
@@ -117,7 +115,7 @@ def find_sudocmdgroup(module, name):
 
     try:
         _result = api_command(module, "sudocmdgroup_show", to_text(name), args)
-    except ipalib.errors.NotFound:
+    except ipalib_errors.NotFound:
         return None
     else:
         return _result["result"]

--- a/plugins/modules/ipavault.py
+++ b/plugins/modules/ipavault.py
@@ -320,8 +320,8 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils._text import to_text
 from ansible.module_utils.ansible_freeipa_module import temp_kinit, \
     temp_kdestroy, valid_creds, api_connect, api_command, \
-    gen_add_del_lists, compare_args_ipa, module_params_get, exit_raw_json
-from ipalib.errors import EmptyModlist, NotFound
+    gen_add_del_lists, compare_args_ipa, module_params_get, exit_raw_json, \
+    ipalib_errors
 
 
 def find_vault(module, name, username, service, shared):
@@ -579,7 +579,7 @@ def get_stored_data(module, res_find, args):
     # retrieve vault stored data
     try:
         result = api_command(module, 'vault_retrieve', name, pwdargs)
-    except NotFound:
+    except ipalib_errors.NotFound:
         return None
 
     return result['result'].get('data')
@@ -991,7 +991,7 @@ def main():
                             changed = True
                     else:
                         changed = True
-            except EmptyModlist:
+            except ipalib_errors.EmptyModlist:
                 result = {}
             except Exception as exception:
                 ansible_module.fail_json(


### PR DESCRIPTION
Instead of importing ipalib.errors directly, all modules must import asible_freeipa_module.ipalib_errors.

This PR fixes the behavior on modules config, dnsrecord, dnszone, service, sudocmdgroup, and vault.