### PR TITLE
[WIP] contributing: Testing modules with containers.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,6 @@
 # ignore virtual environments
 /.tox/
 /.venv/
+/.ansible-freeipa-tests/
 
 tests/logs/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -90,6 +90,9 @@ enabled.
 The tests run automatically on every pull request, using Fedora, CentOS 7,
 and CentOS 8 environments.
 
+While developing modules, you can run the tests locally, using containers.
+See [Testing ansible-freeipa modules with containers].
+
 See the document [Running the tests] and also the section `Preparing the
 development environment`, to prepare your environment.
 
@@ -119,3 +122,5 @@ examples of commonly performed tasks.
 [pre-commit]: https://pre-commit.com
 [Running the tests]: tests/README.md
 [tests]: tests/
+[podman]: https://podman.io
+[Testing ansible-freeipa modules with containers]: tests/README-containers.md

--- a/tests/README-containers.md
+++ b/tests/README-containers.md
@@ -1,0 +1,134 @@
+# Testing ansible-freeipa modules with containers
+
+> This document describe the rationale, design and usage of `utils/ansible-freeipa-test.sh`.<br>
+> For the impatient, if you have [podman] installed, run `utils/ansible-freeipa-test.sh -m config` from the project root directory.
+
+
+## Introduction
+
+`ansible-freeipa` relies on two types of tests to verify the behavior is consistent with the modules design. There are pytest tests and Ansible playbook tests. All modules must provide a series of tasks in one or more Ansible playbook to test module behavior and idempotence verification, to be considered for inclusion.
+
+Each pull request triggers the execution of all registered tests, for all modules, given the environment is available, so it is possible to verify that the changes do not break existing behavior. The tests also run on different versions of FreeIPA, available for the latests versions of CentOS 7, CentOS 8, and Fedora.
+
+The problem is that, when executed in parallel, it takes about an hour to execute all tests in the current CI environment (as of May 2020), and it is not practical to wait so long to test minor modifications.
+
+An alternative to running tests in the CI is to have a FreeIPA server installation in a virtual machine (e.g. with libvirt), as use the development workstation as an Ansible controller to that server, to verify the module behavior. It works very well, as is a recommended setup for testing, as it allows for different Linux distributions, different FreeIPA versions, etc.
+
+Although the recommended way of testing `ansible-freeipa` is with a virtual machine, it also has some drawbacks, as requiring a virtual machine to be set, and having the available resources to run the virtualization along with the development environment.
+
+Using containers is a lightweight version of the setup with a virtual machine, and, although it shows some limitations, it is a fast and easier to configure way of testing `ansible-freeipa` modules.
+
+> NOTE 1: Tests with [podman] have only been tested under Fedora, but we'd like to hear about the experience in other environments.
+
+> NOTE 2: Although the tooling is ready in `ansible-freeipa-test.sh` to use [docker], there were some issues with D-Bus during testing, which used by FreeIPA, so, currently, `docker` is not supported.
+
+
+## Prerequisites
+
+The current size of the testing container is 1.4GiB. FreeIPA requires about 2GiB of free RAM. There must also be some room for the development environment, so it is suggested that at least 2GiB of storage and 4GiB or RAM is available, for a master-only setup.
+
+If you have [podman] installed and working on your environment, and the available hardware requirements, `ansible-freeipa-test.sh` should work. Please, [open an issue] if it doesn't (don't forget to detail your environment and issues).
+
+You will also need Python available in your `PATH`, and network connection allowing you to download data from https://quay.io.
+
+
+## Using `ansible-freeipa-test.sh`
+
+`ansible-freeipa-test.sh` is used to run playbook tests for `ansible-freeipa`. The tests are executed using a container as the FreeIPA server, and the almost all software infrastructure is installed in a Python virtual environment, using `pip`. This way, the environment is somewhat isolated from the development machine.
+
+There are two options to prepare your testing environment, it is suggested that you take the easier path, which is described here. The hardest path is to create the containers and virtual environment yourself, where you have more flexibility, but are on your own.
+
+There are a few options for `ansible-freeipa-test.sh`, here is the output of its usage message (displayed when using `-h`):
+
+```
+usage: ansbile-freeipa-test.sh [-v...] [-h] [-p CONTAINER] [-e VENV]
+                               [-m MODULE] [TEST...]
+
+Run ansible-freeipa tests in a container, using a virtual environment.
+
+position arguments:
+  TEST                A list of playbook tests to be executed.
+                      Either a TEST or a MODULE must be provided.
+
+optional arguments:
+  -h                  display this help message and exit.
+  -v                  verbose mode (You may use -vvv or -vvvvv for
+                      increased information.)
+  -i IMAGE            select one of the available ansible-freeipa
+                      public images. Default is 'fedora-latest'.
+                      Selecting message will force container
+                      (re)creation.
+  -p CONTAINER        use the container with name/id CONTAINER.
+                      default: dev-test-master
+  -f                  force creation of container, even if it exists.
+  -C                  do not stop and remove container at exit.
+  -e VENV             use the virtual environment VENV
+                      default: asible-freeipa-tests
+  -m MODULE           add all tests for the MODULE (e.g.: -m config).
+  -x                  stop on first test failure.
+  -M MEMORY           define container memory soft limit, in Gb
+                      (default: 2)
+  -A                  Use latest ansible-core version. (Will force
+                      virtual environment recriation.)
+  -a PRED             Set predicate to select ansible verion. (Will
+                      force virtual environment recriation.)
+                      Default: ">=2.9,<2.10" (Ansible 2.9)
+  -t                  Run tests on all images: CentOS 7, CentOS 8
+                      and Fedora.
+```
+
+You can use it to run single specific tests, or all tests for a module (all `test_*` found, recursively, in `tests/<MODULE>`). By issuing `utils/ansible-freeipa-test.sh tests/group/test_group.yml`, the selected playbook will be executed, but if you use `utils/ansible-freeipa-test.sh -m dnszone`, all tests in `tests/dnszone` will be executed.
+
+When you provide a set of tests (or modules) for `ansible-freeipa-test.sh`, it will create a container, based on one of `ansible-freeipa` CI's images. The default is to use `fedora-latest`, but the image can be selected using the `-i` option. A Python virtual environment will also be created, where all the required tools will be installed. Neither your system installation, nor your user's configuration is modified.
+
+After the selected tests are executed, the container is stopped and removed (unless `-C` is used). The image used to create the container is kept, preventing multiple downloads of the same image, unless the upstream CI image is updated.
+
+A module can be tested against all supported images by using the flag `-t`, which will force recreation of the container, and will destroy the container upon test completion.
+
+Regular commands, of the container engine, can be used to manage containers and images used.
+
+## Available images
+
+| Tag           | Description                          |  IPA  |
+| :------------ | :----------------------------------- | :---: |
+| centos-7      | CentOS Linux release 7.6.1810 (Core) | 4.6.8 |
+| centos-8      | CentOS Linux release 8.3.2011 (Core) | 4.9.2 |
+| fedora-latest | Fedora release 34 (Thirty Four)      | 4.9.6 |
+
+> Note: these were the versions used the last time this document was updated. The actual versions might change as the images are automatically updated by the CI build system.
+
+## Issues
+
+While testing `ansible-freeipa` modules with [podman] and [Ansible] provides a very good baseline to check for development status of the module, some issues are still present. This list is not exaustive, but contain some common behaviors you will encounter when using `ansible-freeipa-test.sh`.
+
+### Kerberos authentication failed
+
+Sometimes Kerberos KDC fails to start, or fail to provide TGT for `admin` authentication. If that happens, you should just re-run the script.
+
+### Ansible warning messages
+
+Currently there are some Ansible warning messages that can be safely ignored and will be fixed in the future.
+
+> ```
+[WARNING]: Unhandled error in Python interpreter discovery for host dev-test-
+master: Expecting value: line 1 column 1 (char 0)```
+
+This message has only been seen when running the Ansible playbooks with podman. It looks like an Ansible limitation, and does not interfere with tests, as far the script has been tested.
+
+>```[WARNING]: Platform linux on host dev-test-master is using the discovered
+Python interpreter at /usr/bin/python, but future installation of another
+Python interpreter could change this. See https://docs.ansible.com/ansible/2.9/
+reference_appendices/interpreter_discovery.html for more information.```
+
+This message is shown on every Ansible execution, and will be removed in a future release of `ansilbe-freeipa`.
+
+### Container is (or is not) removed.
+
+When a test container does not exist, the default behavior is for `ansible-freeipa-test.sh` to create a new container and remove it after executing tests. If a test fails, the container is not removed, and this is on purpose. You may inspect container status with `podman exec -it <container_name> bash`.
+
+If you want the container to be available, even if tests pass, use the `-C` option.
+
+
+[ansible]: https://ansible.com
+[podman]: https://podman.io
+[open an issue]: https://github.com/freeipa/ansible-freeipa/issues/new

--- a/utils/ansible-freeipa-test.sh
+++ b/utils/ansible-freeipa-test.sh
@@ -1,0 +1,378 @@
+#!/bin/bash
+
+trap interrupt_exception SIGINT
+
+WHITE="\033[37;1m"
+YELLOW="\033[33;1m"
+RED="\033[31;1m"
+CYAN="\033[36;1m"
+GREEN="\033[32;1m"
+MAGENTA="\033[35;1m"
+RST="\033[0m"
+
+die() {
+    echo -e "${RED}ERROR: $*\n${RST}"
+    exit 1
+}
+
+quiet() {
+     "$@" >/dev/null 2>&1
+}
+
+warn() {
+    echo -e "${YELLOW}Warning: $*${RST}"
+}
+
+
+interrupt_exception() {
+    trap - SIGINT
+    warn "User interrupted test execution."
+    cleanup
+    exit 1
+}
+
+stop_container() {
+    echo "Stopping container..."
+    quiet ${engine} stop "${scenario}"
+    echo "Removing container..."
+    quiet ${engine} rm "${scenario}"
+}
+
+cleanup() {
+    if [ "${STOP_CONTAINER}" = "1" ]
+    then
+        stop_container
+        rm "${inventory}"
+    fi
+
+    if [ ! -z "${STOP_VIRTUALENV}" ]
+    then
+        echo "Deactivating virtual environment"
+        deactivate
+    fi
+}
+
+in_python_virtualenv() {
+    local script
+    read -r -d "" script <<'EOS'
+import sys;
+base = getattr(sys, "base_prefix", None) or getattr(sys, "real_prefix", None) or sys.prefix
+print('yes' if sys.prefix != base else 'no')
+EOS
+    test "`python -c "${script}"`" = "yes"
+}
+
+run_inline_playbook() {
+    local playbook
+    local err
+    playbook=`mktemp /tmp/ansible-freeipa-test-playbook_ipa.XXXXXXXX`
+    cat - >"${playbook}"
+    ansible-playbook -i "${inventory}" "${playbook}"
+    err=$?
+    rm "${playbook}"
+    return ${err}
+}
+
+brief_usage() {
+    cat << EOF
+
+usage: ansbile-freeipa-test.sh [-v...] [-h] [-e VENV] [-x] [-M MEMORY]
+                               [-i IMAGE] [-p CONTAINER] [-C] [-f]
+                               [-A|-a PRED]
+                               [-m MODULE] [TEST...]
+EOF
+}
+
+usage() {
+    brief_usage
+    cat << EOF
+
+Run ansible-freeipa tests in a container, using a virtual environment.
+
+position arguments:
+  TEST                A list of playbook tests to be executed.
+                      Either a TEST or a MODULE must be provided.
+
+optional arguments:
+  -h                  display this help message and exit.
+  -v                  verbose mode (You may use -vvv or -vvvvv for
+                      increased information.)
+  -i IMAGE            select one of the available ansible-freeipa
+                      public images. Default is 'fedora-latest'.
+                      Selecting message will force container
+                      (re)creation.
+  -p CONTAINER        use the container with name/id CONTAINER.
+                      default: dev-test-master
+  -f                  force creation of container, even if it exists.
+  -C                  do not stop or remove container at exit.
+  -e VENV             use the virtual environment VENV
+                      default: asible-freeipa-tests
+  -m MODULE           add all tests for the MODULE (e.g.: -m config).
+  -x                  stop on first test failure.
+  -M MEMORY           define container memory soft limit, in Gb
+                      (default: 2)
+  -A                  Use latest ansible-core version. (Will force
+                      virtual environment recriation.)
+  -a PRED             Set predicate to select ansible verion. (Will
+                      force virtual environment recriation.)
+                      Default: ">=2.9,<2.10" (Ansible 2.9)
+  -t                  Run tests on all images: CentOS 7, CentOS 8
+                      and Fedora.
+
+EOF
+}
+
+TOPDIR="`dirname $0`/.."
+
+TEST_SET=()
+STOP_CONTAINER=1
+CONTINUE_ON_ERROR="no"
+scenario="dev-test-master"
+IMAGE_TAG="fedora-latest"
+engine="podman"
+MEMORY=2
+unset ANSIBLE_COLLECTIONS
+unset ANSIBLE_VERSION
+unset verbose
+unset STOP_VIRTUALENV
+unset FORCE_CONTAINER
+unset TEST_ON_ALL
+
+while getopts "Aa:Ce:fhi:m:M:p:tvx" opt
+do
+    case "${opt}" in
+        A)
+            ANSIBLE_VERSION='-core'
+            ANSIBLE_COLLECTIONS="containers.podman"
+            ;;
+        a)
+            ANSIBLE_VERSION="${OPTARG}"
+            unset ANSIBLE_COLLECTIONS
+            ;;
+        # c) engine="${OPTARG}" ;;
+        C) STOP_CONTAINER=0 ;;
+        e) TESTENV_DIR="${OPTARG}" ;;
+        f) FORCE_CONTAINER="yes" ;;
+        h) usage && exit 0;;
+        i) IMAGE_TAG=${OPTARG} ; FORCE_CONTAINER="yes" ;;
+        m) TEST_SET+=(`find ${TOPDIR}/tests/${OPTARG} -name 'test_*.yml'`) ;;
+        M) MEMORY=${OPTARG} ;;
+        p) scenario="${OPTARG}" ;;
+        v) verbose=${verbose:--}${opt} ;;
+        x) unset CONTINUE_ON_ERROR ;;
+        t) TEST_ON_ALL="yes" ; FORCE_CONTAINER="yes" ;;
+        *) brief_usage && exit 1 ;;
+    esac
+done
+
+TEST_SET+=(${@:$OPTIND})
+
+[ ${#TEST_SET[@]} -gt 0 ] || die "No test defined."
+
+if [ "${TEST_ON_ALL}" == "yes" -a ${STOP_CONTAINER} -ne 1 ]
+then
+    die "Containers must be stopped when testing against all images."
+fi
+
+inventory=`mktemp /tmp/ansible-freeipa-test-inventory.XXXXXXXX`
+cat << EOF > "${inventory}"
+[ipaserver]
+${scenario}  ansible_connection=${engine}
+
+[ipaserver:vars]
+ipaserver_domain = test.local
+ipaserver_realm = TEST.LOCAL
+EOF
+
+echo -e "${WHITE}INFO:${RST} Inventory file: ${CYAN}${inventory}${MAGENTA}"
+cat "${inventory}"
+echo -e "${RST}"
+
+# prepare virtual environment
+test_env="${TESTENV_DIR:-.ansible-freeipa-tests}"
+VENV=`in_python_virtualenv && echo Y || echo N`
+if [ -z "${ANSIBLE_VERSION}" ]
+then
+    ANSIBLE_VERSION=">=2.9,<2.10"
+else
+    [ "${VENV}" == "Y" ] && deactivate
+    VENV="N"
+    rm -rf "$test_env"
+    warn "Virtual environment will be (re)created."
+fi
+
+if [ "$VENV" == "N" ]
+then
+    echo -e "${WHITE}Preparing virtual environment: ${test_env}${RST}"
+    if [ ! -d "${test_env}" ]
+    then
+        echo -e "Creating virtual environment: ${test_env}..."
+        if ! python3 -m venv "${test_env}"
+        then
+            die "Cannot create virtual environment."
+        fi
+    fi
+    if [ -f "${test_env}/bin/activate" ]
+    then
+        echo -e "Starting virtual environment: ${test_env}"
+        . "${test_env}/bin/activate"
+        STOP_VIRTUALENV="yes"
+    else
+        die "Cannot activate environment."
+    fi
+    echo -e "${WHITE}Installing required tools.${RST}"
+    echo "Upgrading: pip setuptools wheel"
+    pip install --quiet --upgrade pip setuptools wheel
+    echo "Installing: testinfra ansible${ANSIBLE_VERSION}"
+    pip install --quiet "testinfra" "ansible${ANSIBLE_VERSION}"
+    echo "Installing ansible-freeipa test requirements..."
+    pip install --quiet -r requirements-tests.txt
+    echo -e "${CYAN}Ansible version: `ansible --version | sed -n "1p"`${RST}"
+    if [ ! -z "${ANSIBLE_COLLECTIONS}" ]
+    then
+        warn "Installed collections will not be removed after execution."
+        echo "Installing: Ansible Collection ${ANSIBLE_COLLECTIONS}"
+        ansible-galaxy collection install ${ANSIBLE_COLLECTIONS}
+    fi
+fi
+
+# configure Ansible paths to roles and modules.
+ANSIBLE_ROLES_PATH="${TOPDIR}/roles"
+ANSIBLE_LIBRARY="${TOPDIR}/plugins/modules:${TOPDIR}/molecule"
+ANSIBLE_MODULE_UTILS="${TOPDIR}/plugins/module_utils"
+
+declare -a image_results
+
+# Check if container exits.
+echo -e "${WHITE}Checking '${scenario}' container.${RST}"
+container_id=`${engine} ps --all -q -f "name=${scenario}\$"`
+
+if [ "${TEST_ON_ALL}" == "yes" ]
+then
+    images=("centos-7" "centos-8" "fedora-latest")
+else
+    images=(${IMAGE_TAG})
+fi
+
+for IMAGE_TAG in ${images[@]}
+do
+    # if force recreation of container, and it exsits, remove it
+    if  [ ! -z "${FORCE_CONTAINER}" -a ! -z "${container_id}" ]
+    then
+        warn "Removing existing container..."
+        quiet ${engine} stop "${container_id}"
+        quiet ${engine} rm "${container_id}"
+        # this will force creation of a new container, later.
+        unset container_id
+    fi
+    # if container is not set, create it.
+    if  [ -z "${container_id}" ]
+    then
+        hostname="ipaserver.test.local"
+
+        # Retrieve image and start container.
+        echo -e "Pulling FreeIPA image '${CYAN}${IMAGE_TAG}${RST}'..."
+        img_id=`${engine} pull -q quay.io/ansible-freeipa/upstream-tests:${IMAGE_TAG}`
+        echo -e "Creating '${CYAN}${scenario}${RST}' container..."
+        CONFIG="--hostname ${hostname} --name ${scenario} --memory ${MEMORY}g --memory-swap -1"
+        container_id=`${engine} create ${CONFIG} "${img_id}"`
+    else
+        STOP_CONTAINER=0
+    fi
+
+    quiet ${engine} start "${scenario}"
+    # wait for FreeIPA services to be available
+    run_inline_playbook <<EOF
+---
+- name: Wait for IPA services to be available
+  hosts: ipaserver
+  gather_facts: no
+  tasks:
+  - name: Wait for IPA to be started.
+    systemd:
+      name: ipa
+      state: started
+  - name: Wait for Kerberos KDC to be started.
+    systemd:
+      name: krb5kdc
+      state: started
+    register: result
+    until: not result.failed
+    retries: 30
+    delay: 5
+  - name: Check if TGT is available for admin.
+    shell:
+      cmd: echo SomeADMINpassword | kinit -c ansible_freeipa_cache admin
+    register: result
+    until: not result.failed
+    retries: 30
+    delay: 5
+  - name: Cleanup TGT.
+    shell:
+      cmd: kdestroy -c ansible_freeipa_cache -A
+...
+EOF
+    if [ $? -ne 0 ]
+    then
+        cleanup
+        die "Failed to verify IPA or KDC services."
+    fi
+
+    # Check image software versions.
+    run_inline_playbook <<EOF
+---
+- name: Software environment.
+  hosts: ipaserver
+  become: yes
+  gather_facts: no
+  tasks:
+  - name: Retrieve versions.
+    shell:
+      cmd: |
+        rpm -q freeipa-server freeipa-client ipa-server ipa-client 389-ds-base pki-ca krb5-server
+        cat /etc/redhat-release
+        uname -a
+    register: result
+  - name: Testing environment.
+    debug:
+      var: result.stdout_lines
+EOF
+    if [ $? -ne 0 ]
+    then
+        cleanup
+        die "Failed to verify software installation."
+    fi
+
+    # run tests
+    RESULT=0
+    for test in "${TEST_SET[@]}"
+    do
+        echo -e "\n${WHITE}Running: ${CYAN}${test#utils/../}${RST}"
+        ansible-playbook ${verbose} -i "${inventory}" "${test}" || RESULT=2
+        [ -z "${CONTINUE_ON_ERROR}" -a $RESULT -ne 0 ] && die "Stopping on test failure."
+    done
+
+    image_results[${#image_results[@]}]="${IMAGE_TAG}|${RESULT}"
+
+    quiet stop_container
+done
+
+cleanup
+
+# Return test result if any test has failed.
+RESULT=0
+for result in ${image_results[@]}
+do
+    img="${WHITE}`echo ${result} | cut -d'|' -f1`${RST}"
+    error=`echo ${result} | cut -d'|' -f2`
+    if [ ${error} -ne 0 ]
+    then
+        RESULT=${error}
+        echo -e "${RED}FAILED${RST}: $img: Some playbooks tests have failed."
+    else
+        echo -e "${GREEN}Success${RST}: $img: all playbook tests passed."
+    fi
+
+done
+
+exit ${RESULT}


### PR DESCRIPTION
This patch provides a way to run ansible-freeipa test playbooks with
containers and software tools installed in a virtual environment, in the
developer's workstation, using the same test images as used in the
project CI environment.
