### PR TITLE
Remote module execution

### DIFF
--- a/README-automember.md
+++ b/README-automember.md
@@ -122,6 +122,7 @@ Variable | Description | Required
 -------- | ----------- | --------
 `ipaadmin_principal` | The admin principal is a string and defaults to `admin` | no
 `ipaadmin_password` | The admin password is a string and is required if there is no admin ticket available on the node | no
+`ipa_context` | The context in which the module will execute. Executing in a server context is preferred, use `client` to execute in a client context if the server cannot be accessed. Valid values are `server`, `client`. Default to `server`. | no
 `name` \| `cn` | Automember rule. | yes
 `description` | A description of this auto member rule. | no
 `automember_type` | Grouping to which the rule applies. It can be one of `group`, `hostgroup`. | yes

--- a/README-config.md
+++ b/README-config.md
@@ -91,6 +91,7 @@ Variable | Description | Required
 -------- | ----------- | --------
 `ipaadmin_principal` | The admin principal is a string and defaults to `admin` | no
 `ipaadmin_password` | The admin password is a string and is required if there is no admin ticket available on the node | no
+`ipa_context` | The context in which the module will execute. Executing in a server context is preferred, use `client` to execute in a client context if the server cannot be accessed. Valid values are `server`, `client`. Default to `server`. | no
 `maxusername` \| `ipamaxusernamelength` |  Set the maximum username length (1 to 255) | no
 `maxhostname` \| `ipamaxhostnamelength` |  Set the maximum hostname length between 64-255. Only usable with IPA versions 4.8.0 and up. | no
 `homedirectory` \| `ipahomesrootdir` |  Set the default location of home directories | no

--- a/README-delegation.md
+++ b/README-delegation.md
@@ -142,6 +142,7 @@ Variable | Description | Required
 -------- | ----------- | --------
 `ipaadmin_principal` | The admin principal is a string and defaults to `admin` | no
 `ipaadmin_password` | The admin password is a string and is required if there is no admin ticket available on the node | no
+`ipa_context` | The context in which the module will execute. Executing in a server context is preferred, use `client` to execute in a client context if the server cannot be accessed. Valid values are `server`, `client`. Default to `server`. | no
 `name` \| `aciname` | The list of delegation name strings. | yes
 `permission` \| `permissions` |  The permission to grant `read`, `read,write`, `write`]. Default is `write`. | no
 `attribute` \| `attrs` | The attribute list to which the delegation applies. | no

--- a/README-dnsconfig.md
+++ b/README-dnsconfig.md
@@ -126,6 +126,7 @@ Variable | Description | Required
 -------- | ----------- | --------
 `ipaadmin_principal` | The admin principal is a string and defaults to `admin` | no
 `ipaadmin_password` | The admin password is a string and is required if there is no admin ticket available on the node | no
+`ipa_context` | The context in which the module will execute. Executing in a server context is preferred, use `client` to execute in a client context if the server cannot be accessed. Valid values are `server`, `client`. Default to `server`. | no
 `forwarders` | The list of forwarders dicts. Each `forwarders` dict entry has:| no
 &nbsp; | `ip_address` - The IPv4 or IPv6 address of the DNS server. | yes
 &nbsp; | `port` - The custom port that should be used on this server. | no

--- a/README-dnsforwardzone.md
+++ b/README-dnsforwardzone.md
@@ -107,6 +107,7 @@ Variable | Description | Required
 -------- | ----------- | --------
 `ipaadmin_principal` | The admin principal is a string and defaults to `admin` | no
 `ipaadmin_password` | The admin password is a string and is required if there is no admin ticket available on the node | no
+`ipa_context` | The context in which the module will execute. Executing in a server context is preferred, use `client` to execute in a client context if the server cannot be accessed. Valid values are `server`, `client`. Default to `server`. | no
 `name` \| `cn` | Zone name (FQDN). | yes if `state` == `present`
 `forwarders` \| `idnsforwarders` |  Per-zone forwarders. A custom port can be specified for each forwarder. Options | no
 &nbsp; | `ip_address`: The forwarder IP address. | yes

--- a/README-dnsrecord.md
+++ b/README-dnsrecord.md
@@ -249,6 +249,7 @@ Variable | Description | Required
 -------- | ----------- | --------
 `ipaadmin_principal` | The admin principal is a string and defaults to `admin` | no
 `ipaadmin_password` | The admin password is a string and is required if there is no admin ticket available on the node | no
+`ipa_context` | The context in which the module will execute. Executing in a server context is preferred, use `client` to execute in a client context if the server cannot be accessed. Valid values are `server`, `client`. Default to `server`. | no
 `zone_name` \| `dnszone` | The DNS zone name to which DNS record needs to be managed. You can use one global zone name for multiple records. | no
   required: true
 `records` | The list of dns records dicts. Each `records` dict entry can contain **record variables**. | no

--- a/README-dnszone.md
+++ b/README-dnszone.md
@@ -203,6 +203,7 @@ Variable | Description | Required
 -------- | ----------- | --------
 `ipaadmin_principal` | The admin principal is a string and defaults to `admin` | no
 `ipaadmin_password` | The admin password is a string and is required if there is no admin ticket available on the node | no
+`ipa_context` | The context in which the module will execute. Executing in a server context is preferred, use `client` to execute in a client context if the server cannot be accessed. Valid values are `server`, `client`. Default to `server`. | no
 `name` \| `zone_name` | The zone name string or list of strings. | no
 `name_from_ip` | Derive zone name from reverse of IP (PTR). Can only be used with `state: present`. | no
 `forwarders` | The list of forwarders dicts. Each `forwarders` dict entry has:| no

--- a/README-group.md
+++ b/README-group.md
@@ -154,6 +154,7 @@ Variable | Description | Required
 -------- | ----------- | --------
 `ipaadmin_principal` | The admin principal is a string and defaults to `admin` | no
 `ipaadmin_password` | The admin password is a string and is required if there is no admin ticket available on the node | no
+`ipa_context` | The context in which the module will execute. Executing in a server context is preferred, use `client` to execute in a client context if the server cannot be accessed. Valid values are `server`, `client`. Default to `server`. | no
 `name` \| `cn` | The list of group name strings. | no
 `description` | The group description string. | no
 `gid` \| `gidnumber` | The GID integer. | no

--- a/README-hbacrule.md
+++ b/README-hbacrule.md
@@ -136,6 +136,7 @@ Variable | Description | Required
 -------- | ----------- | --------
 `ipaadmin_principal` | The admin principal is a string and defaults to `admin` | no
 `ipaadmin_password` | The admin password is a string and is required if there is no admin ticket available on the node | no
+`ipa_context` | The context in which the module will execute. Executing in a server context is preferred, use `client` to execute in a client context if the server cannot be accessed. Valid values are `server`, `client`. Default to `server`. | no
 `name` \| `cn` | The list of hbacrule name strings. | yes
 `description` | The hbacrule description string. | no
 `usercategory` \| `usercat` | User category the rule applies to. Choices: ["all", ""] | no

--- a/README-hbacsvc.md
+++ b/README-hbacsvc.md
@@ -98,6 +98,7 @@ Variable | Description | Required
 -------- | ----------- | --------
 `ipaadmin_principal` | The admin principal is a string and defaults to `admin` | no
 `ipaadmin_password` | The admin password is a string and is required if there is no admin ticket available on the node | no
+`ipa_context` | The context in which the module will execute. Executing in a server context is preferred, use `client` to execute in a client context if the server cannot be accessed. Valid values are `server`, `client`. Default to `server`. | no
 `name` \| `cn` \| `service` | The list of hbacsvc name strings. | no
 `description` | The hbacsvc description string. | no
 `state` | The state to ensure. It can be one of `present` or `absent`, default: `present`. | no

--- a/README-hbacsvcgroup.md
+++ b/README-hbacsvcgroup.md
@@ -136,6 +136,7 @@ Variable | Description | Required
 -------- | ----------- | --------
 `ipaadmin_principal` | The admin principal is a string and defaults to `admin` | no
 `ipaadmin_password` | The admin password is a string and is required if there is no admin ticket available on the node | no
+`ipa_context` | The context in which the module will execute. Executing in a server context is preferred, use `client` to execute in a client context if the server cannot be accessed. Valid values are `server`, `client`. Default to `server`. | no
 `name` \| `cn` | The list of hbacsvcgroup name strings. | no
 `description` | The hbacsvcgroup description string. | no
 `nomembers` | Suppress processing of membership attributes. (bool) | no

--- a/README-host.md
+++ b/README-host.md
@@ -376,6 +376,7 @@ There are only return values if one or more random passwords have been generated
 Variable | Description | Returned When
 -------- | ----------- | -------------
 `host` | Host dict with random password. (dict) <br>Options: | If random is yes and host did not exist or update_password is yes
+`ipa_context` | The context in which the module will execute. Executing in a server context is preferred, use `client` to execute in a client context if the server cannot be accessed. Valid values are `server`, `client`. Default to `server`. | no
 &nbsp; | `randompassword` - The generated random password | If only one host is handled by the module
 &nbsp; | `name` - The host name of the host that got a new random password. (dict) <br> Options: <br> &nbsp; `randompassword` - The generated random password | If several hosts are handled by the module
 

--- a/README-hostgroup.md
+++ b/README-hostgroup.md
@@ -150,6 +150,7 @@ Variable | Description | Required
 -------- | ----------- | --------
 `ipaadmin_principal` | The admin principal is a string and defaults to `admin` | no
 `ipaadmin_password` | The admin password is a string and is required if there is no admin ticket available on the node | no
+`ipa_context` | The context in which the module will execute. Executing in a server context is preferred, use `client` to execute in a client context if the server cannot be accessed. Valid values are `server`, `client`. Default to `server`. | no
 `name` \| `cn` | The list of hostgroup name strings. | no
 `description` | The hostgroup description string. | no
 `nomembers` | Suppress processing of membership attributes. (bool) | no

--- a/README-location.md
+++ b/README-location.md
@@ -81,6 +81,7 @@ Variable | Description | Required
 -------- | ----------- | --------
 `ipaadmin_principal` | The admin principal is a string and defaults to `admin` | no
 `ipaadmin_password` | The admin password is a string and is required if there is no admin ticket available on the node | no
+`ipa_context` | The context in which the module will execute. Executing in a server context is preferred, use `client` to execute in a client context if the server cannot be accessed. Valid values are `server`, `client`. Default to `server`. | no
 `name` \| `idnsname` | The list of location name strings. | yes
 `description` | The IPA location string | false
 `state` | The state to ensure. It can be one of `present`, `absent`, default: `present`. | no

--- a/README-permission.md
+++ b/README-permission.md
@@ -161,6 +161,7 @@ Variable | Description | Required
 -------- | ----------- | --------
 `ipaadmin_principal` | The admin principal is a string and defaults to `admin` | no
 `ipaadmin_password` | The admin password is a string and is required if there is no admin ticket available on the node | no
+`ipa_context` | The context in which the module will execute. Executing in a server context is preferred, use `client` to execute in a client context if the server cannot be accessed. Valid values are `server`, `client`. Default to `server`. | no
 `name` \| `cn` | The permission name string. | yes
 `right` \| `ipapermright` | Rights to grant. It can be a list of one or more of `read`, `search`, `compare`, `write`, `add`, `delete`, and `all` default: `all` | no
 `attrs` | All attributes to which the permission applies. | no

--- a/README-privilege.md
+++ b/README-privilege.md
@@ -133,6 +133,7 @@ Variable | Description | Required
 -------- | ----------- | --------
 `ipaadmin_principal` | The admin principal is a string and defaults to `admin`. | no
 `ipaadmin_password` | The admin password is a string and is required if there is no admin ticket available on the node. | no
+`ipa_context` | The context in which the module will execute. Executing in a server context is preferred, use `client` to execute in a client context if the server cannot be accessed. Valid values are `server`, `client`. Default to `server`. | no
 `name` \| `cn` | The list of privilege name strings. | yes
 `description` | Privilege description. | no
 `rename` \| `new_name` | Rename the privilege object. | no

--- a/README-pwpolicy.md
+++ b/README-pwpolicy.md
@@ -98,6 +98,7 @@ Variable | Description | Required
 -------- | ----------- | --------
 `ipaadmin_principal` | The admin principal is a string and defaults to `admin` | no
 `ipaadmin_password` | The admin password is a string and is required if there is no admin ticket available on the node | no
+`ipa_context` | The context in which the module will execute. Executing in a server context is preferred, use `client` to execute in a client context if the server cannot be accessed. Valid values are `server`, `client`. Default to `server`. | no
 `name` \| `cn` | The list of pwpolicy name strings. If name is not given, `global_policy` will be used automatically. | no
 `maxlife` \| `krbmaxpwdlife` | Maximum password lifetime in days. (int) | no
 `minlife` \| `krbminpwdlife` | Minimum password lifetime in hours. (int) | no

--- a/README-role.md
+++ b/README-role.md
@@ -245,6 +245,7 @@ Variable | Description | Required
 -------- | ----------- | --------
 `ipaadmin_principal` | The admin principal is a string and defaults to `admin` | no
 `ipaadmin_password` | The admin password is a string and is required if there is no admin ticket available on the node | no
+`ipa_context` | The context in which the module will execute. Executing in a server context is preferred, use `client` to execute in a client context if the server cannot be accessed. Valid values are `server`, `client`. Default to `server`. | no
 `name` \| `cn` | The list of role name strings. | yes
 `description` | A description for the role. | no
 `rename` | Rename the role object. | no

--- a/README-selfservice.md
+++ b/README-selfservice.md
@@ -138,6 +138,7 @@ Variable | Description | Required
 -------- | ----------- | --------
 `ipaadmin_principal` | The admin principal is a string and defaults to `admin` | no
 `ipaadmin_password` | The admin password is a string and is required if there is no admin ticket available on the node | no
+`ipa_context` | The context in which the module will execute. Executing in a server context is preferred, use `client` to execute in a client context if the server cannot be accessed. Valid values are `server`, `client`. Default to `server`. | no
 `name` \| `aciname` | The list of selfservice name strings. | yes
 `permission` \| `permissions` |  The permission to grant `read`, `read,write`, `write`]. Default is `write`. | no
 `attribute` \| `attrs` | The attribute list to which the selfservice applies. | no

--- a/README-server.md
+++ b/README-server.md
@@ -230,6 +230,7 @@ Variable | Description | Required
 -------- | ----------- | --------
 `ipaadmin_principal` | The admin principal is a string and defaults to `admin` | no
 `ipaadmin_password` | The admin password is a string and is required if there is no admin ticket available on the node | no
+`ipa_context` | The context in which the module will execute. Executing in a server context is preferred, use `client` to execute in a client context if the server cannot be accessed. Valid values are `server`, `client`. Default to `server`. | no
 `name` \| `cn` | The list of server name strings. | yes
 `location` \| `ipalocation_location` | The server location string. Only in state: present. "" for location reset. | no
 `service_weight` \| `ipaserviceweight` | Weight for server services. Type Values 0 to 65535, -1 for weight reset. Only in state: present. (int) | no

--- a/README-service.md
+++ b/README-service.md
@@ -291,6 +291,7 @@ Variable | Description | Required
 -------- | ----------- | --------
 `ipaadmin_principal` | The admin principal is a string and defaults to `admin` | no
 `ipaadmin_password` | The admin password is a string and is required if there is no admin ticket available on the node | no
+`ipa_context` | The context in which the module will execute. Executing in a server context is preferred, use `client` to execute in a client context if the server cannot be accessed. Valid values are `server`, `client`. Default to `server`. | no
 `name` \| `service` | The list of service name strings. | yes
 `certificate` \| `usercertificate` | Base-64 encoded service certificate. | no
 `pac_type` \| `ipakrbauthzdata` | Supported PAC type. It can be one of `MS-PAC`, `PAD`, or `NONE`. | no

--- a/README-sudocmd.md
+++ b/README-sudocmd.md
@@ -83,6 +83,7 @@ Variable | Description | Required
 -------- | ----------- | --------
 `ipaadmin_principal` | The admin principal is a string and defaults to `admin` | no
 `ipaadmin_password` | The admin password is a string and is required if there is no admin ticket available on the node | no
+`ipa_context` | The context in which the module will execute. Executing in a server context is preferred, use `client` to execute in a client context if the server cannot be accessed. Valid values are `server`, `client`. Default to `server`. | no
 `name` \| `sudocmd` | The sudo command strings. | yes
 `description` | The command description string. | no
 `nomembers` | Suppress processing of membership attributes. (bool) | no

--- a/README-sudocmdgroup.md
+++ b/README-sudocmdgroup.md
@@ -123,6 +123,7 @@ Variable | Description | Required
 -------- | ----------- | --------
 `ipaadmin_principal` | The admin principal is a string and defaults to `admin` | no
 `ipaadmin_password` | The admin password is a string and is required if there is no admin ticket available on the node | no
+`ipa_context` | The context in which the module will execute. Executing in a server context is preferred, use `client` to execute in a client context if the server cannot be accessed. Valid values are `server`, `client`. Default to `server`. | no
 `name` \| `cn` | The list of sudocmdgroup name strings. | no
 `description` | The sudocmdgroup description string. | no
 `nomembers` | Suppress processing of membership attributes. (bool) | no

--- a/README-sudorule.md
+++ b/README-sudorule.md
@@ -120,6 +120,7 @@ Variable | Description | Required
 -------- | ----------- | --------
 `ipaadmin_principal` | The admin principal is a string and defaults to `admin` | no
 `ipaadmin_password` | The admin password is a string and is required if there is no admin ticket available on the node | no
+`ipa_context` | The context in which the module will execute. Executing in a server context is preferred, use `client` to execute in a client context if the server cannot be accessed. Valid values are `server`, `client`. Default to `server`. | no
 `name` \| `cn` | The list of sudorule name strings. | yes
 `description` | The sudorule description string. | no
 `usercategory` \| `usercat` | User category the rule applies to. Choices: ["all", ""] | no

--- a/README-topology.md
+++ b/README-topology.md
@@ -159,6 +159,7 @@ Variable | Description | Required
 -------- | ----------- | --------
 `ipaadmin_principal` | The admin principal is a string and defaults to `admin` | no
 `ipaadmin_password` | The admin password is a string and is required if there is no admin ticket available on the node | no
+`ipa_context` | The context in which the module will execute. Executing in a server context is preferred, use `client` to execute in a client context if the server cannot be accessed. Valid values are `server`, `client`. Default to `server`. | no
 `suffix` | The topology suffix to be used, this can either be `domain`, `ca` or `domain+ca` | yes
 `name` \| `cn` | The topology segment name (cn) is the unique identifier for a segment. | no
 `left` \| `leftnode` | The left replication node string - an IPA server | no
@@ -176,6 +177,7 @@ Variable | Description | Required
 -------- | ----------- | --------
 `ipaadmin_principal` | The admin principal is a string and defaults to `admin` | no
 `ipaadmin_password` | The admin password is a string and is required if there is no admin ticket available on the node | no
+`ipa_context` | The context in which the module will execute. Executing in a server context is preferred, use `client` to execute in a client context if the server cannot be accessed. Valid values are `server`, `client`. Default to `server`. | no
 `suffix` | The topology suffix to be used, this can either be `domain` or `ca` | yes
 `state` | The state to ensure. It can only be `verified` | yes
 

--- a/README-trust.md
+++ b/README-trust.md
@@ -101,6 +101,7 @@ Variable | Description | Required
 -------- | ----------- | --------
 `ipaadmin_principal` | The admin principal is a string and defaults to `admin` | no
 `ipaadmin_password` | The admin password is a string and is required if there is no admin ticket available on the node | no
+`ipa_context` | The context in which the module will execute. Executing in a server context is preferred, use `client` to execute in a client context if the server cannot be accessed. Valid values are `server`, `client`. Default to `server`. | no
 `realm` | The realm name string. | yes
 `admin` | Active Directory domain administrator string. | no
 `password` | Active Directory domain administrator's password string. | no

--- a/README-user.md
+++ b/README-user.md
@@ -365,6 +365,7 @@ Variable | Description | Required
 -------- | ----------- | --------
 `ipaadmin_principal` | The admin principal is a string and defaults to `admin` | no
 `ipaadmin_password` | The admin password is a string and is required if there is no admin ticket available on the node | no
+`ipa_context` | The context in which the module will execute. Executing in a server context is preferred, use `client` to execute in a client context if the server cannot be accessed. Valid values are `server`, `client`. Default to `server`. | no
 `name` | The list of user name strings. `name` with *user variables* or `users` containing *user variables* need to be used. | no
 **User variables** | Only used with `name` variable in the first level. | no
 `users` | The list of user dicts. Each `users` dict entry can contain **user variables**.<br>There is one required option in the `users` dict:| no
@@ -408,7 +409,7 @@ Variable | Description | Required
 `manager` | List of manager user names. | no
 `carlicense` | List of car licenses. | no
 `sshpubkey` \| `ipasshpubkey` | List of SSH public keys. | no
-`userauthtype` | List of supported user authentication types. Choices: `password`, `radius`, `otp` and ``. Use empty string to reset userauthtype to the initial value. | no
+`userauthtype` | List of supported user authentication types. Choices: `password`, `radius`, `otp` and \`\`. Use empty string to reset userauthtype to the initial value. | no
 `userclass` | User category. (semantics placed on this attribute are for local interpretation). | no
 `radius` | RADIUS proxy configuration  | no
 `radiususer` | RADIUS proxy username | no

--- a/plugins/module_utils/ansible_freeipa_module.py
+++ b/plugins/module_utils/ansible_freeipa_module.py
@@ -176,20 +176,23 @@ else:
         """
         Initialize IPA API with the provided context.
 
-        `context` can be any of:
-            * `server` (default)
-            * `ansible-freeipa`
-            * `cli_installer`
+        context:
+            The context to execute IPA plugins. Can be any of
+            [server, client, cli].
         """
         env = Env()
         env._bootstrap()
         env._finalize_core(**dict(DEFAULT_CONFIG))
 
-        # available contexts are 'server', 'ansible-freeipa' and
-        # 'cli_installer'
-
+        # IPA uses 'cli' for a 'client' context, but 'client'
+        # provides a better user interface. Here we map the
+        # value if needed.
         if context is None:
             context = 'server'
+        elif context == "client":
+            context = "cli"
+        if context not in ('server', 'cli'):
+            raise ValueError("Invalid execution context: %s" % (context))
 
         api.bootstrap(context=context, debug=env.debug, log=None)
         api.finalize()
@@ -722,6 +725,7 @@ else:
             """
             principal = self.ipa_params.ipaadmin_principal
             password = self.ipa_params.ipaadmin_password
+            ipa_context = self.ipa_params.ipa_context
 
             try:
                 if not valid_creds(self, principal):
@@ -729,7 +733,7 @@ else:
                         principal, password,
                     )
 
-                api_connect()
+                api_connect(ipa_context)
 
             except Exception as excpt:
                 self.fail_json(msg=str(excpt))

--- a/plugins/modules/ipaautomember.py
+++ b/plugins/modules/ipaautomember.py
@@ -49,6 +49,13 @@ options:
   ipaadmin_password:
     description: The admin password
     required: false
+  ipa_context:
+    description: |
+      The context in which the module will execute. Executing in a server
+      context is preferred, use `client` to execute in a client context if
+      the server cannot be accessed.
+    choices: ["server", "client"]
+    default: server
   name:
     description: The automember rule
     required: true
@@ -228,6 +235,7 @@ def main():
     # general
     ipaadmin_principal = ansible_module.params.get("ipaadmin_principal")
     ipaadmin_password = ansible_module.params.get("ipaadmin_password")
+    ipa_context = ansible_module.params.get("ipa_context")
     names = ansible_module.params.get("name")
 
     # present
@@ -266,7 +274,7 @@ def main():
         if not valid_creds(ansible_module, ipaadmin_principal):
             ccache_dir, ccache_name = temp_kinit(ipaadmin_principal,
                                                  ipaadmin_password)
-        api_connect()
+        api_connect(ipa_context)
 
         commands = []
 

--- a/plugins/modules/ipadelegation.py
+++ b/plugins/modules/ipadelegation.py
@@ -38,6 +38,13 @@ options:
   ipaadmin_password:
     description: The admin password.
     required: false
+  ipa_context:
+    description: |
+      The context in which the module will execute. Executing in a server
+      context is preferred, use `client` to execute in a client context if
+      the server cannot be accessed.
+    choices: ["server", "client"]
+    default: server
   name:
     description: The list of delegation name strings.
     required: true
@@ -153,7 +160,8 @@ def main():
             # general
             ipaadmin_principal=dict(type="str", default="admin"),
             ipaadmin_password=dict(type="str", required=False, no_log=True),
-
+            ipa_context=dict(type="str", required=False, default="server",
+                             choices=["server", "client"]),
             name=dict(type="list", aliases=["aciname"], default=None,
                       required=True),
             # present
@@ -180,6 +188,8 @@ def main():
     ipaadmin_principal = module_params_get(ansible_module,
                                            "ipaadmin_principal")
     ipaadmin_password = module_params_get(ansible_module, "ipaadmin_password")
+    ipa_context = module_params_get(ansible_module, "ipa_context")
+
     names = module_params_get(ansible_module, "name")
 
     # present
@@ -242,7 +252,7 @@ def main():
         if not valid_creds(ansible_module, ipaadmin_principal):
             ccache_dir, ccache_name = temp_kinit(ipaadmin_principal,
                                                  ipaadmin_password)
-        api_connect()
+        api_connect(ipa_context)
 
         commands = []
         for name in names:

--- a/plugins/modules/ipadnsrecord.py
+++ b/plugins/modules/ipadnsrecord.py
@@ -40,6 +40,13 @@ options:
   ipaadmin_password:
     description: The admin password
     required: false
+  ipa_context:
+    description: |
+      The context in which the module will execute. Executing in a server
+      context is preferred, use `client` to execute in a client context if
+      the server cannot be accessed.
+    choices: ["server", "client"]
+    default: server
   records:
     description: The list of user dns records dicts
     required: false
@@ -1111,7 +1118,8 @@ def configure_module():
             # general
             ipaadmin_principal=dict(type="str", default="admin"),
             ipaadmin_password=dict(type="str", no_log=True),
-
+            ipa_context=dict(type="str", required=False, default="server",
+                             choices=["server", "client"]),
             name=dict(type="list", aliases=["record_name"], default=None,
                       required=False),
 
@@ -1221,13 +1229,14 @@ def connect_to_api(module):
     """Connect to the IPA API."""
     ipaadmin_principal = module_params_get(module, "ipaadmin_principal")
     ipaadmin_password = module_params_get(module, "ipaadmin_password")
+    ipa_context = module_params_get(module, "ipa_context")
 
     ccache_dir = None
     ccache_name = None
     if not valid_creds(module, ipaadmin_principal):
         ccache_dir, ccache_name = temp_kinit(ipaadmin_principal,
                                              ipaadmin_password)
-    api_connect()
+    api_connect(ipa_context)
 
     return ccache_dir, ccache_name
 

--- a/plugins/modules/ipadnszone.py
+++ b/plugins/modules/ipadnszone.py
@@ -38,6 +38,13 @@ options:
   ipaadmin_password:
     description: The admin password
     required: false
+  ipa_context:
+    description: |
+      The context in which the module will execute. Executing in a server
+      context is preferred, use `client` to execute in a client context if
+      the server cannot be accessed.
+    choices: ["server", "client"]
+    default: server
   name:
     description: The zone name string.
     required: true
@@ -414,7 +421,7 @@ class DNSZoneModule(FreeIPABaseModule):
             is_zone_active = False
         else:
             zone = response["result"]
-            is_zone_active = zone.get("idnszoneactive") == ["TRUE"]
+            is_zone_active = zone.get("idnszoneactive")[0] == "TRUE"
 
         return zone, is_zone_active
 
@@ -523,6 +530,8 @@ def get_argument_spec():
         ),
         ipaadmin_principal=dict(type="str", default="admin"),
         ipaadmin_password=dict(type="str", required=False, no_log=True),
+        ipa_context=dict(type="str", required=False, default="server",
+                         choices=["server", "client"]),
         name=dict(
             type="list", default=None, required=False, aliases=["zone_name"]
         ),

--- a/plugins/modules/ipagroup.py
+++ b/plugins/modules/ipagroup.py
@@ -38,6 +38,13 @@ options:
   ipaadmin_password:
     description: The admin password
     required: false
+  ipa_context:
+    description: |
+      The context in which the module will execute. Executing in a server
+      context is preferred, use `client` to execute in a client context if
+      the server cannot be accessed.
+    choices: ["server", "client"]
+    default: server
   name:
     description: The group name
     required: false
@@ -283,7 +290,8 @@ def main():
             # general
             ipaadmin_principal=dict(type="str", default="admin"),
             ipaadmin_password=dict(type="str", required=False, no_log=True),
-
+            ipa_context=dict(type="str", required=False, default="server",
+                             choices=["server", "client"]),
             name=dict(type="list", aliases=["cn"], default=None,
                       required=True),
             # present
@@ -324,6 +332,7 @@ def main():
         "ipaadmin_principal",
     )
     ipaadmin_password = module_params_get(ansible_module, "ipaadmin_password")
+    ipa_context = module_params_get(ansible_module, "ipa_context")
     names = module_params_get(ansible_module, "name")
 
     # present
@@ -384,7 +393,7 @@ def main():
         if not valid_creds(ansible_module, ipaadmin_principal):
             ccache_dir, ccache_name = temp_kinit(ipaadmin_principal,
                                                  ipaadmin_password)
-        api_connect()
+        api_connect(ipa_context)
 
         has_add_member_service = api_check_param("group_add_member", "service")
         if service is not None and not has_add_member_service:

--- a/plugins/modules/ipahbacrule.py
+++ b/plugins/modules/ipahbacrule.py
@@ -38,6 +38,13 @@ options:
   ipaadmin_password:
     description: The admin password
     required: false
+  ipa_context:
+    description: |
+      The context in which the module will execute. Executing in a server
+      context is preferred, use `client` to execute in a client context if
+      the server cannot be accessed.
+    choices: ["server", "client"]
+    default: server
   name:
     description: The hbacrule name
     required: true
@@ -202,7 +209,8 @@ def main():
             # general
             ipaadmin_principal=dict(type="str", default="admin"),
             ipaadmin_password=dict(type="str", required=False, no_log=True),
-
+            ipa_context=dict(type="str", required=False, default="server",
+                             choices=["server", "client"]),
             name=dict(type="list", aliases=["cn"], default=None,
                       required=True),
             # present
@@ -238,6 +246,7 @@ def main():
     ipaadmin_principal = module_params_get(ansible_module,
                                            "ipaadmin_principal")
     ipaadmin_password = module_params_get(ansible_module, "ipaadmin_password")
+    ipa_context = module_params_get(ansible_module, "ipa_context")
     names = module_params_get(ansible_module, "name")
 
     # present
@@ -323,7 +332,7 @@ def main():
         if not valid_creds(ansible_module, ipaadmin_principal):
             ccache_dir, ccache_name = temp_kinit(ipaadmin_principal,
                                                  ipaadmin_password)
-        api_connect()
+        api_connect(ipa_context)
 
         commands = []
 

--- a/plugins/modules/ipahbacsvc.py
+++ b/plugins/modules/ipahbacsvc.py
@@ -38,6 +38,13 @@ options:
   ipaadmin_password:
     description: The admin password
     required: false
+  ipa_context:
+    description: |
+      The context in which the module will execute. Executing in a server
+      context is preferred, use `client` to execute in a client context if
+      the server cannot be accessed.
+    choices: ["server", "client"]
+    default: server
   name:
     description: The group name
     required: false
@@ -107,7 +114,8 @@ def main():
             # general
             ipaadmin_principal=dict(type="str", default="admin"),
             ipaadmin_password=dict(type="str", required=False, no_log=True),
-
+            ipa_context=dict(type="str", required=False, default="server",
+                             choices=["server", "client"]),
             name=dict(type="list", aliases=["cn", "service"], default=None,
                       required=True),
             # present
@@ -128,6 +136,7 @@ def main():
     # general
     ipaadmin_principal = ansible_module.params.get("ipaadmin_principal")
     ipaadmin_password = ansible_module.params.get("ipaadmin_password")
+    ipa_context = ansible_module.params.get("ipa_context")
     names = ansible_module.params.get("name")
 
     # present
@@ -164,7 +173,7 @@ def main():
         if not valid_creds(ansible_module, ipaadmin_principal):
             ccache_dir, ccache_name = temp_kinit(ipaadmin_principal,
                                                  ipaadmin_password)
-        api_connect()
+        api_connect(ipa_context)
 
         commands = []
 

--- a/plugins/modules/ipahbacsvcgroup.py
+++ b/plugins/modules/ipahbacsvcgroup.py
@@ -39,6 +39,13 @@ options:
   ipaadmin_password:
     description: The admin password
     required: false
+  ipa_context:
+    description: |
+      The context in which the module will execute. Executing in a server
+      context is preferred, use `client` to execute in a client context if
+      the server cannot be accessed.
+    choices: ["server", "client"]
+    default: server
   name:
     description: The hbacsvcgroup name
     required: false
@@ -149,7 +156,8 @@ def main():
             # general
             ipaadmin_principal=dict(type="str", default="admin"),
             ipaadmin_password=dict(type="str", required=False, no_log=True),
-
+            ipa_context=dict(type="str", required=False, default="server",
+                             choices=["server", "client"]),
             name=dict(type="list", aliases=["cn"], default=None,
                       required=True),
             # present
@@ -172,6 +180,7 @@ def main():
     # general
     ipaadmin_principal = ansible_module.params.get("ipaadmin_principal")
     ipaadmin_password = ansible_module.params.get("ipaadmin_password")
+    ipa_context = ansible_module.params.get("ipa_context")
     names = ansible_module.params.get("name")
 
     # present
@@ -219,7 +228,7 @@ def main():
         if not valid_creds(ansible_module, ipaadmin_principal):
             ccache_dir, ccache_name = temp_kinit(ipaadmin_principal,
                                                  ipaadmin_password)
-        api_connect()
+        api_connect(ipa_context)
 
         commands = []
 

--- a/plugins/modules/ipahost.py
+++ b/plugins/modules/ipahost.py
@@ -38,11 +38,17 @@ options:
   ipaadmin_password:
     description: The admin password
     required: false
+  ipa_context:
+    description: |
+      The context in which the module will execute. Executing in a server
+      context is preferred, use `client` to execute in a client context if
+      the server cannot be accessed.
+    choices: ["server", "client"]
+    default: server
   name:
     description: The full qualified domain name.
     aliases: ["fqdn"]
     required: true
-
   hosts:
     description: The list of user host dicts
     required: false
@@ -668,7 +674,8 @@ def main():
             # general
             ipaadmin_principal=dict(type="str", default="admin"),
             ipaadmin_password=dict(type="str", no_log=True),
-
+            ipa_context=dict(type="str", required=False, default="server",
+                             choices=["server", "client"]),
             name=dict(type="list", aliases=["fqdn"], default=None,
                       required=False),
 
@@ -709,6 +716,7 @@ def main():
                                            "ipaadmin_principal")
     ipaadmin_password = module_params_get(ansible_module,
                                           "ipaadmin_password")
+    ipa_context = module_params_get(ansible_module, "ipa_context")
     names = module_params_get(ansible_module, "name")
     hosts = module_params_get(ansible_module, "hosts")
 
@@ -792,7 +800,7 @@ def main():
         if not valid_creds(ansible_module, ipaadmin_principal):
             ccache_dir, ccache_name = temp_kinit(ipaadmin_principal,
                                                  ipaadmin_password)
-        api_connect()
+        api_connect(ipa_context)
 
         # Check version specific settings
 

--- a/plugins/modules/ipahostgroup.py
+++ b/plugins/modules/ipahostgroup.py
@@ -39,6 +39,13 @@ options:
   ipaadmin_password:
     description: The admin password
     required: false
+  ipa_context:
+    description: |
+      The context in which the module will execute. Executing in a server
+      context is preferred, use `client` to execute in a client context if
+      the server cannot be accessed.
+    choices: ["server", "client"]
+    default: server
   name:
     description: The hostgroup name
     required: false
@@ -190,7 +197,8 @@ def main():
             # general
             ipaadmin_principal=dict(type="str", default="admin"),
             ipaadmin_password=dict(type="str", required=False, no_log=True),
-
+            ipa_context=dict(type="str", required=False, default="server",
+                             choices=["server", "client"]),
             name=dict(type="list", aliases=["cn"], default=None,
                       required=True),
             # present
@@ -221,6 +229,7 @@ def main():
                                            "ipaadmin_principal")
     ipaadmin_password = module_params_get(ansible_module,
                                           "ipaadmin_password")
+    ipa_context = module_params_get(ansible_module, "ipa_context")
     names = module_params_get(ansible_module, "name")
 
     # present
@@ -293,7 +302,7 @@ def main():
         if not valid_creds(ansible_module, ipaadmin_principal):
             ccache_dir, ccache_name = temp_kinit(ipaadmin_principal,
                                                  ipaadmin_password)
-        api_connect()
+        api_connect(ipa_context)
 
         has_add_membermanager = api_check_command(
             "hostgroup_add_member_manager")

--- a/plugins/modules/ipalocation.py
+++ b/plugins/modules/ipalocation.py
@@ -38,6 +38,13 @@ options:
   ipaadmin_password:
     description: The admin password.
     required: false
+  ipa_context:
+    description: |
+      The context in which the module will execute. Executing in a server
+      context is preferred, use `client` to execute in a client context if
+      the server cannot be accessed.
+    choices: ["server", "client"]
+    default: server
   name:
     description: The list of location name strings.
     required: true
@@ -104,7 +111,8 @@ def main():
             # general
             ipaadmin_principal=dict(type="str", default="admin"),
             ipaadmin_password=dict(type="str", required=False, no_log=True),
-
+            ipa_context=dict(type="str", required=False, default="server",
+                             choices=["server", "client"]),
             name=dict(type="list", aliases=["idnsname"],
                       default=None, required=True),
             # present
@@ -124,6 +132,7 @@ def main():
     ipaadmin_principal = module_params_get(ansible_module,
                                            "ipaadmin_principal")
     ipaadmin_password = module_params_get(ansible_module, "ipaadmin_password")
+    ipa_context = module_params_get(ansible_module, "ipa_context")
     names = module_params_get(ansible_module, "name")
 
     # present
@@ -159,7 +168,7 @@ def main():
         if not valid_creds(ansible_module, ipaadmin_principal):
             ccache_dir, ccache_name = temp_kinit(ipaadmin_principal,
                                                  ipaadmin_password)
-        api_connect()
+        api_connect(ipa_context)
 
         commands = []
         for name in names:

--- a/plugins/modules/ipaprivilege.py
+++ b/plugins/modules/ipaprivilege.py
@@ -41,6 +41,13 @@ options:
   ipaadmin_password:
     description: The admin password.
     required: false
+  ipa_context:
+    description: |
+      The context in which the module will execute. Executing in a server
+      context is preferred, use `client` to execute in a client context if
+      the server cannot be accessed.
+    choices: ["server", "client"]
+    default: server
   name:
     description: The list of privilege name strings.
     required: true
@@ -138,7 +145,8 @@ def main():
             # general
             ipaadmin_principal=dict(type="str", default="admin"),
             ipaadmin_password=dict(type="str", required=False, no_log=True),
-
+            ipa_context=dict(type="str", required=False, default="server",
+                             choices=["server", "client"]),
             name=dict(type="list", aliases=["cn"],
                       default=None, required=True),
             # present
@@ -163,6 +171,7 @@ def main():
     ipaadmin_principal = module_params_get(ansible_module,
                                            "ipaadmin_principal")
     ipaadmin_password = module_params_get(ansible_module, "ipaadmin_password")
+    ipa_context = module_params_get(ansible_module, "ipa_context")
     names = module_params_get(ansible_module, "name")
 
     # present
@@ -217,7 +226,7 @@ def main():
         if not valid_creds(ansible_module, ipaadmin_principal):
             ccache_dir, ccache_name = temp_kinit(ipaadmin_principal,
                                                  ipaadmin_password)
-        api_connect()
+        api_connect(ipa_context)
 
         commands = []
         for name in names:

--- a/plugins/modules/ipapwpolicy.py
+++ b/plugins/modules/ipapwpolicy.py
@@ -38,6 +38,13 @@ options:
   ipaadmin_password:
     description: The admin password
     required: false
+  ipa_context:
+    description: |
+      The context in which the module will execute. Executing in a server
+      context is preferred, use `client` to execute in a client context if
+      the server cannot be accessed.
+    choices: ["server", "client"]
+    default: server
   name:
     description: The group name
     required: false
@@ -165,7 +172,8 @@ def main():
             # general
             ipaadmin_principal=dict(type="str", default="admin"),
             ipaadmin_password=dict(type="str", required=False, no_log=True),
-
+            ipa_context=dict(type="str", required=False, default="server",
+                             choices=["server", "client"]),
             name=dict(type="list", aliases=["cn"], default=None,
                       required=False),
             # present
@@ -200,6 +208,7 @@ def main():
     # general
     ipaadmin_principal = ansible_module.params.get("ipaadmin_principal")
     ipaadmin_password = ansible_module.params.get("ipaadmin_password")
+    ipa_context = ansible_module.params.get("ipa_context")
     names = ansible_module.params.get("name")
 
     # present
@@ -251,7 +260,7 @@ def main():
         if not valid_creds(ansible_module, ipaadmin_principal):
             ccache_dir, ccache_name = temp_kinit(ipaadmin_principal,
                                                  ipaadmin_password)
-        api_connect()
+        api_connect(ipa_context)
 
         commands = []
 

--- a/plugins/modules/iparole.py
+++ b/plugins/modules/iparole.py
@@ -40,6 +40,13 @@ options:
   ipaadmin_password:
     description: The admin password.
     required: false
+  ipa_context:
+    description: |
+      The context in which the module will execute. Executing in a server
+      context is preferred, use `client` to execute in a client context if
+      the server cannot be accessed.
+    choices: ["server", "client"]
+    default: server
   role:
     description: The list of role name strings.
     required: true
@@ -425,7 +432,8 @@ def create_module():
             # generalgroups
             ipaadmin_principal=dict(type="str", default="admin"),
             ipaadmin_password=dict(type="str", required=False, no_log=True),
-
+            ipa_context=dict(type="str", required=False, default="server",
+                             choices=["server", "client"]),
             name=dict(type="list", aliases=["cn"], default=None,
                       required=True),
             # present
@@ -459,6 +467,7 @@ def create_module():
 def main():
     """Process role module script."""
     ansible_module = create_module()
+    ipa_context = module_params_get(ansible_module, "ipa_context")
     check_parameters(ansible_module)
 
     # Init
@@ -466,7 +475,7 @@ def main():
     ccache_name = None
     try:
         ccache_dir, ccache_name = verify_credentials(ansible_module)
-        api_connect()
+        api_connect(ipa_context)
 
         state = module_params_get(ansible_module, "state")
         action = module_params_get(ansible_module, "action")

--- a/plugins/modules/ipaselfservice.py
+++ b/plugins/modules/ipaselfservice.py
@@ -38,6 +38,13 @@ options:
   ipaadmin_password:
     description: The admin password.
     required: false
+  ipa_context:
+    description: |
+      The context in which the module will execute. Executing in a server
+      context is preferred, use `client` to execute in a client context if
+      the server cannot be accessed.
+    choices: ["server", "client"]
+    default: server
   name:
     description: The list of selfservice name strings.
     required: true
@@ -140,7 +147,8 @@ def main():
             # general
             ipaadmin_principal=dict(type="str", default="admin"),
             ipaadmin_password=dict(type="str", required=False, no_log=True),
-
+            ipa_context=dict(type="str", required=False, default="server",
+                             choices=["server", "client"]),
             name=dict(type="list", aliases=["aciname"], default=None,
                       required=True),
             # present
@@ -165,6 +173,7 @@ def main():
     ipaadmin_principal = module_params_get(ansible_module,
                                            "ipaadmin_principal")
     ipaadmin_password = module_params_get(ansible_module, "ipaadmin_password")
+    ipa_context = module_params_get(ansible_module, "ipa_context")
     names = module_params_get(ansible_module, "name")
 
     # present
@@ -225,7 +234,7 @@ def main():
         if not valid_creds(ansible_module, ipaadmin_principal):
             ccache_dir, ccache_name = temp_kinit(ipaadmin_principal,
                                                  ipaadmin_password)
-        api_connect()
+        api_connect(ipa_context)
 
         commands = []
         for name in names:

--- a/plugins/modules/ipaserver.py
+++ b/plugins/modules/ipaserver.py
@@ -38,6 +38,13 @@ options:
   ipaadmin_password:
     description: The admin password.
     required: false
+  ipa_context:
+    description: |
+      The context in which the module will execute. Executing in a server
+      context is preferred, use `client` to execute in a client context if
+      the server cannot be accessed.
+    choices: ["server", "client"]
+    default: server
   name:
     description: The list of server name strings.
     required: true
@@ -251,7 +258,8 @@ def main():
             # general
             ipaadmin_principal=dict(type="str", default="admin"),
             ipaadmin_password=dict(type="str", required=False, no_log=True),
-
+            ipa_context=dict(type="str", required=False, default="server",
+                             choices=["server", "client"]),
             name=dict(type="list", aliases=["cn"],
                       default=None, required=True),
             # present
@@ -285,6 +293,7 @@ def main():
     ipaadmin_principal = module_params_get(ansible_module,
                                            "ipaadmin_principal")
     ipaadmin_password = module_params_get(ansible_module, "ipaadmin_password")
+    ipa_context = module_params_get(ansible_module, "ipa_context")
     names = module_params_get(ansible_module, "name")
 
     # present
@@ -344,7 +353,7 @@ def main():
         if not valid_creds(ansible_module, ipaadmin_principal):
             ccache_dir, ccache_name = temp_kinit(ipaadmin_principal,
                                                  ipaadmin_password)
-        api_connect()
+        api_connect(ipa_context)
 
         commands = []
         for name in names:

--- a/plugins/modules/ipaservice.py
+++ b/plugins/modules/ipaservice.py
@@ -39,6 +39,13 @@ options:
   ipaadmin_password:
     description: The admin password
     required: false
+  ipa_context:
+    description: |
+      The context in which the module will execute. Executing in a server
+      context is preferred, use `client` to execute in a client context if
+      the server cannot be accessed.
+    choices: ["server", "client"]
+    default: server
   name:
     description: The service to manage
     required: true
@@ -354,7 +361,8 @@ def init_ansible_module():
             # general
             ipaadmin_principal=dict(type="str", default="admin"),
             ipaadmin_password=dict(type="str", required=False, no_log=True),
-
+            ipa_context=dict(type="str", required=False, default="server",
+                             choices=["server", "client"]),
             name=dict(type="list", aliases=["service"], default=None,
                       required=True),
             # service attributesstr
@@ -427,6 +435,7 @@ def main():
     ipaadmin_principal = module_params_get(ansible_module,
                                            "ipaadmin_principal")
     ipaadmin_password = module_params_get(ansible_module, "ipaadmin_password")
+    ipa_context = module_params_get(ansible_module, "ipa_context")
     names = module_params_get(ansible_module, "name")
 
     # service attributes
@@ -483,7 +492,7 @@ def main():
         if not valid_creds(ansible_module, ipaadmin_principal):
             ccache_dir, ccache_name = temp_kinit(ipaadmin_principal,
                                                  ipaadmin_password)
-        api_connect()
+        api_connect(ipa_context)
 
         has_skip_host_check = api_check_param(
             "service_add", "skip_host_check")

--- a/plugins/modules/ipasudocmd.py
+++ b/plugins/modules/ipasudocmd.py
@@ -39,6 +39,13 @@ options:
   ipaadmin_password:
     description: The admin password
     required: false
+  ipa_context:
+    description: |
+      The context in which the module will execute. Executing in a server
+      context is preferred, use `client` to execute in a client context if
+      the server cannot be accessed.
+    choices: ["server", "client"]
+    default: server
   name:
     description: The sudo command
     required: true
@@ -108,7 +115,8 @@ def main():
             # general
             ipaadmin_principal=dict(type="str", default="admin"),
             ipaadmin_password=dict(type="str", required=False, no_log=True),
-
+            ipa_context=dict(type="str", required=False, default="server",
+                             choices=["server", "client"]),
             name=dict(type="list", aliases=["sudocmd"], default=None,
                       required=True),
             # present
@@ -127,6 +135,7 @@ def main():
     # general
     ipaadmin_principal = ansible_module.params.get("ipaadmin_principal")
     ipaadmin_password = ansible_module.params.get("ipaadmin_password")
+    ipa_context = ansible_module.params.get("ipa_context")
     names = ansible_module.params.get("name")
 
     # present
@@ -153,7 +162,7 @@ def main():
         if not valid_creds(ansible_module, ipaadmin_principal):
             ccache_dir, ccache_name = temp_kinit(ipaadmin_principal,
                                                  ipaadmin_password)
-        api_connect()
+        api_connect(ipa_context)
 
         commands = []
 

--- a/plugins/modules/ipasudocmdgroup.py
+++ b/plugins/modules/ipasudocmdgroup.py
@@ -39,6 +39,13 @@ options:
   ipaadmin_password:
     description: The admin password
     required: false
+  ipa_context:
+    description: |
+      The context in which the module will execute. Executing in a server
+      context is preferred, use `client` to execute in a client context if
+      the server cannot be accessed.
+    choices: ["server", "client"]
+    default: server
   name:
     description: The sudocmodgroup name
     required: false
@@ -145,7 +152,8 @@ def main():
             # general
             ipaadmin_principal=dict(type="str", default="admin"),
             ipaadmin_password=dict(type="str", required=False, no_log=True),
-
+            ipa_context=dict(type="str", required=False, default="server",
+                             choices=["server", "client"]),
             name=dict(type="list", aliases=["cn"], default=None,
                       required=True),
             # present
@@ -168,6 +176,7 @@ def main():
     # general
     ipaadmin_principal = ansible_module.params.get("ipaadmin_principal")
     ipaadmin_password = ansible_module.params.get("ipaadmin_password")
+    ipa_context = ansible_module.params.get("ipa_context")
     names = ansible_module.params.get("name")
 
     # present
@@ -215,7 +224,7 @@ def main():
         if not valid_creds(ansible_module, ipaadmin_principal):
             ccache_dir, ccache_name = temp_kinit(ipaadmin_principal,
                                                  ipaadmin_password)
-        api_connect()
+        api_connect(ipa_context)
 
         commands = []
 

--- a/plugins/modules/ipasudorule.py
+++ b/plugins/modules/ipasudorule.py
@@ -38,6 +38,13 @@ options:
   ipaadmin_password:
     description: The admin password
     required: false
+  ipa_context:
+    description: |
+      The context in which the module will execute. Executing in a server
+      context is preferred, use `client` to execute in a client context if
+      the server cannot be accessed.
+    choices: ["server", "client"]
+    default: server
   name:
     description: The sudorule name
     required: true
@@ -240,7 +247,8 @@ def main():
             # general
             ipaadmin_principal=dict(type="str", default="admin"),
             ipaadmin_password=dict(type="str", required=False, no_log=True),
-
+            ipa_context=dict(type="str", required=False, default="server",
+                             choices=["server", "client"]),
             name=dict(type="list", aliases=["cn"], default=None,
                       required=True),
             # present
@@ -289,6 +297,7 @@ def main():
     ipaadmin_principal = module_params_get(ansible_module,
                                            "ipaadmin_principal")
     ipaadmin_password = module_params_get(ansible_module, "ipaadmin_password")
+    ipa_context = module_params_get(ansible_module, "ipa_context")
     names = module_params_get(ansible_module, "name")
 
     # present
@@ -399,7 +408,7 @@ def main():
         if not valid_creds(ansible_module, ipaadmin_principal):
             ccache_dir, ccache_name = temp_kinit(ipaadmin_principal,
                                                  ipaadmin_password)
-        api_connect()
+        api_connect(ipa_context)
 
         commands = []
 

--- a/plugins/modules/ipatopologysegment.py
+++ b/plugins/modules/ipatopologysegment.py
@@ -38,6 +38,13 @@ options:
   ipaadmin_password:
     description: The admin password
     required: false
+  ipa_context:
+    description: |
+      The context in which the module will execute. Executing in a server
+      context is preferred, use `client` to execute in a client context if
+      the server cannot be accessed.
+    choices: ["server", "client"]
+    default: server
   suffix:
     description: Topology suffix
     required: true
@@ -178,6 +185,8 @@ def main():
         argument_spec=dict(
             ipaadmin_principal=dict(type="str", default="admin"),
             ipaadmin_password=dict(type="str", required=False, no_log=True),
+            ipa_context=dict(type="str", required=False, default="server",
+                             choices=["server", "client"]),
             suffix=dict(choices=["domain", "ca", "domain+ca"], required=True),
             name=dict(type="str", aliases=["cn"], default=None),
             left=dict(type="str", aliases=["leftnode"], default=None),
@@ -197,6 +206,7 @@ def main():
 
     ipaadmin_principal = ansible_module.params.get("ipaadmin_principal")
     ipaadmin_password = ansible_module.params.get("ipaadmin_password")
+    ipa_context = ansible_module.params.get("ipa_context")
     suffixes = ansible_module.params.get("suffix")
     name = ansible_module.params.get("name")
     left = ansible_module.params.get("left")
@@ -220,7 +230,7 @@ def main():
         if not valid_creds(ansible_module, ipaadmin_principal):
             ccache_dir, ccache_name = temp_kinit(ipaadmin_principal,
                                                  ipaadmin_password)
-        api_connect()
+        api_connect(ipa_context)
 
         commands = []
 

--- a/plugins/modules/ipatrust.py
+++ b/plugins/modules/ipatrust.py
@@ -38,6 +38,13 @@ options:
     description:
     - Realm name
     required: true
+  ipa_context:
+    description: |
+      The context in which the module will execute. Executing in a server
+      context is preferred, use `client` to execute in a client context if
+      the server cannot be accessed.
+    choices: ["server", "client"]
+    default: server
   trust_type:
     description:
     - Trust type (ad for Active Directory, default)
@@ -179,6 +186,8 @@ def main():
             # general
             ipaadmin_principal=dict(type="str", default="admin"),
             ipaadmin_password=dict(type="str", required=False, no_log=True),
+            ipa_context=dict(type="str", required=False, default="server",
+                             choices=["server", "client"]),
             realm=dict(type="str", default=None, required=True),
             # state
             state=dict(type="str", default="present",
@@ -210,6 +219,7 @@ def main():
     ipaadmin_principal = module_params_get(
         ansible_module, "ipaadmin_principal")
     ipaadmin_password = module_params_get(ansible_module, "ipaadmin_password")
+    ipa_context = module_params_get(ansible_module, "ipa_context")
     realm = module_params_get(ansible_module, "realm")
 
     # state
@@ -235,7 +245,7 @@ def main():
         if not valid_creds(ansible_module, ipaadmin_principal):
             ccache_dir, ccache_name = temp_kinit(
                 ipaadmin_principal, ipaadmin_password)
-        api_connect()
+        api_connect(ipa_context)
         res_find = find_trust(ansible_module, realm)
 
         if state == "absent":

--- a/plugins/modules/ipauser.py
+++ b/plugins/modules/ipauser.py
@@ -38,6 +38,13 @@ options:
   ipaadmin_password:
     description: The admin password
     required: false
+  ipa_context:
+    description: |
+      The context in which the module will execute. Executing in a server
+      context is preferred, use `client` to execute in a client context if
+      the server cannot be accessed.
+    choices: ["server", "client"]
+    default: server
   name:
     description: The list of users (internally uid).
     required: false
@@ -797,7 +804,8 @@ def main():
             # general
             ipaadmin_principal=dict(type="str", default="admin"),
             ipaadmin_password=dict(type="str", required=False, no_log=True),
-
+            ipa_context=dict(type="str", required=False, default="server",
+                             choices=["server", "client"]),
             name=dict(type="list", aliases=["login"], default=None,
                       required=False),
             users=dict(type="list", aliases=["login"], default=None,
@@ -839,6 +847,7 @@ def main():
     ipaadmin_principal = module_params_get(ansible_module,
                                            "ipaadmin_principal")
     ipaadmin_password = module_params_get(ansible_module, "ipaadmin_password")
+    ipa_context = module_params_get(ansible_module, "ipa_context")
     names = module_params_get(ansible_module, "name")
     users = module_params_get(ansible_module, "users")
 
@@ -936,7 +945,7 @@ def main():
         if not valid_creds(ansible_module, ipaadmin_principal):
             ccache_dir, ccache_name = temp_kinit(ipaadmin_principal,
                                                  ipaadmin_password)
-        api_connect()
+        api_connect(ipa_context)
 
         # Check version specific settings
 

--- a/plugins/modules/ipavault.py
+++ b/plugins/modules/ipavault.py
@@ -592,7 +592,9 @@ def main():
             # generalgroups
             ipaadmin_principal=dict(type="str", default="admin"),
             ipaadmin_password=dict(type="str", required=False, no_log=True),
-
+            # Currently vault does not work on 'server' context.
+            # ipa_context=dict(type="str", required=False, default="server",
+            #                  choices=["server", "client"]),
             name=dict(type="list", aliases=["cn"], default=None,
                       required=True),
 
@@ -738,11 +740,9 @@ def main():
         if not valid_creds(ansible_module, ipaadmin_principal):
             ccache_dir, ccache_name = temp_kinit(ipaadmin_principal,
                                                  ipaadmin_password)
-            # Need to set krb5 ccache name, due to context='ansible-freeipa'
-            if ccache_name is not None:
-                os.environ["KRB5CCNAME"] = ccache_name
 
-        api_connect(context='ansible-freeipa')
+        # currently, ipavault only works on client context.
+        api_connect(context='client')
 
         commands = []
 

--- a/tests/automember/test_automember_client_context.yml
+++ b/tests/automember/test_automember_client_context.yml
@@ -1,0 +1,99 @@
+---
+- name: Test automember
+  hosts: ipaclients
+  become: true
+
+  tasks:
+  - block:  # only execute tests if groups['ipaclients'] is defined.
+    # CLEANUP TEST ITEMS
+    - name: Ensure group testgroup is absent
+      ipagroup:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: testgroup
+        state: absent
+
+    - name: Ensure group automember rule testgroup is absent
+      ipaautomember:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: testgroup
+        state: absent
+        automember_type: group
+
+    # CREATE TEST ITEMS
+    - name: Ensure testgroup group is present
+      ipagroup:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: testgroup
+
+    # START TESTS
+    - name: Execute with server context in the client.
+      ipaautomember:
+        ipaadmin_password: SomeADMINpassword
+        name: testgroup
+        description: testgroup automember rule.
+        automember_type: group
+      register: result
+      failed_when: not (result.failed and "No module named 'ipaserver'" in result.msg)
+
+    - name: Ensure testgroup group automember rule is present
+      ipaautomember:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: testgroup
+        description: testgroup automember rule.
+        automember_type: group
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: Ensure testgroup group automember rule is present again
+      ipaautomember:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: testgroup
+        description: testgroup automember rule.
+        automember_type: group
+      register: result
+      failed_when: result.changed or result.failed
+
+    - name: Ensure testgroup group automember rule is absent
+      ipaautomember:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: testgroup
+        description: testgroup automember rule.
+        automember_type: group
+        state: absent
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: Ensure testgroup group automember rule is absent, again
+      ipaautomember:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: testgroup
+        description: testgroup automember rule.
+        automember_type: group
+        state: absent
+      register: result
+      failed_when: result.changed or result.failed
+
+     # CLEANUP TEST ITEMS
+    - name: Ensure group testgroup is absent
+      ipagroup:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: testgroup
+        state: absent
+
+    - name: Ensure group automember rule testgroup is absent
+      ipaautomember:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        automember_type: group
+        name: testgroup
+        state: absent
+
+    when: groups['ipaclients'] is defined

--- a/tests/config/test_config.yml
+++ b/tests/config/test_config.yml
@@ -14,12 +14,12 @@
     register: previousconfig
 
   - debug:
-      msg: "{{previousconfig}}"
+      var: previousconfig
 
   # setup environment.
   - name: create test group
     ipagroup:
-      ipaadmin_password: 'SomeADMINpassword'
+      ipaadmin_password: SomeADMINpassword
       name: somedefaultgroup
 
   - name: Ensure the default e-mail domain is ipa.test.
@@ -249,14 +249,14 @@
   - name: change enable_migration
     ipaconfig:
       ipaadmin_password: SomeADMINpassword
-      enable_migration: '{{ not previousconfig.config.enable_migration }}'
+      enable_migration: '{{ not (previousconfig.config.enable_migration | bool) }}'
     register: result
     failed_when: not result.changed or result.failed
 
   - name: change enable_migration, again
     ipaconfig:
       ipaadmin_password: SomeADMINpassword
-      enable_migration: '{{ not previousconfig.config.enable_migration }}'
+      enable_migration: '{{ not (previousconfig.config.enable_migration | bool) }}'
     register: result
     failed_when: result.changed or result.failed
 
@@ -332,27 +332,27 @@
 
   - name: reset changed fields
     ipaconfig:
-      ipaadmin_password: 'SomeADMINpassword'
-      maxusername: '{{previousconfig.config.maxusername | default(omit)}}'
-      homedirectory: '{{previousconfig.config.homedirectory | default(omit)}}'
-      defaultshell: '{{previousconfig.config.defaultshell | default(omit)}}'
-      defaultgroup: '{{previousconfig.config.defaultgroup | default(omit)}}'
-      emaildomain: '{{previousconfig.config.emaildomain | default(omit)}}'
-      searchtimelimit: '{{previousconfig.config.searchtimelimit | default(omit)}}'
-      searchrecordslimit: '{{previousconfig.config.searchrecordslimit | default(omit)}}'
-      usersearch: '{{previousconfig.config.usersearch | default(omit)}}'
-      groupsearch: '{{previousconfig.config.groupsearch | default(omit)}}'
-      enable_migration: '{{previousconfig.config.enable_migration | default(omit)}}'
-      groupobjectclasses: '{{previousconfig.config.groupobjectclasses | default(omit)}}'
-      userobjectclasses: '{{previousconfig.config.userobjectclasses | default(omit)}}'
-      pwdexpnotify: '{{previousconfig.config.pwdexpnotify | default(omit)}}'
-      configstring: '{{previousconfig.config.configstring | default(omit)}}'
-      selinuxusermapdefault: '{{previousconfig.config.selinuxusermapdefault | default(omit)}}'
-      selinuxusermaporder: '{{previousconfig.config.selinuxusermaporder | default(omit)}}'
-      pac_type: '{{previousconfig.config.pac_type | default(omit)}}'
-      user_auth_type: '{{previousconfig.config.user_auth_type | default(omit)}}'
-      domain_resolution_order: '{{previousconfig.config.domain_resolution_order | default(omit)}}'
-      ca_renewal_master_server: '{{previousconfig.config.ca_renewal_master_server | default(omit)}}'
+      ipaadmin_password: SomeADMINpassword
+      maxusername: '{{ previousconfig.config.maxusername | default(omit) | int }}'
+      homedirectory: '{{ previousconfig.config.homedirectory | default(omit)}}'
+      defaultshell: '{{ previousconfig.config.defaultshell | default(omit)}}'
+      defaultgroup: '{{ previousconfig.config.defaultgroup | default(omit)}}'
+      emaildomain: '{{ previousconfig.config.emaildomain | default(omit)}}'
+      searchtimelimit: '{{ previousconfig.config.searchtimelimit | default(omit) | int }}'
+      searchrecordslimit: '{{ previousconfig.config.searchrecordslimit | default(omit) | int }}'
+      usersearch: '{{ previousconfig.config.usersearch | default(omit) }}'
+      groupsearch: '{{ previousconfig.config.groupsearch | default(omit) }}'
+      enable_migration: '{{ previousconfig.config.enable_migration | default(omit) | bool }}'
+      groupobjectclasses: '{{ previousconfig.config.groupobjectclasses | default(omit) }}'
+      userobjectclasses: '{{ previousconfig.config.userobjectclasses | default(omit) }}'
+      pwdexpnotify: '{{ previousconfig.config.pwdexpnotify | default(omit) | int }}'
+      configstring: '{{ previousconfig.config.configstring | default(omit) }}'
+      selinuxusermapdefault: '{{ previousconfig.config.selinuxusermapdefault | default(omit) }}'
+      selinuxusermaporder: '{{ previousconfig.config.selinuxusermaporder | default(omit) }}'
+      pac_type: '{{ previousconfig.config.pac_type | default(omit) }}'
+      user_auth_type: '{{ previousconfig.config.user_auth_type | default(omit) }}'
+      domain_resolution_order: '{{ previousconfig.config.domain_resolution_order | default(omit) }}'
+      ca_renewal_master_server: '{{ previousconfig.config.ca_renewal_master_server | default(omit) }}'
     register: result
     failed_when: not result.changed or result.failed
 
@@ -360,32 +360,32 @@
     block:
       - ipaconfig:
           ipaadmin_password: SomeADMINpassword
-          maxhostname: '{{previousconfig.config.maxhostname | default(omit)}}'
+          maxhostname: '{{ previousconfig.config.maxhostname | default(omit) }}'
     when: ipa_version is version('4.8.0', '>=')
 
   - name: reset changed fields, again
     ipaconfig:
-      ipaadmin_password: 'SomeADMINpassword'
-      maxusername: '{{previousconfig.config.maxusername | default(omit)}}'
-      homedirectory: '{{previousconfig.config.homedirectory | default(omit)}}'
-      defaultshell: '{{previousconfig.config.defaultshell | default(omit)}}'
-      defaultgroup: '{{previousconfig.config.defaultgroup | default(omit)}}'
-      emaildomain: '{{previousconfig.config.emaildomain | default(omit)}}'
-      searchtimelimit: '{{previousconfig.config.searchtimelimit | default(omit)}}'
-      searchrecordslimit: '{{previousconfig.config.searchrecordslimit | default(omit)}}'
-      usersearch: '{{previousconfig.config.usersearch | default(omit)}}'
-      groupsearch: '{{previousconfig.config.groupsearch | default(omit)}}'
-      enable_migration: '{{previousconfig.config.enable_migration | default(omit)}}'
-      groupobjectclasses: '{{previousconfig.config.groupobjectclasses | default(omit)}}'
-      userobjectclasses: '{{previousconfig.config.userobjectclasses | default(omit)}}'
-      pwdexpnotify: '{{previousconfig.config.pwdexpnotify | default(omit)}}'
-      configstring: '{{previousconfig.config.configstring | default(omit)}}'
-      selinuxusermapdefault: '{{previousconfig.config.selinuxusermapdefault | default(omit)}}'
-      selinuxusermaporder: '{{previousconfig.config.selinuxusermaporder | default(omit)}}'
-      pac_type: '{{previousconfig.config.pac_type | default(omit)}}'
-      user_auth_type: '{{previousconfig.config.user_auth_type | default(omit)}}'
-      domain_resolution_order: '{{previousconfig.config.domain_resolution_order | default(omit)}}'
-      ca_renewal_master_server: '{{previousconfig.config.ca_renewal_master_server | default(omit)}}'
+      ipaadmin_password: SomeADMINpassword
+      maxusername: '{{previousconfig.config.maxusername | default(omit) | int }}'
+      homedirectory: '{{previousconfig.config.homedirectory | default(omit) }}'
+      defaultshell: '{{previousconfig.config.defaultshell | default(omit) }}'
+      defaultgroup: '{{previousconfig.config.defaultgroup | default(omit) }}'
+      emaildomain: '{{previousconfig.config.emaildomain | default(omit) }}'
+      searchtimelimit: '{{previousconfig.config.searchtimelimit | default(omit) | int }}'
+      searchrecordslimit: '{{previousconfig.config.searchrecordslimit | default(omit) | int }}'
+      usersearch: '{{previousconfig.config.usersearch | default(omit) }}'
+      groupsearch: '{{previousconfig.config.groupsearch | default(omit) }}'
+      enable_migration: '{{previousconfig.config.enable_migration | default(omit) | bool }}'
+      groupobjectclasses: '{{previousconfig.config.groupobjectclasses | default(omit) }}'
+      userobjectclasses: '{{previousconfig.config.userobjectclasses | default(omit) }}'
+      pwdexpnotify: '{{previousconfig.config.pwdexpnotify | default(omit) | int }}'
+      configstring: '{{previousconfig.config.configstring | default(omit) }}'
+      selinuxusermapdefault: '{{previousconfig.config.selinuxusermapdefault | default(omit) }}'
+      selinuxusermaporder: '{{previousconfig.config.selinuxusermaporder | default(omit) }}'
+      pac_type: '{{previousconfig.config.pac_type | default(omit) }}'
+      user_auth_type: '{{previousconfig.config.user_auth_type | default(omit) }}'
+      domain_resolution_order: '{{previousconfig.config.domain_resolution_order | default(omit) }}'
+      ca_renewal_master_server: '{{previousconfig.config.ca_renewal_master_server | default(omit) }}'
     register: result
     failed_when: result.changed or result.failed
 
@@ -393,13 +393,13 @@
     block:
       - ipaconfig:
           ipaadmin_password: SomeADMINpassword
-          maxhostname: '{{previousconfig.config.maxhostname | default(omit)}}'
+          maxhostname: '{{ previousconfig.config.maxhostname | default(omit) }}'
     when: ipa_version is version('4.8.0', '>=')
 
   # cleanup
 
   - name: cleanup test group
     ipagroup:
-      ipaadmin_password: 'SomeADMINpassword'
+      ipaadmin_password: SomeADMINpassword
       name: somedefaultgroup
       state: absent

--- a/tests/config/test_config_client_context.yml
+++ b/tests/config/test_config_client_context.yml
@@ -1,0 +1,471 @@
+---
+- name: Playbook to handle server configuration
+  hosts: ipaclients
+  become: true
+  gather_facts: false
+
+  tasks:
+  - block: # only execute tests if groups['ipaclients'] is defined.
+
+    - include_tasks: ../env_freeipa_facts.yml
+
+    # Retrieve current configuration.
+    - name: return current values of the global configuration options
+      ipaconfig:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+      register: previousconfig
+
+    - debug:
+        msg: "{{previousconfig}}"
+
+    # setup environment.
+    - name: Ensure the default e-mail domain is ipa.test.
+      ipaconfig:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        emaildomain: ipa.test
+
+    - name: set default shell to '/bin/sh'
+      ipaconfig:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        defaultshell: /bin/sh
+
+    - name: set default group
+      ipaconfig:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        defaultgroup: ipausers
+
+    - name: set default home directory
+      ipaconfig:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        homedirectory: /home
+
+    - name: clear pac-type
+      ipaconfig:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        pac_type: ""
+
+    - name: set maxhostname to 255
+      block:
+        - ipaconfig:
+            ipaadmin_password: SomeADMINpassword
+            ipa_context: client
+            maxhostname: 255
+      when: ipa_version is version('4.8.0', '>=')
+
+    - name: set maxusername to 45
+      ipaconfig:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        maxusername: 45
+
+    - name: set pwdexpnotify to 0
+      ipaconfig:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        pwdexpnotify: 0
+
+    - name: set searchrecordslimit to 10
+      ipaconfig:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        searchrecordslimit: 10
+
+    - name: set searchtimelimit to 1
+      ipaconfig:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        searchtimelimit: 1
+
+    - name: clear configstring
+      ipaconfig:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        configstring: ""
+
+    - name: set configstring to AllowNThash
+      ipaconfig:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        configstring: 'KDC:Disable Lockout'
+
+    - name: set selinuxusermapdefault
+      ipaconfig:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        selinuxusermapdefault: "staff_u:s0-s0:c0.c1023"
+
+    - name: set selinuxusermaporder
+      ipaconfig:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        selinuxusermaporder: 'user_u:s0$staff_u:s0-s0:c0.c1023'
+
+    - name: set usersearch to `uid`
+      ipaconfig:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        usersearch: uid
+
+    - name: set groupsearch to `cn`
+      ipaconfig:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        groupsearch: cn
+
+    - name: create test group
+      ipagroup:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: somedefaultgroup
+
+    # tests
+    - name: Execute with server context in the client.
+      ipaconfig:
+        ipaadmin_password: SomeADMINpassword
+        maxusername: 45
+      register: result
+      failed_when: not (result.failed and "No module named 'ipaserver'" in result.msg)
+
+    - name: Ensure the default e-mail domain is somedomain.test.
+      ipaconfig:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        emaildomain: somedomain.test
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: Ensure the default e-mail domain is somedomain.test, again.
+      ipaconfig:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        emaildomain: somedomain.test
+      register: result
+      failed_when: result.changed or result.failed
+
+    - name: set default shell to '/bin/someshell'
+      ipaconfig:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        defaultshell: /bin/someshell
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: set default shell to '/bin/someshell', again.
+      ipaconfig:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        defaultshell: /bin/someshell
+      register: result
+      failed_when: result.changed or result.failed
+
+    - name: set default group
+      ipaconfig:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        defaultgroup: somedefaultgroup
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: set default group, again
+      ipaconfig:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        defaultgroup: somedefaultgroup
+      register: result
+      failed_when: result.changed or result.failed
+
+    - name: set default home directory
+      ipaconfig:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        homedirectory: /Users
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: set default home directory, again
+      ipaconfig:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        homedirectory: /Users
+      register: result
+      failed_when: result.changed or result.failed
+
+    - name: set pac-type
+      ipaconfig:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        pac_type: "nfs:NONE"
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: set pac-type, again.
+      ipaconfig:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        pac_type: "nfs:NONE"
+      register: result
+      failed_when: result.changed or result.failed
+
+    - name: set maxusername to 33
+      ipaconfig:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        maxusername: 33
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: set maxusername to 33, again.
+      ipaconfig:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        maxusername: 33
+      register: result
+      failed_when: result.changed or result.failed
+
+    - name: set maxhostname to 77
+      block:
+        - ipaconfig:
+            ipaadmin_password: SomeADMINpassword
+            ipa_context: client
+            maxhostname: 77
+          register: result
+          failed_when: not result.changed or result.failed
+
+        - ipaconfig:
+            ipaadmin_password: SomeADMINpassword
+            ipa_context: client
+            maxhostname: 77
+          register: result
+          failed_when: result.changed or result.failed
+      when: ipa_version is version('4.8.0', '>=')
+
+    - name: set pwdexpnotify to 17
+      ipaconfig:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        pwdexpnotify: 17
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: set pwdexpnotify to 17, again
+      ipaconfig:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        pwdexpnotify: 17
+      register: result
+      failed_when: result.changed or result.failed
+
+    - name: set searchrecordslimit to -1
+      ipaconfig:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        searchrecordslimit: -1
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: set searchrecordslimit to -1, again.
+      ipaconfig:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        searchrecordslimit: -1
+      register: result
+      failed_when: result.changed or result.failed
+
+    - name: set searchtimelimit to 12345
+      ipaconfig:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        searchtimelimit: 12345
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: set searchtimelimit to 12345, again.
+      ipaconfig:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        searchtimelimit: 12345
+      register: result
+      failed_when: result.changed or result.failed
+
+    - name: change enable_migration
+      ipaconfig:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        enable_migration: '{{ not (previousconfig.config.enable_migration | bool) }}'
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: change enable_migration, again
+      ipaconfig:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        enable_migration: '{{ not (previousconfig.config.enable_migration | bool) }}'
+      register: result
+      failed_when: result.changed or result.failed
+
+    - name: set configstring to AllowNThash
+      ipaconfig:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        configstring: AllowNThash
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: set configstring to AllowNThash, again.
+      ipaconfig:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        configstring: AllowNThash
+      register: result
+      failed_when: result.changed or result.failed
+
+    - name: set selinuxusermaporder
+      ipaconfig:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        selinuxusermaporder: 'user_u:s0$staff_u:s0-s0:c0.c1023$sysadm_u:s0-s0:c0.c1023$unconfined_u:s0-s0:c0.c1023'
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: set selinuxusermaporder, again
+      ipaconfig:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        selinuxusermaporder: 'user_u:s0$staff_u:s0-s0:c0.c1023$sysadm_u:s0-s0:c0.c1023$unconfined_u:s0-s0:c0.c1023'
+      register: result
+      failed_when: result.changed or result.failed
+
+    - name: set selinuxusermapdefault
+      ipaconfig:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        selinuxusermapdefault: 'user_u:s0'
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: set selinuxusermapdefault, again
+      ipaconfig:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        selinuxusermapdefault: 'user_u:s0'
+      register: result
+      failed_when: result.changed or result.failed
+
+    - name: set groupsearch to `description`
+      ipaconfig:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        groupsearch: description
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: set groupsearch to `gidNumber`, again
+      ipaconfig:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        groupsearch: description
+      register: result
+      failed_when: result.changed or result.failed
+
+    - name: set usersearch to `uidNumber`
+      ipaconfig:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        usersearch: uidNumber
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: set usersearch to `uidNumber`, again
+      ipaconfig:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        usersearch: uidNumber
+      register: result
+      failed_when: result.changed or result.failed
+
+    - name: reset changed fields
+      ipaconfig:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        maxusername: '{{previousconfig.config.maxusername | default(omit) | int }}'
+        homedirectory: '{{previousconfig.config.homedirectory | default(omit) }}'
+        defaultshell: '{{previousconfig.config.defaultshell | default(omit) }}'
+        defaultgroup: '{{previousconfig.config.defaultgroup | default(omit) }}'
+        emaildomain: '{{previousconfig.config.emaildomain | default(omit) }}'
+        searchtimelimit: '{{previousconfig.config.searchtimelimit | default(omit) | int }}'
+        searchrecordslimit: '{{previousconfig.config.searchrecordslimit | default(omit) | int }}'
+        usersearch: '{{previousconfig.config.usersearch | default(omit) }}'
+        groupsearch: '{{previousconfig.config.groupsearch | default(omit) }}'
+        enable_migration: '{{previousconfig.config.enable_migration | default(omit) | bool }}'
+        groupobjectclasses: '{{previousconfig.config.groupobjectclasses | default(omit) }}'
+        userobjectclasses: '{{previousconfig.config.userobjectclasses | default(omit) }}'
+        pwdexpnotify: '{{previousconfig.config.pwdexpnotify | default(omit) | int }}'
+        configstring: '{{previousconfig.config.configstring | default(omit) }}'
+        selinuxusermapdefault: '{{previousconfig.config.selinuxusermapdefault | default(omit) }}'
+        selinuxusermaporder: '{{previousconfig.config.selinuxusermaporder | default(omit) }}'
+        pac_type: '{{previousconfig.config.pac_type | default(omit) }}'
+        user_auth_type: '{{previousconfig.config.user_auth_type | default(omit) }}'
+        domain_resolution_order: '{{previousconfig.config.domain_resolution_order | default(omit) }}'
+        ca_renewal_master_server: '{{previousconfig.config.ca_renewal_master_server | default(omit) }}'
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: reset maxhostname
+      block:
+        - ipaconfig:
+            ipaadmin_password: SomeADMINpassword
+            ipa_context: client
+            maxhostname: '{{previousconfig.config.maxhostname | default(omit)}}'
+      when: ipa_version is version('4.8.0', '>=')
+
+    - name: reset changed fields, again
+      ipaconfig:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        maxusername: '{{previousconfig.config.maxusername | default(omit) | int }}'
+        homedirectory: '{{previousconfig.config.homedirectory | default(omit) }}'
+        defaultshell: '{{previousconfig.config.defaultshell | default(omit) }}'
+        defaultgroup: '{{previousconfig.config.defaultgroup | default(omit) }}'
+        emaildomain: '{{previousconfig.config.emaildomain | default(omit) }}'
+        searchtimelimit: '{{previousconfig.config.searchtimelimit | default(omit) | int }}'
+        searchrecordslimit: '{{previousconfig.config.searchrecordslimit | default(omit) | int }}'
+        usersearch: '{{previousconfig.config.usersearch | default(omit) }}'
+        groupsearch: '{{previousconfig.config.groupsearch | default(omit) }}'
+        enable_migration: '{{previousconfig.config.enable_migration | default(omit) | bool }}'
+        groupobjectclasses: '{{previousconfig.config.groupobjectclasses | default(omit) }}'
+        userobjectclasses: '{{previousconfig.config.userobjectclasses | default(omit) }}'
+        pwdexpnotify: '{{previousconfig.config.pwdexpnotify | default(omit) | int }}'
+        configstring: '{{previousconfig.config.configstring | default(omit) }}'
+        selinuxusermapdefault: '{{previousconfig.config.selinuxusermapdefault | default(omit) }}'
+        selinuxusermaporder: '{{previousconfig.config.selinuxusermaporder | default(omit) }}'
+        pac_type: '{{previousconfig.config.pac_type | default(omit) }}'
+        user_auth_type: '{{previousconfig.config.user_auth_type | default(omit) }}'
+        domain_resolution_order: '{{previousconfig.config.domain_resolution_order | default(omit) }}'
+        ca_renewal_master_server: '{{previousconfig.config.ca_renewal_master_server | default(omit) }}'
+      register: result
+      failed_when: result.changed or result.failed
+
+    - name: reset maxhostname
+      block:
+        - ipaconfig:
+            ipaadmin_password: SomeADMINpassword
+            ipa_context: client
+            maxhostname: '{{previousconfig.config.maxhostname | default(omit)}}'
+      when: ipa_version is version('4.8.0', '>=')
+
+    # cleanup
+
+    - name: cleanup test group
+      ipagroup:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: somedefaultgroup
+        state: absent
+
+    when: groups['ipaclients'] is defined

--- a/tests/delegation/test_delegation_client_context.yml
+++ b/tests/delegation/test_delegation_client_context.yml
@@ -1,0 +1,297 @@
+---
+- name: Test delegation
+  hosts: ipaclients
+  become: true
+
+  tasks:
+  - block:  # only execute tests if groups['ipaclients'] is defined.
+
+    # CLEANUP TEST ITEMS
+
+    - name: Ensure test groups are absent
+      ipagroup:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: managers,managers2,employees,employees2
+        state: absent
+
+    - name: Ensure delegation "basic manager attributes" is absent
+      ipadelegation:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: "basic manager attributes"
+        state: absent
+
+    # CREATE TEST ITEMS
+
+    - name: Ensure test group managers is present
+      ipagroup:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: managers
+
+    - name: Ensure test group managers2 is present
+      ipagroup:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: managers2
+
+    - name: Ensure test group employees is present
+      ipagroup:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: employees
+
+    - name: Ensure test group employees2 is present
+      ipagroup:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: employees2
+
+    # TESTS
+    - name: Execute with server context in the client.
+      ipadelegation:
+        ipaadmin_password: SomeADMINpassword
+        name: "basic manager attributes"
+        permission: read
+        attribute:
+        - businesscategory
+        group: managers
+        membergroup: employees
+      register: result
+      failed_when: not (result.failed and "No module named 'ipaserver'" in result.msg)
+
+    - name: Ensure delegation "basic manager attributes" is present
+      ipadelegation:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: "basic manager attributes"
+        permission: read
+        attribute:
+        - businesscategory
+        group: managers
+        membergroup: employees
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: Ensure delegation "basic manager attributes" is present again
+      ipadelegation:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: "basic manager attributes"
+        permission: read
+        attribute:
+        - businesscategory
+        group: managers
+        membergroup: employees
+      register: result
+      failed_when: result.changed or result.failed
+
+    - name: Ensure delegation "basic manager attributes" is present with different attribute employeetype
+      ipadelegation:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: "basic manager attributes"
+        permission: read
+        attribute:
+        - employeetype
+        group: managers
+        membergroup: employees
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: Ensure delegation "basic manager attributes" is present with different attribute employeetype again
+      ipadelegation:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: "basic manager attributes"
+        permission: read
+        attribute:
+        - employeetype
+        group: managers
+        membergroup: employees
+      register: result
+      failed_when: result.changed or result.failed
+
+    - name: Ensure delegation "basic manager attributes" member attribute departmentnumber is present
+      ipadelegation:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: "basic manager attributes"
+        attribute:
+        - departmentnumber
+        action: member
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: Ensure delegation "basic manager attributes" member attribute departmentnumber is present again
+      ipadelegation:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: "basic manager attributes"
+        attribute:
+        - departmentnumber
+        action: member
+      register: result
+      failed_when: result.changed or result.failed
+
+    - name: Ensure delegation "basic manager attributes" member attributes employeetype and employeenumber are present
+      ipadelegation:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: "basic manager attributes"
+        attribute:
+        - employeetype
+        - employeenumber
+        action: member
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: Ensure delegation "basic manager attributes" member attributes employeetype and employeenumber are present again
+      ipadelegation:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: "basic manager attributes"
+        attribute:
+        - employeetype
+        - employeenumber
+        action: member
+      register: result
+      failed_when: result.changed or result.failed
+
+    - name: Ensure delegation "basic manager attributes" member attributes employeenumber and employeetype are absent
+      ipadelegation:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: "basic manager attributes"
+        attribute:
+        - employeenumber
+        - employeetype
+        action: member
+        state: absent
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: Ensure delegation "basic manager attributes" member attributes employeenumber and employeetype are absent again
+      ipadelegation:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: "basic manager attributes"
+        attribute:
+        - employeenumber
+        - employeetype
+        action: member
+        state: absent
+      register: result
+      failed_when: result.changed or result.failed
+
+    # TEST permission change
+
+    - name: Ensure delegation "basic manager attributes" is present with different read,write permission
+      ipadelegation:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: "basic manager attributes"
+        permission: read,write
+        attribute:
+        - businesscategory
+        group: managers
+        membergroup: employees
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: Ensure delegation "basic manager attributes" is present with different read,write permission again
+      ipadelegation:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: "basic manager attributes"
+        permission: read,write
+        attribute:
+        - businesscategory
+        group: managers
+        membergroup: employees
+      register: result
+      failed_when: result.changed or result.failed
+
+    - name: Ensure delegation "basic manager attributes" is present with different group managers2
+      ipadelegation:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: "basic manager attributes"
+        group: managers2
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: Ensure delegation "basic manager attributes" is present with different group managers2 again
+      ipadelegation:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: "basic manager attributes"
+        group: managers2
+      register: result
+      failed_when: result.changed or result.failed
+
+    - name: Ensure delegation "basic manager attributes" is present with different membergroup employees2
+      ipadelegation:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: "basic manager attributes"
+        membergroup: employees2
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: Ensure delegation "basic manager attributes" is present with different membergroup employees2 again
+      ipadelegation:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: "basic manager attributes"
+        membergroup: employees2
+      register: result
+      failed_when: result.changed or result.failed
+
+    - name: Ensure delegation "basic manager attributes" fails with bad permission read,read
+      ipadelegation:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: "basic manager attributes"
+        permission: read,read
+      register: result
+      failed_when: not result.failed or "Invalid permission" not in result.msg
+
+    - name: Ensure delegation "basic manager attributes" fails with bad permission read,write,write
+      ipadelegation:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: "basic manager attributes"
+        permission: read,write,write
+      register: result
+      failed_when: not result.failed or "Invalid permission" not in result.msg
+
+    - name: Ensure delegation "basic manager attributes" fails with bad attribute businesscategory,businesscategory
+      ipadelegation:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: "basic manager attributes"
+        attribute:
+        - businesscategory
+        - businesscategory
+      register: result
+      failed_when: not result.failed or "Invalid attribute" not in result.msg
+
+    # CLEANUP TEST ITEMS
+
+    - name: Ensure delegation "basic manager attributes" is absent
+      ipadelegation:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: "basic manager attributes"
+        state: absent
+
+    - name: Ensure test groups are absent
+      ipagroup:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: managers,managers2,employees,employees2
+        state: absent
+
+    when: groups['ipaclients'] is defined

--- a/tests/dnsconfig/test_dnsconfig_client_context.yml
+++ b/tests/dnsconfig/test_dnsconfig_client_context.yml
@@ -1,0 +1,212 @@
+---
+- name: Test dnsconfig
+  hosts: ipaclients
+  become: yes
+  gather_facts: yes
+
+  tasks:
+  - block:  # only execute tests if groups['ipaclients'] is defined.
+
+    # Setup.
+    - name: Ensure forwarders are absent.
+      ipadnsconfig:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        forwarders:
+          - ip_address: 8.8.8.8
+          - ip_address: 8.8.4.4
+          - ip_address: 2001:4860:4860::8888
+          - ip_address: 2001:4860:4860::8888
+            port: 53
+        state: absent
+
+    # Tests.
+
+    - name: Execute with server context in the client.
+      ipadnsconfig:
+        ipaadmin_password: SomeADMINpassword
+        forwarders:
+          - ip_address: 1.2.3.4
+      register: result
+      failed_when: not (result.failed and "No module named 'ipaserver'" in result.msg)
+
+    - name: Set config to invalid IPv4.
+      ipadnsconfig:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        forwarders:
+          - ip_address: 1.2.3.500
+      register: result
+      failed_when: not result.failed or "Invalid IP for DNS forwarder" not in result.msg
+
+    - name: Set config to invalid IP.
+      ipadnsconfig:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        forwarders:
+          - ip_address: 1.in.va.lid
+      register: result
+      failed_when: not result.failed or "Invalid IP for DNS forwarder" not in result.msg
+
+    - name: Set config to invalid IPv6.
+      ipadnsconfig:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        forwarders:
+          - ip_address: fd00::invalid
+      register: result
+      failed_when: not result.failed or "Invalid IP for DNS forwarder" not in result.msg
+
+    - name: Set dnsconfig.
+      ipadnsconfig:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        forwarders:
+          - ip_address: 8.8.8.8
+          - ip_address: 8.8.4.4
+          - ip_address: 2001:4860:4860::8888
+            port: 53
+        forward_policy: only
+        allow_sync_ptr: yes
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: Set dnsconfig, with the same values.
+      ipadnsconfig:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        forwarders:
+          - ip_address: 8.8.8.8
+          - ip_address: 8.8.4.4
+          - ip_address: 2001:4860:4860::8888
+            port: 53
+        forward_policy: only
+        allow_sync_ptr: yes
+      register: result
+      failed_when: result.changed or result.failed
+
+    - name: Ensure forwarder is absent.
+      ipadnsconfig:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        forwarders:
+          - ip_address: 8.8.8.8
+        state: absent
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: Ensure forwarder is absent, again.
+      ipadnsconfig:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        forwarders:
+          - ip_address: 8.8.8.8
+        state: absent
+      register: result
+      failed_when: result.changed or result.failed
+
+    - name: Disable global forwarders.
+      ipadnsconfig:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        forward_policy: none
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: Disable global forwarders, again.
+      ipadnsconfig:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        forward_policy: none
+      register: result
+      failed_when: result.changed or result.failed
+
+    - name: Re-enable global forwarders.
+      ipadnsconfig:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        forward_policy: first
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: Re-enable global forwarders, again.
+      ipadnsconfig:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        forward_policy: first
+      register: result
+      failed_when: result.changed or result.failed
+
+    - name: Disable PTR record synchronization.
+      ipadnsconfig:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        allow_sync_ptr: no
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: Disable PTR record synchronization, again.
+      ipadnsconfig:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        allow_sync_ptr: no
+      register: result
+      failed_when: result.changed or result.failed
+
+    - name: Re-enable PTR record synchronization.
+      ipadnsconfig:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        allow_sync_ptr: yes
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: Re-enable PTR record synchronization, again.
+      ipadnsconfig:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        allow_sync_ptr: yes
+      register: result
+      failed_when: result.changed or result.failed
+
+    - name: Ensure all forwarders are absent.
+      ipadnsconfig:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        forwarders:
+          - ip_address: 8.8.8.8
+          - ip_address: 8.8.4.4
+          - ip_address: 2001:4860:4860::8888
+            port: 53
+        state: absent
+      register: result
+      failed_when: not result.changed or result.failed
+
+
+    - name: Ensure all forwarders are absent, again.
+      ipadnsconfig:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        forwarders:
+          - ip_address: 8.8.8.8
+          - ip_address: 8.8.4.4
+          - ip_address: 2001:4860:4860::8888
+            port: 53
+        state: absent
+      register: result
+      failed_when: result.changed or result.failed
+
+    # Cleanup.
+    - name: Ensure forwarders are absent.
+      ipadnsconfig:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        forwarders:
+          - ip_address: 8.8.8.8
+          - ip_address: 8.8.4.4
+          - ip_address: 2001:4860:4860::8888
+          - ip_address: 2001:4860:4860::8888
+            port: 53
+        state: absent
+
+    when: groups['ipaclients'] is defined

--- a/tests/dnsforwardzone/test_dnsforwardzone_client_context.yml
+++ b/tests/dnsforwardzone/test_dnsforwardzone_client_context.yml
@@ -1,0 +1,390 @@
+---
+- name: Test dnsforwardzone
+  hosts: ipaclients
+  become: true
+  gather_facts: false
+
+  tasks:
+  - block:  # only execute tests if groups['ipaclients'] is defined.
+
+    - name: Execute with server context in the client.
+      ipadnsforwardzone:
+        ipaadmin_password: SomeADMINpassword
+        name:
+        - example.com
+        - newfailzone.com
+        state: absent
+      register: result
+      failed_when: not (result.failed and "No module named 'ipaserver'" in result.msg)
+
+    - name: ensure test forwardzones are absent
+      ipadnsforwardzone:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name:
+        - example.com
+        - newfailzone.com
+        state: absent
+
+    - name: ensure forwardzone example.com is created
+      ipadnsforwardzone:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        state: present
+        name: example.com
+        forwarders:
+          - ip_address: 8.8.8.8
+        forwardpolicy: first
+        skip_overlap_check: true
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: ensure forwardzone example.com is present again
+      ipadnsforwardzone:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        state: present
+        name: example.com
+        forwarders:
+          - ip_address: 8.8.8.8
+        forwardpolicy: first
+        skip_overlap_check: true
+      register: result
+      failed_when: result.changed or result.failed
+
+    - name: ensure forwardzone example.com has two forwarders
+      ipadnsforwardzone:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        state: present
+        name: example.com
+        forwarders:
+          - ip_address: 8.8.8.8
+          - ip_address: 4.4.4.4
+            port: 8053
+        forwardpolicy: first
+        skip_overlap_check: true
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: ensure forwardzone example.com has one forwarder again
+      ipadnsforwardzone:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: example.com
+        forwarders:
+          - ip_address: 8.8.8.8
+        forwardpolicy: first
+        skip_overlap_check: true
+        state: present
+      register: result
+      failed_when: result.changed or result.failed
+
+    - name: skip_overlap_check can only be set on creation so change nothing
+      ipadnsforwardzone:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: example.com
+        forwarders:
+          - ip_address: 8.8.8.8
+        forwardpolicy: first
+        skip_overlap_check: false
+        state: present
+      register: result
+      failed_when: result.changed or result.failed
+
+    - name: ensure forwardzone example.com is absent.
+      ipadnsforwardzone:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: example.com
+        state: absent
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: ensure forwardzone example.com is absent, again.
+      ipadnsforwardzone:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: example.com
+        state: absent
+      register: result
+      failed_when: result.changed or result.failed
+
+    - name: change all the things at once
+      ipadnsforwardzone:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        state: present
+        name: example.com
+        forwarders:
+          - ip_address: 8.8.8.8
+          - ip_address: 4.4.4.4
+            port: 8053
+        forwardpolicy: only
+        skip_overlap_check: true
+        permission: yes
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: change zone forward policy
+      ipadnsforwardzone:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: example.com
+        forwardpolicy: first
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: change zone forward policy, again
+      ipadnsforwardzone:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: example.com
+        forwardpolicy: first
+      register: result
+      failed_when: result.changed or result.failed
+
+    - name: ensure forwardzone example.com is absent.
+      ipadnsforwardzone:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: example.com
+        state: absent
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: ensure forwardzone example.com is absent, again.
+      ipadnsforwardzone:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: example.com
+        state: absent
+      register: result
+      failed_when: result.changed or result.failed
+
+    - name: ensure forwardzone example.com is created with minimal args
+      ipadnsforwardzone:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        state: present
+        name: example.com
+        skip_overlap_check: true
+        forwarders:
+          - ip_address: 8.8.8.8
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: ensure forwardzone example.com is created with minimal args, again
+      ipadnsforwardzone:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        state: present
+        name: example.com
+        skip_overlap_check: true
+        forwarders:
+          - ip_address: 8.8.8.8
+      register: result
+      failed_when: result.changed or result.failed
+
+    - name: add a forwarder to any existing ones
+      ipadnsforwardzone:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        state: present
+        name: example.com
+        forwarders:
+          - ip_address: 4.4.4.4
+            port: 8053
+        action: member
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: add a forwarder to any existing ones, again
+      ipadnsforwardzone:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        state: present
+        name: example.com
+        forwarders:
+          - ip_address: 4.4.4.4
+            port: 8053
+        action: member
+      register: result
+      failed_when: result.changed or result.failed
+
+    - name: check the list of forwarders is what we expect
+      ipadnsforwardzone:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        state: present
+        name: example.com
+        forwarders:
+          - ip_address: 4.4.4.4
+            port: 8053
+          - ip_address: 8.8.8.8
+        action: member
+      register: result
+      failed_when: result.changed or result.failed
+
+    - name: remove a single forwarder
+      ipadnsforwardzone:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        state: absent
+        name: example.com
+        forwarders:
+          - ip_address: 8.8.8.8
+        action: member
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: remove a single forwarder, again
+      ipadnsforwardzone:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        state: absent
+        name: example.com
+        forwarders:
+          - ip_address: 8.8.8.8
+        action: member
+      register: result
+      failed_when: result.changed or result.failed
+
+    - name: check the list of forwarders is what we expect now
+      ipadnsforwardzone:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        state: present
+        name: example.com
+        forwarders:
+          - ip_address: 4.4.4.4
+            port: 8053
+        action: member
+      register: result
+      failed_when: result.changed or result.failed
+
+    - name: Add a permission for per-forward zone access delegation.
+      ipadnsforwardzone:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: example.com
+        permission: yes
+        action: member
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: Add a permission for per-forward zone access delegation, again.
+      ipadnsforwardzone:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: example.com
+        permission: yes
+        action: member
+      register: result
+      failed_when: result.changed or result.failed
+
+    - name: Remove a permission for per-forward zone access delegation.
+      ipadnsforwardzone:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: example.com
+        permission: no
+        action: member
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: Remove a permission for per-forward zone access delegation, again.
+      ipadnsforwardzone:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: example.com
+        permission: no
+        action: member
+      register: result
+      failed_when: result.changed or result.failed
+
+    - name: disable the forwarder
+      ipadnsforwardzone:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: example.com
+        state: disabled
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: disable the forwarder again
+      ipadnsforwardzone:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: example.com
+        state: disabled
+      register: result
+      failed_when: result.changed or result.failed
+
+    - name: enable the forwarder
+      ipadnsforwardzone:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: example.com
+        state: enabled
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: enable the forwarder, again
+      ipadnsforwardzone:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: example.com
+        state: enabled
+      register: result
+      failed_when: result.changed or result.failed
+
+    - name: ensure forwardzone example.com is absent again
+      ipadnsforwardzone:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: example.com
+        state: absent
+
+    - name: try to create a new forwarder with action=member
+      ipadnsforwardzone:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        state: present
+        name: example.com
+        forwarders:
+          - ip_address: 4.4.4.4
+            port: 8053
+        action: member
+        skip_overlap_check: true
+      register: result
+      failed_when: not result.failed or "not found" not in result.msg
+
+    - name: try to create a new forwarder with disabled state
+      ipadnsforwardzone:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: example.com
+        state: disabled
+      register: result
+      failed_when: not result.failed or "not found" not in result.msg
+
+    - name: Ensure forwardzone is not added without forwarders, with correct message.
+      ipadnsforwardzone:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: newfailzone.com
+      register: result
+      failed_when: not result.failed or "No forwarders specified" not in result.msg
+
+    - name: ensure forwardzone example.com is absent - tidy up
+      ipadnsforwardzone:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name:
+        - example.com
+        - newfailzone.com
+        state: absent
+
+    when: groups['ipaclients'] is defined

--- a/tests/dnsrecord/env_cleanup.yml
+++ b/tests/dnsrecord/env_cleanup.yml
@@ -3,6 +3,7 @@
    - name: Ensure that dns records are absent
      ipadnsrecord:
        ipaadmin_password: SomeADMINpassword
+       ipa_context: "{{ ipa_test_context | default('server') }}"
        zone_name: "{{ testzone }}"
        del_all: yes
        name:
@@ -17,6 +18,7 @@
    - name: Ensure that dns reverse ipv6 records are absent
      ipadnsrecord:
        ipaadmin_password: SomeADMINpassword
+       ipa_context: "{{ ipa_test_context | default('server') }}"
        zone_name: ip6.arpa.
        del_all: yes
        name:
@@ -31,6 +33,7 @@
    - name: Ensure that dns reverse ipv6 records are absent (workaround)
      ipadnsrecord:
        ipaadmin_password: SomeADMINpassword
+       ipa_context: "{{ ipa_test_context | default('server') }}"
        zone_name: "{{ zone_ipv6_reverse_workaround }}"
        del_all: yes
        name:
@@ -45,6 +48,7 @@
    - name: Ensure that dns reverse records are absent
      ipadnsrecord:
        ipaadmin_password: SomeADMINpassword
+       ipa_context: "{{ ipa_test_context | default('server') }}"
        zone_name: "{{ zone_prefix_reverse_24 }}"
        name:
        - "101"
@@ -65,6 +69,7 @@
    - name: Ensure that dns reverse records are absent (workaround 1)
      ipadnsrecord:
        ipaadmin_password: SomeADMINpassword
+       ipa_context: "{{ ipa_test_context | default('server') }}"
        zone_name: "{{ zone_prefix_reverse_16 }}"
        name:
        - "101.122"
@@ -85,6 +90,7 @@
    - name: Ensure that dns reverse records are absent (workaround 2)
      ipadnsrecord:
        ipaadmin_password: SomeADMINpassword
+       ipa_context: "{{ ipa_test_context | default('server') }}"
        zone_name: "{{ zone_prefix_reverse_8 }}"
        name:
        - "168.101.122"
@@ -105,6 +111,7 @@
    - name: Ensure that "{{ safezone }}" dns records are absent
      ipadnsrecord:
        ipaadmin_password: SomeADMINpassword
+       ipa_context: "{{ ipa_test_context | default('server') }}"
        zone_name: "{{ safezone }}"
        records:
        - name: iron01
@@ -114,6 +121,7 @@
    - name: Ensure that NS record for "{{ safezone }}" is absent
      ipadnsrecord:
        ipaadmin_password: SomeADMINpassword
+       ipa_context: "{{ ipa_test_context | default('server') }}"
        name: iron01
        zone_name: "{{ safezone }}"
        ns_rec: iron01
@@ -122,6 +130,7 @@
    - name: Ensure DNS testing zones are absent.
      ipadnszone:
        ipaadmin_password: SomeADMINpassword
+       ipa_context: "{{ ipa_test_context | default('server') }}"
        name: "{{ item }}"
        state: absent
      with_items:

--- a/tests/dnsrecord/env_setup.yml
+++ b/tests/dnsrecord/env_setup.yml
@@ -10,6 +10,7 @@
   - name: Ensure DNS testing zones are present.
     ipadnszone:
       ipaadmin_password: SomeADMINpassword
+      ipa_context: "{{ ipa_test_context | default('server') }}"
       name: "{{ item }}"
       skip_nameserver_check: yes
       skip_overlap_check: yes
@@ -25,6 +26,7 @@
   - name: Ensure DNSSEC zone '"{{ safezone }}"' is present.
     ipadnszone:
       ipaadmin_password: SomeADMINpassword
+      ipa_context: "{{ ipa_test_context | default('server') }}"
       name: "{{ safezone }}"
       dnssec: yes
       skip_nameserver_check: yes

--- a/tests/dnsrecord/test_dnsrecord_client_context.yml
+++ b/tests/dnsrecord/test_dnsrecord_client_context.yml
@@ -1,0 +1,175 @@
+---
+- name: Test dnsrecord
+  hosts: ipaclients
+  become: no
+  gather_facts: yes
+
+  tasks:
+
+  # tests
+  - block:  # only execute tests if groups['ipaclients'] is defined.
+    - name: Define test context.
+      set_fact:
+        ipa_test_context: "client"
+
+    - name: Setup test environment
+      include_tasks: env_setup.yml
+
+    - name: Execute with server context in the client.
+      ipadnsrecord:
+        ipaadmin_password: SomeADMINpassword
+        name: host01
+        zone_name: "{{ testzone }}"
+        a_rec: 192.168.122.101
+      register: result
+      failed_when: not (result.failed and "No module named 'ipaserver'" in result.msg)
+
+    - name: Ensure that dns A record for 'host01' is present
+      ipadnsrecord:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: host01
+        zone_name: "{{ testzone }}"
+        a_rec: 192.168.122.101
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: Ensure that dns A record for 'host01' is present, again
+      ipadnsrecord:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: host01
+        zone_name: "{{ testzone }}"
+        a_rec: 192.168.122.101
+      register: result
+      failed_when: result.changed or result.failed
+
+    - name: Ensure that dns A records for 'host01' are present
+      ipadnsrecord:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: host01
+        zone_name: "{{ testzone }}"
+        a_rec:
+        - 192.168.122.101
+        - 192.168.122.102
+        - 192.168.122.103
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: Ensure that dns A records for 'host01' are present, again
+      ipadnsrecord:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: host01
+        zone_name: "{{ testzone }}"
+        a_rec:
+        - 192.168.122.101
+        - 192.168.122.102
+        - 192.168.122.103
+      register: result
+      failed_when: result.changed or result.failed
+
+    - name: Ensure that dns A records for 'host01' are absent
+      ipadnsrecord:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: host01
+        zone_name: "{{ testzone }}"
+        a_rec:
+        - 192.168.122.101
+        - 192.168.122.102
+        state: absent
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: Ensure that dns A records for 'host01' are absent, again
+      ipadnsrecord:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: host01
+        zone_name: "{{ testzone }}"
+        a_rec:
+        - 192.168.122.101
+        - 192.168.122.102
+        state: absent
+      register: result
+      failed_when: result.changed or result.failed
+
+    - name: Ensure that dns AAAA record for 'host01' is present
+      ipadnsrecord:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: host01
+        zone_name: "{{ testzone }}"
+        aaaa_rec: fd00::0001
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: Ensure that dns AAAA record for 'host01' is present, again
+      ipadnsrecord:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: host01
+        zone_name: "{{ testzone }}"
+        aaaa_rec: fd00::0001
+      register: result
+      failed_when: result.changed or result.failed
+
+    - name: Ensure that dns AAAA records for 'host01' are present
+      ipadnsrecord:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: host01
+        zone_name: "{{ testzone }}"
+        aaaa_rec:
+        - fd00::0001
+        - fd00::0011
+        - fd00::0021
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: Ensure that dns AAAAA records for 'host01' are present, again
+      ipadnsrecord:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: host01
+        zone_name: "{{ testzone }}"
+        aaaa_rec:
+        - fd00::0001
+        - fd00::0011
+        - fd00::0021
+      register: result
+      failed_when: result.changed or result.failed
+
+    - name: Ensure that dns AAAAA records for 'host01' are absent
+      ipadnsrecord:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: host01
+        zone_name: "{{ testzone }}"
+        aaaa_rec:
+        - fd00::0001
+        - fd00::0011
+        state: absent
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: Ensure that dns AAAAA records for 'host01' are absent, again
+      ipadnsrecord:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: host01
+        zone_name: "{{ testzone }}"
+        aaaa_rec:
+        - fd00::0001
+        - fd00::0011
+        state: absent
+      register: result
+      failed_when: result.changed or result.failed
+
+    # Cleanup
+    - name: Cleanup test environment.
+      include_tasks: env_cleanup.yml
+
+    when: groups['ipaclients'] is defined

--- a/tests/dnszone/env_cleanup.yml
+++ b/tests/dnszone/env_cleanup.yml
@@ -2,6 +2,7 @@
 - name: Ensure zone is absent.
   ipadnszone:
     ipaadmin_password: SomeADMINpassword
+    ipa_context: "{{ ipa_test_context | default('server') }}"
     name:
       - testzone.local
       - test1.testzone.local

--- a/tests/dnszone/test_dnszone_client_context.yml
+++ b/tests/dnszone/test_dnszone_client_context.yml
@@ -1,0 +1,252 @@
+---
+- name: Test dnszone
+  hosts: ipaclients
+  become: yes
+  gather_facts: yes
+
+  tasks:
+  - block:  # only execute tests if groups['ipaclients'] is defined.
+
+    # Setup
+    - set_fact:
+        ipa_test_context: client
+
+    - name: Setup testing environment
+      include_tasks: env_setup.yml
+
+    # Tests
+    - name: Execute with server context in the client.
+      ipadnszone:
+        ipaadmin_password: SomeADMINpassword
+        name: testzone.local
+        state: present
+      register: result
+      failed_when: not (result.failed and "No module named 'ipaserver'" in result.msg)
+
+    - name: Ensure zone is present.
+      ipadnszone:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: testzone.local
+        state: present
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: Ensure zone is present, again.
+      ipadnszone:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: testzone.local
+        state: present
+      register: result
+      failed_when: result.changed or result.failed
+
+    - name: Ensure zone is disabled.
+      ipadnszone:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: testzone.local
+        state: disabled
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: Ensure zone is disabled, again.
+      ipadnszone:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: testzone.local
+        state: disabled
+      register: result
+      failed_when: result.changed or result.failed
+
+    - name: Ensure zone is enabled.
+      ipadnszone:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: testzone.local
+        state: enabled
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: Ensure zone is enabled, again.
+      ipadnszone:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: testzone.local
+        state: enabled
+      register: result
+      failed_when: result.changed or result.failed
+
+    - name: Ensure forward_policy is none.
+      ipadnszone:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: testzone.local
+        forward_policy: none
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: Ensure forward_policy is none, again.
+      ipadnszone:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: testzone.local
+        forward_policy: none
+      register: result
+      failed_when: result.changed or result.failed
+
+    - name: Ensure forward_policy is first.
+      ipadnszone:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: testzone.local
+        forward_policy: first
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: Ensure forward_policy is first, again.
+      ipadnszone:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: testzone.local
+        forward_policy: first
+      register: result
+      failed_when: result.changed or result.failed
+
+    - name: Ensure first forwarder is set.
+      ipadnszone:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: testzone.local
+        forwarders:
+          - ip_address: 8.8.8.8
+            port: 53
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: Ensure first and second forwarder are set.
+      ipadnszone:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: testzone.local
+        forwarders:
+          - ip_address: 8.8.8.8
+            port: 53
+          - ip_address: 2001:4860:4860::8888
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: Ensure first and second forwarder are set, again.
+      ipadnszone:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: testzone.local
+        forwarders:
+          - ip_address: 8.8.8.8
+            port: 53
+          - ip_address: 2001:4860:4860::8888
+      register: result
+      failed_when: result.changed or result.failed
+
+    - name: Ensure only second forwarder is set.
+      ipadnszone:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: testzone.local
+        forwarders:
+          - ip_address: 2001:4860:4860::8888
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: Nothing changes.
+      ipadnszone:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: testzone.local
+      register: result
+      failed_when: result.changed or result.failed
+
+    - name: Ensure no forwarders are set.
+      ipadnszone:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: testzone.local
+        forwarders: []
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: Create zones test1
+      ipadnszone:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: test1.testzone.local
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: Create zones test1, again
+      ipadnszone:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: test1.testzone.local
+      register: result
+      failed_when: result.changed or result.failed
+
+    - name: Create zones test2
+      ipadnszone:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: test2.testzone.local
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: Create zones test2, again
+      ipadnszone:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: test2.testzone.local
+      register: result
+      failed_when: result.changed or result.failed
+
+    - name: Create zones test3
+      ipadnszone:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: test3.testzone.local
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: Create zones test3, again
+      ipadnszone:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: test3.testzone.local
+      register: result
+      failed_when: result.changed or result.failed
+
+    - name: Ensure multiple zones are absent
+      ipadnszone:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name:
+          - test1.testzone.local
+          - test2.testzone.local
+          - test3.testzone.local
+        state: absent
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: Ensure multiple zones are absent, again
+      ipadnszone:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name:
+          - test1.testzone.local
+          - test2.testzone.local
+          - test3.testzone.local
+        state: absent
+      register: result
+      failed_when: result.changed or result.failed
+
+    # Teardown
+    - name: Teardown testing environment
+      include_tasks: env_teardown.yml

--- a/tests/group/test_group_client_context.yml
+++ b/tests/group/test_group_client_context.yml
@@ -1,0 +1,196 @@
+---
+- name: Test group
+  hosts: ipaclients
+  become: yes
+  gather_facts: no
+
+  tasks:
+  - block:  # only execute tests if groups['ipaclients'] is defined.
+
+    - name: Execute with server context in the client.
+      ipagroup:
+        ipaadmin_password: SomeADMINpassword
+        name: group1
+      register: result
+      failed_when: not (result.failed and "No module named 'ipaserver'" in result.msg)
+
+    - name: Ensure users user1, user2 and user3 are absent
+      ipauser:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: user1,user2,user3
+        state: absent
+
+    - name: Ensure group group3, group2 and group1 are absent
+      ipagroup:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: group3,group2,group1
+        state: absent
+
+    - name: Ensure users user1..user3 are present
+      ipauser:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        users:
+        - name: user1
+          first: user1
+          last: Last
+        - name: user2
+          first: user2
+          last: Last
+        - name: user3
+          first: user3
+          last: Last
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: Ensure group1 is present
+      ipagroup:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: group1
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: Ensure group1 is present again
+      ipagroup:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: group1
+      register: result
+      failed_when: result.changed or result.failed
+
+    - name: Ensure group2 is present
+      ipagroup:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: group2
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: Ensure group2 is present again
+      ipagroup:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: group2
+      register: result
+      failed_when: result.changed or result.failed
+
+    - name: Ensure group3 is present
+      ipagroup:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: group3
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: Ensure group3 is present again
+      ipagroup:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: group3
+      register: result
+      failed_when: result.changed or result.failed
+
+    - name: Ensure groups group2 and group3 are present in group group1
+      ipagroup:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: group1
+        group:
+        - group2
+        - group3
+        action: member
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: Ensure groups group2 and group3 are present in group group1 again
+      ipagroup:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: group1
+        group:
+        - group2
+        - group3
+        action: member
+      register: result
+      failed_when: result.changed or result.failed
+
+    - name: Ensure group3 ia present in group group1
+      ipagroup:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: group1
+        group:
+        - group3
+        action: member
+      register: result
+      failed_when: result.changed or result.failed
+
+    - name: Ensure users user1, user2 and user3 are present in group group1
+      ipagroup:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: group1
+        user:
+        - user1
+        - user2
+        - user3
+        action: member
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: Ensure users user1, user2 and user3 are present in group group1 again
+      ipagroup:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: group1
+        user:
+        - user1
+        - user2
+        - user3
+        action: member
+      register: result
+      failed_when: result.changed or result.failed
+
+    - name: Ensure user user7 is absent in group group1
+      ipagroup:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: group1
+        user:
+        - user7
+        action: member
+        state: absent
+      register: result
+      failed_when: result.changed or result.failed
+
+    - name: Ensure group group4 is absent
+      ipagroup:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: group4
+        state: absent
+      register: result
+      failed_when: result.changed or result.failed
+
+    - name: Ensure group group3, group2 and group1 are absent
+      ipagroup:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: group3,group2,group1
+        state: absent
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: Ensure users user1, user2 and user3 are absent
+      ipauser:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: user1,user2,user3
+        state: absent
+      register: result
+      failed_when: not result.changed or result.failed
+
+    when: groups['ipaclients'] is defined

--- a/tests/hbacrule/test_hbacrule_client_context.yml
+++ b/tests/hbacrule/test_hbacrule_client_context.yml
@@ -1,0 +1,203 @@
+---
+- name: Test HBAC client context.
+  hosts: ipaclients
+  become: yes
+  gather_facts: no
+
+  tasks:
+  - block:  # only execute tests if groups['ipaclients'] is defined.
+
+    - name: Execute with server context in the client.
+      ipahbacrule:
+        ipaadmin_password: SomeADMINpassword
+        name:
+        - testrule
+        state: absent
+      register: result
+      failed_when: not (result.failed and "No module named 'ipaserver'" in result.msg)
+
+    - name: Ensure HBAC rules are absent
+      ipahbacrule:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name:
+        - testrule
+        state: absent
+
+    - name: Ensure HBAC rule is present, with usercategory 'all'
+      ipahbacrule:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: testrule
+        usercategory: all
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: Ensure HBAC rule is present, with usercategory 'all', again.
+      ipahbacrule:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: testrule
+        usercategory: all
+      register: result
+      failed_when: result.changed or result.failed
+
+    - name: Ensure HBAC rule is present, with no usercategory.
+      ipahbacrule:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: testrule
+        usercategory: ""
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: Ensure HBAC rule is present, with no usercategory, again.
+      ipahbacrule:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: testrule
+        usercategory: ""
+      register: result
+      failed_when: result.changed or result.failed
+
+    - name: Ensure HBAC rule is present, with hostcategory 'all'
+      ipahbacrule:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: testrule
+        hostcategory: all
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: Ensure HBAC rule is present, with hostcategory 'all', again.
+      ipahbacrule:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: testrule
+        hostcategory: all
+      register: result
+      failed_when: result.changed or result.failed
+
+    - name: Ensure HBAC rule is present, with no hostcategory.
+      ipahbacrule:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: testrule
+        hostcategory: ""
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: Ensure HBAC rule is present, with no hostcategory, again.
+      ipahbacrule:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: testrule
+        hostcategory: ""
+      register: result
+      failed_when: result.changed or result.failed
+
+    - name: Ensure HBAC rule is present, with servicecategory 'all'
+      ipahbacrule:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: testrule
+        servicecategory: all
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: Ensure HBAC rule is present, with servicecategory 'all', again.
+      ipahbacrule:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: testrule
+        servicecategory: all
+      register: result
+      failed_when: result.changed or result.failed
+
+    - name: Ensure HBAC rule is present, with no servicecategory.
+      ipahbacrule:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: testrule
+        servicecategory: ""
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: Ensure HBAC rule is present, with no servicecategory, again.
+      ipahbacrule:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: testrule
+        servicecategory: ""
+      register: result
+      failed_when: result.changed or result.failed
+
+    - name: Ensure `user` cannot be added if usercategory is `all`.
+      ipahbacrule:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: allusers
+        user: shouldfail01
+        usercategory: "all"
+      register: result
+      failed_when: not result.failed or "Users cannot be added when user category='all'" not in result.msg
+
+    - name: Ensure `group` cannot be added if usercategory is `all`.
+      ipahbacrule:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: allusers
+        group: shouldfail01
+        usercategory: "all"
+      register: result
+      failed_when: not result.failed or "Users cannot be added when user category='all'" not in result.msg
+
+    - name: Ensure `host` cannot be added if hostcategory is `all`.
+      ipahbacrule:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: allusers
+        host: host.shouldfail.com
+        hostcategory: "all"
+      register: result
+      failed_when: not result.failed or "Hosts cannot be added when host category='all'" not in result.msg
+
+    - name: Ensure `hostgroup` cannot be added if hostcategory is `all`.
+      ipahbacrule:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: allusers
+        hostgroup: shouldfail_hostgroup
+        hostcategory: "all"
+      register: result
+      failed_when: not result.failed or "Hosts cannot be added when host category='all'" not in result.msg
+
+    - name: Ensure `hbacsvc` cannot be added if hbacsvccategory is `all`.
+      ipahbacrule:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: allusers
+        hbacsvc: "HTTP/fail.example.com"
+        servicecategory: "all"
+      register: result
+      failed_when: not result.failed or "Services cannot be added when service category='all'" not in result.msg
+
+    - name: Ensure `hbacsvcgroup` cannot be added if hbacsvccategory is `all`.
+      ipahbacrule:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: allusers
+        hbacsvcgroup: shouldfail_svcgroup
+        servicecategory: "all"
+      register: result
+      failed_when: not result.failed or "Services cannot be added when service category='all'" not in result.msg
+
+    - name: Ensure HBAC rules are absent
+      ipahbacrule:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name:
+        - testrule
+        state: absent
+
+    when: groups['ipaclients'] is defined

--- a/tests/hbacsvc/test_hbacsvc_client_context.yml
+++ b/tests/hbacsvc/test_hbacsvc_client_context.yml
@@ -1,0 +1,77 @@
+---
+- name: Test hbacsvc
+  hosts: ipaclients
+  become: yes
+  gather_facts: no
+
+  tasks:
+  - block:  # only execute tests if groups['ipaclients'] is defined.
+
+    - name: Execute with server context in the client.
+      ipahbacsvc:
+        ipaadmin_password: SomeADMINpassword
+        name: http,tftp
+        state: absent
+      register: result
+      failed_when: not (result.failed and "No module named 'ipaserver'" in result.msg)
+
+    - name: Ensure HBAC Service for http is absent
+      ipahbacsvc:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: http,tftp
+        state: absent
+
+    - name: Ensure HBAC Service for http is present
+      ipahbacsvc:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: http
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: Ensure HBAC Service for http is present again
+      ipahbacsvc:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: http
+      register: result
+      failed_when: result.changed or result.failed
+
+    - name: Ensure HBAC Service for tftp is present
+      ipahbacsvc:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: tftp
+        description: TFTP service
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: Ensure HBAC Service for tftp is present again
+      ipahbacsvc:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: tftp
+        description: TFTP service
+      register: result
+      failed_when: result.changed or result.failed
+
+    - name: Ensure HBAC Services for http and tftp are absent
+      ipahbacsvc:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: http,tftp
+        state: absent
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: Ensure HBAC Services for http and tftp are absent again
+      ipahbacsvc:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: http,tftp
+        state: absent
+      register: result
+      failed_when: result.changed or result.failed
+
+    when: groups['ipaclients'] is defined

--- a/tests/hbacsvcgroup/test_hbacsvcgroup_client_context.yml
+++ b/tests/hbacsvcgroup/test_hbacsvcgroup_client_context.yml
@@ -1,0 +1,113 @@
+---
+- name: Test hbacsvcgroup
+  hosts: ipaclients
+  become: yes 
+  gather_facts: no
+
+  tasks:
+  - block:  # only execute tests if groups['ipaclients'] is defined.
+
+    - name: Execute with server context in the client.
+      ipahbacsvcgroup:
+        ipaadmin_password: SomeADMINpassword
+        name: login
+        state: absent
+      register: result
+      failed_when: not (result.failed and "No module named 'ipaserver'" in result.msg)
+
+    - name: Ensure HBAC Service Group login is absent
+      ipahbacsvcgroup:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: login
+        state: absent
+
+    - name: Ensure HBAC Service for sshd is present
+      ipahbacsvc:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: login
+
+    - name: Ensure HBAC Service Group login is present
+      ipahbacsvcgroup:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: login
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: Ensure HBAC Service Group login is present again
+      ipahbacsvcgroup:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: login
+      register: result
+      failed_when: result.changed or result.failed
+
+    - name: Ensure HBAC Service sshd is present in HBAC Service Group login
+      ipahbacsvcgroup:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: login
+        hbacsvc:
+        - sshd
+        action: member
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: Ensure HBAC Service sshd is present in HBAC Service Group login again
+      ipahbacsvcgroup:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: login
+        hbacsvc:
+        - sshd
+        action: member
+      register: result
+      failed_when: result.changed or result.failed
+
+    - name: Ensure HBAC Services sshd and foo are absent in HBAC Service Group login
+      ipahbacsvcgroup:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: login
+        hbacsvc:
+        - sshd
+        - foo
+        action: member
+        state: absent
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: Ensure HBAC Services sshd and foo are absent in HBAC Service Group login again
+      ipahbacsvcgroup:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: login
+        hbacsvc:
+        - sshd
+        - foo
+        action: member
+        state: absent
+      register: result
+      failed_when: result.changed or result.failed
+
+    - name: Ensure HBAC Service Group login is absent
+      ipahbacsvcgroup:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: login
+        state: absent
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: Ensure HBAC Service Group login is absent again
+      ipahbacsvcgroup:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: login
+        state: absent
+      register: result
+      failed_when: result.changed or result.failed
+
+    when: groups['ipaclients'] is defined

--- a/tests/host/test_host_client_context.yml
+++ b/tests/host/test_host_client_context.yml
@@ -1,0 +1,214 @@
+---
+- name: Test host
+  hosts: ipaclients
+  become: yes
+  gather_facts: yes
+
+  tasks:
+  - block:  # only execute tests if groups['ipaclients'] is defined.
+
+    - name: Get Domain from server name
+      set_fact:
+        ipaserver_domain: "{{ ansible_facts['fqdn'].split('.')[1:] | join ('.') }}"
+      when: ipaserver_domain is not defined
+
+    - name: Set host1_fqdn .. host6_fqdn
+      set_fact:
+        host1_fqdn: "{{ 'host1.' + ipaserver_domain }}"
+        host2_fqdn: "{{ 'host2.' + ipaserver_domain }}"
+        host3_fqdn: "{{ 'host3.' + ipaserver_domain }}"
+        host4_fqdn: "{{ 'host4.' + ipaserver_domain }}"
+        host5_fqdn: "{{ 'host5.' + ipaserver_domain }}"
+        host6_fqdn: "{{ 'host6.' + ipaserver_domain }}"
+
+    - name: Execute with server context in the client.
+      ipahost:
+        ipaadmin_password: SomeADMINpassword
+        name: "{{ host1_fqdn }}"
+      register: result
+      failed_when: not (result.failed and "No module named 'ipaserver'" in result.msg)
+
+    - name: Host absent
+      ipahost:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name:
+        - "{{ host1_fqdn }}"
+        - "{{ host2_fqdn }}"
+        - "{{ host3_fqdn }}"
+        - "{{ host4_fqdn }}"
+        - "{{ host5_fqdn }}"
+        - "{{ host6_fqdn }}"
+        update_dns: yes
+        state: absent
+
+    - name: Get IPv4 address prefix from server node
+      set_fact:
+        ipv4_prefix: "{{ ansible_facts['default_ipv4'].address.split('.')[:-1] |
+                         join('.') }}"
+
+    - name: Host "{{ host1_fqdn }}" present
+      ipahost:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: "{{ host1_fqdn }}"
+        ip_address: "{{ ipv4_prefix + '.201' }}"
+        update_dns: yes
+        reverse: no
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: Host "{{ host1_fqdn }}" present again
+      ipahost:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: "{{ host1_fqdn }}"
+        ip_address: "{{ ipv4_prefix + '.201' }}"
+        update_dns: yes
+        reverse: no
+      register: result
+      failed_when: result.changed or result.failed
+
+    - name: Host "{{ host2_fqdn }}" present
+      ipahost:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: "{{ host2_fqdn }}"
+        ip_address: "{{ ipv4_prefix + '.202' }}"
+        update_dns: yes
+        reverse: no
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: Host "{{ host2_fqdn }}" present again
+      ipahost:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: "{{ host2_fqdn }}"
+        ip_address: "{{ ipv4_prefix + '.202' }}"
+        update_dns: yes
+        reverse: no
+      register: result
+      failed_when: result.changed or result.failed
+
+    - name: Host "{{ host3_fqdn }}" present
+      ipahost:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: "{{ host3_fqdn }}"
+        ip_address: "{{ ipv4_prefix + '.203' }}"
+        update_dns: yes
+        reverse: no
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: Host "{{ host3_fqdn }}" present again
+      ipahost:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: "{{ host3_fqdn }}"
+        ip_address: "{{ ipv4_prefix + '.203' }}"
+        update_dns: yes
+        reverse: no
+      register: result
+      failed_when: result.changed or result.failed
+
+    - name: Host "{{ host4_fqdn }}" present
+      ipahost:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: "{{ host4_fqdn }}"
+        ip_address: "{{ ipv4_prefix + '.204' }}"
+        update_dns: yes
+        reverse: no
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: Host "{{ host4_fqdn }}" present again
+      ipahost:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: "{{ host4_fqdn }}"
+        ip_address: "{{ ipv4_prefix + '.204' }}"
+        update_dns: yes
+        reverse: no
+      register: result
+      failed_when: result.changed or result.failed
+
+    - name: Host "{{ host5_fqdn }}" present
+      ipahost:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: "{{ host5_fqdn }}"
+        ip_address: "{{ ipv4_prefix + '.205' }}"
+        update_dns: yes
+        reverse: no
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: Host "{{ host5_fqdn }}" present again
+      ipahost:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: "{{ host5_fqdn }}"
+        ip_address: "{{ ipv4_prefix + '.205' }}"
+        update_dns: yes
+        reverse: no
+      register: result
+      failed_when: result.changed or result.failed
+
+    - name: Host "{{ host6_fqdn }}" present
+      ipahost:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: "{{ host6_fqdn }}"
+        ip_address: "{{ ipv4_prefix + '.206' }}"
+        update_dns: yes
+        reverse: no
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: Host "{{ host6_fqdn }}" present again
+      ipahost:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: "{{ host6_fqdn }}"
+        ip_address: "{{ ipv4_prefix + '.206' }}"
+        update_dns: yes
+        reverse: no
+      register: result
+      failed_when: result.changed or result.failed
+
+    - name: Hosts host1..host6 absent
+      ipahost:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name:
+        - "{{ host1_fqdn }}"
+        - "{{ host2_fqdn }}"
+        - "{{ host3_fqdn }}"
+        - "{{ host4_fqdn }}"
+        - "{{ host5_fqdn }}"
+        - "{{ host6_fqdn }}"
+        update_dns: yes
+        state: absent
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: Hosts host1..host6 absent again
+      ipahost:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name:
+        - "{{ host1_fqdn }}"
+        - "{{ host2_fqdn }}"
+        - "{{ host3_fqdn }}"
+        - "{{ host4_fqdn }}"
+        - "{{ host5_fqdn }}"
+        - "{{ host6_fqdn }}"
+        update_dns: yes
+        state: absent
+      register: result
+      failed_when: result.changed or result.failed
+
+    when: groups['ipaclients'] is defined

--- a/tests/hostgroup/test_hostgroup_client_context.yml
+++ b/tests/hostgroup/test_hostgroup_client_context.yml
@@ -1,0 +1,215 @@
+---
+- name: Test hostgroup
+  hosts: ipaclients
+  become: yes
+  gather_facts: yes
+
+  tasks:
+  - block:  # only execute tests if groups['ipaclients'] is defined.
+
+    - name: Get Domain from server name
+      set_fact:
+        ipaserver_domain: "{{ ansible_facts['fqdn'].split('.')[1:] | join ('.') }}"
+      when: ipaserver_domain is not defined
+
+    - name: Ensure host-group databases, mysql-server and oracle-server are absent
+      ipahostgroup:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name:
+        - databases
+        - mysql-server
+        - oracle-server
+        state: absent
+
+    - name: Test hosts db1 and db2 absent
+      ipahost:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name:
+        - "{{ 'db1.' + ipaserver_domain }}"
+        - "{{ 'db2.' + ipaserver_domain }}"
+        state: absent
+
+    - name: Host "{{ 'db1.' + ipaserver_domain }}" present
+      ipahost:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: "{{ 'db1.' + ipaserver_domain }}"
+        force: yes
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: Host "{{ 'db2.' + ipaserver_domain }}" present
+      ipahost:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: "{{ 'db2.' + ipaserver_domain }}"
+        force: yes
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: Execute with server context in the client.
+      ipahostgroup:
+        ipaadmin_password: SomeADMINpassword
+        name: mysql-server
+        state: present
+      register: result
+      failed_when: not (result.failed and "No module named 'ipaserver'" in result.msg)
+    
+    - name: Ensure host-group mysql-server is present
+      ipahostgroup:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: mysql-server
+        state: present
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: Ensure host-group mysql-server is present again
+      ipahostgroup:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: mysql-server
+        state: present
+      register: result
+      failed_when: result.changed or result.failed
+
+    - name: Ensure host-group oracle-server is present
+      ipahostgroup:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: oracle-server
+        state: present
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: Ensure host-group oracle-server is present again
+      ipahostgroup:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: oracle-server
+        state: present
+      register: result
+      failed_when: result.changed or result.failed
+
+    - name: Ensure host-group databases is present
+      ipahostgroup:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: databases
+        state: present
+        host:
+        - "{{ 'db1.' + ipaserver_domain }}"
+        hostgroup:
+        - oracle-server
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: Ensure host-group databases is present again
+      ipahostgroup:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: databases
+        state: present
+        host:
+        - "{{ 'db1.' + ipaserver_domain }}"
+        hostgroup:
+        - oracle-server
+      register: result
+      failed_when: result.changed or result.failed
+
+    - name: Ensure host db2 is member of host-group databases
+      ipahostgroup:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: databases
+        state: present
+        host:
+        - "{{ 'db2.' + ipaserver_domain }}"
+        action: member
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: Ensure host db2 is member of host-group databases again
+      ipahostgroup:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: databases
+        state: present
+        host:
+        - "{{ 'db2.' + ipaserver_domain }}"
+        action: member
+      register: result
+      failed_when: result.changed or result.failed
+
+    - name: Ensure host-group mysql-server is member of host-group databases
+      ipahostgroup:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: databases
+        state: present
+        hostgroup:
+        - mysql-server
+        action: member
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: Ensure host-group mysql-server is member of host-group databases again
+      ipahostgroup:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: databases
+        state: present
+        hostgroup:
+        - mysql-server
+        action: member
+      register: result
+      failed_when: result.changed or result.failed
+
+    - name: Ensure host-group oracle-server is member of host-group databases (again)
+      ipahostgroup:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: databases
+        state: present
+        hostgroup:
+        - oracle-server
+        action: member
+      register: result
+      failed_when: result.changed or result.failed
+
+    - name: Ensure host-group databases, mysql-server and oracle-server are absent
+      ipahostgroup:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name:
+        - databases
+        - mysql-server
+        - oracle-server
+        state: absent
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: Ensure host-group databases, mysql-server and oracle-server are absent again
+      ipahostgroup:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name:
+        - databases
+        - mysql-server
+        - oracle-server
+        state: absent
+      register: result
+      failed_when: result.changed or result.failed
+
+    - name: Test hosts db1 and db2 absent
+      ipahost:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name:
+        - "{{ 'db1.' + ipaserver_domain }}"
+        - "{{ 'db2.' + ipaserver_domain }}"
+        state: absent
+
+    when: groups['ipaclients'] is defined

--- a/tests/location/test_location_client_context.yml
+++ b/tests/location/test_location_client_context.yml
@@ -1,0 +1,91 @@
+---
+- name: Test location
+  hosts: ipaclients
+  become: yes
+  gather_facts: no
+
+  tasks:
+  - block:  # only execute tests if groups['ipaclients'] is defined.
+
+    # CLEANUP TEST ITEMS
+
+    - name: Ensure location my_location1 is absent
+      ipalocation:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: my_location1
+        state: absent
+
+    # CREATE TEST ITEMS
+
+    # TESTS
+
+    - name: Execute with server context in the client.
+      ipalocation:
+        ipaadmin_password: SomeADMINpassword
+        name: my_location1
+      register: result
+      failed_when: not (result.failed and "No module named 'ipaserver'" in result.msg)
+
+    - name: Ensure location my_location1 is present
+      ipalocation:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: my_location1
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: Ensure location my_location1 is present again
+      ipalocation:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: my_location1
+      register: result
+      failed_when: result.changed or result.failed
+
+    - name: Ensure location my_location1 is present with description
+      ipalocation:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: my_location1
+        description: My Location 1
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: Ensure location my_location1 is present again with description
+      ipalocation:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: my_location1
+        description: My Location 1
+      register: result
+      failed_when: result.changed or result.failed
+
+    - name: Ensure location my_location1 is absent
+      ipalocation:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: my_location1
+        state: absent
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: Ensure location my_location1 is absent again
+      ipalocation:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: my_location1
+        state: absent
+      register: result
+      failed_when: result.changed or result.failed
+
+    # CLEANUP TEST ITEMS
+
+    - name: Ensure location my_location1 is absent
+      ipalocation:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: my_location1
+        state: absent
+
+    when: groups['ipaclients'] is defined

--- a/tests/permission/test_permission_client_context.yml
+++ b/tests/permission/test_permission_client_context.yml
@@ -1,0 +1,419 @@
+---
+- name: Test permission
+  hosts: ipaclients
+  become: yes
+  gather_facts: yes
+
+  tasks:
+  - include_tasks: ../env_freeipa_facts.yml
+
+  - block:  # only execute tests if groups['ipaclients'] is defined.
+
+    - name: Ensure testing groups are present.
+      ipagroup:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: "{{ item }}"
+        state: present
+      with_items:
+        - rbacgroup1
+        - rbacgroup2
+
+    # CLEANUP TEST ITEMS
+
+    - name: Ensure permission perm-test-1 is absent
+      ipapermission:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name:
+        - perm-test-1
+        - perm-test-bindtype-test
+        - perm-test-renamed
+        state: absent
+
+    # TESTS
+
+    - name: Execute with server context in the client.
+      ipapermission:
+        ipaadmin_password: SomeADMINpassword
+        name:
+        - perm-test-1
+        - perm-test-bindtype-test
+        - perm-test-renamed
+        state: absent
+      register: result
+      failed_when: not (result.failed and "No module named 'ipaserver'" in result.msg)
+
+    - name: Ensure permission perm-test-1 is present
+      ipapermission:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: perm-test-1
+        object_type: host
+        memberof: rbacgroup1
+        filter: '(cn=*.ipa.*)'
+        right: all
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: Ensure permission perm-test-1 is present again
+      ipapermission:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: perm-test-1
+        object_type: host
+        memberof: rbacgroup1
+        filter: '(cn=*.ipa.*)'
+        right: all
+      register: result
+      failed_when: result.changed or result.failed
+
+    - name: Ensure permission perm-test-1 has an extra filter '(cn=*.internal.*)'
+      ipapermission:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: perm-test-1
+        filter: '(cn=*.internal.*)'
+        action: member
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: Ensure permission perm-test-1 has an extra filter '(cn=*.internal.*)', again
+      ipapermission:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: perm-test-1
+        filter: '(cn=*.internal.*)'
+        action: member
+      register: result
+      failed_when: result.changed or result.failed
+
+    - name: Ensure permission perm-test-1 `right` has `write`
+      ipapermission:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: perm-test-1
+        right: write
+        action: member
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: Ensure permission perm-test-1 `right` has `write`, again
+      ipapermission:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: perm-test-1
+        right: write
+        action: member
+      register: result
+      failed_when: result.changed or result.failed
+
+    - name: Ensure permission perm-test-1 `right` has no `write`
+      ipapermission:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: perm-test-1
+        right: write
+        action: member
+        state: absent
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: Ensure permission perm-test-1 `right` has no `write`, again
+      ipapermission:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: perm-test-1
+        right: write
+        action: member
+        state: absent
+      register: result
+      failed_when: result.changed or result.failed
+
+    - name: Ensure permission perm-test-1 `memberof` has `rbackgroup2`
+      ipapermission:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: perm-test-1
+        memberof: rbacgroup2
+        action: member
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: Ensure permission perm-test-1 `memberof` has `rbackgroup2`, again
+      ipapermission:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: perm-test-1
+        memberof: rbacgroup2
+        action: member
+      register: result
+      failed_when: result.changed or result.failed
+
+    - name: Ensure permission perm-test-1 `memberof` item `rbackgroup1` is absent
+      ipapermission:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: perm-test-1
+        memberof: rbacgroup1
+        action: member
+        state: absent
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: Ensure permission perm-test-1 `memberof` item `rbackgroup1` is absent, again
+      ipapermission:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: perm-test-1
+        memberof: rbacgroup1
+        action: member
+        state: absent
+      register: result
+      failed_when: result.changed or result.failed
+
+    - name: Ensure permission perm-test-1 is present with attr carlicense
+      ipapermission:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: perm-test-1
+        attrs:
+        - carlicense
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: Ensure permission perm-test-1 is present with attr carlicense again
+      ipapermission:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: perm-test-1
+        attrs:
+        - carlicense
+      register: result
+      failed_when: result.changed or result.failed
+
+    - name: Ensure permission perm-test-1 is present with attr carlicense and displayname
+      ipapermission:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: perm-test-1
+        attrs:
+        - carlicense
+        - displayname
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: Ensure permission perm-test-1 is present with attr carlicense and displayname again
+      ipapermission:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: perm-test-1
+        attrs:
+        - carlicense
+        - displayname
+      register: result
+      failed_when: result.changed or result.failed
+
+    - name: Ensure attr gecos is present in permission perm-test-1
+      ipapermission:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: perm-test-1
+        attrs:
+        - gecos
+        action: member
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: Ensure attr gecos is present in permission perm-test-1 again
+      ipapermission:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: perm-test-1
+        attrs:
+        - gecos
+        action: member
+      register: result
+      failed_when: result.changed or result.failed
+
+    - name: Ensure attr gecos is absent in permission perm-test-1
+      ipapermission:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: perm-test-1
+        attrs:
+        - gecos
+        action: member
+        state: absent
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: Ensure attr gecos is absent in permission perm-test-1 again
+      ipapermission:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: perm-test-1
+        attrs:
+        - gecos
+        action: member
+        state: absent
+      register: result
+      failed_when: result.changed or result.failed
+
+    - name: Ensure attributes carlicense and displayname are present in permission "System{{':'}} Update DNS Entries"
+      ipapermission:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: "System: Update DNS Entries"
+        attrs:
+        - carlicense
+        - displayname
+        action: member
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: Ensure attributes carlicense and displayname are present in permission "System{{':'}} Update DNS Entries" again
+      ipapermission:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: "System: Update DNS Entries"
+        attrs:
+        - carlicense
+        - displayname
+        action: member
+      register: result
+      failed_when: result.changed or result.failed
+
+    - name: Ensure attributes carlicense and displayname are present in permission "System{{':'}} Update DNS Entries"
+      ipapermission:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: "System: Update DNS Entries"
+        attrs:
+        - carlicense
+        - displayname
+        action: member
+        state: absent
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: Ensure attributes carlicense and displayname are present in permission "System{{':'}} Update DNS Entries" again
+      ipapermission:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: "System: Update DNS Entries"
+        attrs:
+        - carlicense
+        - displayname
+        action: member
+        state: absent
+      register: result
+      failed_when: result.changed or result.failed
+
+    - name: Ensure permission perm-test-1 has rawfilter '(objectclass=ipagroup)'
+      ipapermission:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: perm-test-1
+        rawfilter: '(objectclass=ipagroup)'
+        action: member
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: Ensure permission perm-test-1 has rawfilter '(objectclass=ipagroup)', again
+      ipapermission:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: perm-test-1
+        rawfilter: '(objectclass=ipagroup)'
+        action: member
+      register: result
+      failed_when: result.changed or result.failed
+
+    - name: Ensure filter and rawfilter cannot be used together.
+      ipapermission:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: perm-test-1
+        rawfilter: '(objectclass=ipagroup)'
+        filter: '(cn=*.internal.*)'
+        action: member
+      register: result
+      failed_when: not result.failed or "Cannot specify target filter and extra target filter simultaneously" not in result.msg
+
+    - name: Rename permission perm-test-1 to perm-test-renamed
+      ipapermission:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: perm-test-1
+        rename: perm-test-renamed
+        state: renamed
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: Ensure permission perm-test-1 is absent
+      ipapermission:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: perm-test-1
+        state: absent
+      register: result
+      failed_when: result.changed or result.failed
+
+    - name: Ensure permission perm-test-renamed is present
+      ipapermission:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: perm-test-renamed
+        object_type: host
+        right: all
+      register: result
+      failed_when: result.changed or result.failed
+
+    - name: Ensure permission with bindtype 'self' is present, if IPA version >= 4.8.7
+      ipapermission:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: perm-test-bindtype-test
+        bindtype: self
+        object_type: host
+        right: all
+      when: ipa_version is version('4.8.7', '>=')
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: Fail to set permission perm-test-renamed bindtype to 'self', if IPA version < 4.8.7
+      ipapermission:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: perm-test-bindtype-test
+        bindtype: self
+        object_type: host
+        right: all
+      when: ipa_version is version('4.8.7', '<')
+      register: result
+      failed_when: not result.failed or "Bindtype 'self' is not supported by your IPA version." not in result.msg
+
+    # CLEANUP TEST ITEMS
+
+    - name: Ensure testing permissions are absent
+      ipapermission:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name:
+        - perm-test-1
+        - perm-test-bindtype-test
+        - perm-test-renamed
+        state: absent
+
+    - name: Ensure testing groups are absent.
+      ipagroup:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: "{{ item }}"
+        state: absent
+      with_items:
+        - rbacgroup1
+        - rbacgroup2
+
+    when: groups['ipaclients'] is defined

--- a/tests/privilege/test_privilege_client_context.yml
+++ b/tests/privilege/test_privilege_client_context.yml
@@ -1,0 +1,206 @@
+---
+- name: Test privilege
+  hosts: ipaclients
+  become: yes
+  gather_facts: no
+
+  tasks:
+
+  - block:  # only execute tests if groups['ipaclients'] is defined.
+
+    # CLEANUP TEST ITEMS
+
+    - name: Ensure privilege "Broad Privilege" is absent
+      ipaprivilege:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name:
+        - Broad Privilege
+        - DNS Privilege
+        state: absent
+
+    # CREATE TEST ITEMS
+
+    # TESTS
+
+    - name: Execute with server context in the client.
+      ipaprivilege:
+        ipaadmin_password: SomeADMINpassword
+        name: Broad Privilege
+        description: Broad Privilege
+      register: result
+      failed_when: not (result.failed and "No module named 'ipaserver'" in result.msg)
+
+    - name: Ensure privilege Broad Privilege is present
+      ipaprivilege:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: Broad Privilege
+        description: Broad Privilege
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: Ensure privilege Broad Privilege is present again
+      ipaprivilege:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: Broad Privilege
+        description: Broad Privilege
+      register: result
+      failed_when: result.changed or result.failed
+
+    - name: Change privilege Broad Privilege description
+      ipaprivilege:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: Broad Privilege
+        description: Broad Privilege description
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: Ensure privilege Broad Privilege has permissions
+      ipaprivilege:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: Broad Privilege
+        permission:
+        - "Write IPA Configuration"
+        - "System: Write DNS Configuration"
+        - "System: Update DNS Entries"
+        action: member
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: Ensure privilege Broad Privilege has permissions, again
+      ipaprivilege:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: Broad Privilege
+        permission:
+        - "Write IPA Configuration"
+        - "System: Write DNS Configuration"
+        - "System: Update DNS Entries"
+        action: member
+      register: result
+      failed_when: result.changed or result.failed
+
+    - name: Ensure privilege Broad Privilege member permission "Write IPA Configuration" is absent
+      ipaprivilege:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: Broad Privilege
+        permission:
+        - "Write IPA Configuration"
+        action: member
+        state: absent
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: Ensure privilege Broad Privilege member permission "Write IPA Configuration" is absent again
+      ipaprivilege:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: Broad Privilege
+        permission:
+        - "Write IPA Configuration"
+        action: member
+        state: absent
+      register: result
+      failed_when: result.changed or result.failed
+
+    - name: Ensure privilege Broad Privilege is absent
+      ipaprivilege:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: Broad Privilege
+        state: absent
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: Ensure privilege Broad Privilege is present
+      ipaprivilege:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: Broad Privilege
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: Ensure privilege Broad Privilege is renamed to "DNS Privilege"
+      ipaprivilege:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: Broad Privilege
+        rename: DNS Privilege
+        state: renamed
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: Ensure privilege Broad Privilege cannot be renamed, because it does not exist.
+      ipaprivilege:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: Broad Privilege
+        rename: DNS Privilege
+        state: renamed
+      register: result
+      failed_when: not result.failed or "No privilege found to be renamed" not in result.msg
+
+    - name: Ensure privilege cannot be renamed to the same name.
+      ipaprivilege:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: DNS Privilege
+        rename: DNS Privilege
+        state: renamed
+      register: result
+      failed_when: result.changed or result.failed
+
+    - name: Ensure privilege cannot be renamed to the same name.
+      ipaprivilege:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: DNS Privilege
+        rename: DNS Privilege
+        state: renamed
+      register: result
+      failed_when: result.changed or result.failed
+
+    - name: Ensure "Broad Privilege" is absent.
+      ipaprivilege:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: Broad Privilege
+        state: absent
+
+    - name: Ensure privilege Broad Privilege is created with permission. (issue 529)
+      ipaprivilege:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: Broad Privilege
+        permission:
+        - "Write IPA Configuration"
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: Ensure privilege Broad Privilege is created with permission, again. (issue 529)
+      ipaprivilege:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: Broad Privilege
+        permission:
+        - "Write IPA Configuration"
+      register: result
+      failed_when: result.changed or result.failed
+
+    # CLEANUP TEST ITEMS
+
+    - name: Ensure privilege testing privileges are absent
+      ipaprivilege:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name:
+        - Broad Privilege
+        - DNS Privilege
+        state: absent
+
+    when: groups['ipaclients'] is defined

--- a/tests/pwpolicy/test_pwpolicy_client_context.yml
+++ b/tests/pwpolicy/test_pwpolicy_client_context.yml
@@ -1,0 +1,130 @@
+---
+- name: Test pwpolicy
+  hosts: ipaclients
+  become: no
+  gather_facts: no
+
+  tasks:
+  - block:  # only execute tests if groups['ipaclients'] is defined.
+
+    - name: Execute with server context in the client.
+      ipapwpolicy:
+        ipaadmin_password: SomeADMINpassword
+        maxlife: 90
+      register: result
+      failed_when: not (result.failed and "No module named 'ipaserver'" in result.msg)
+
+    - name: Ensure maxlife of 90 for global_policy
+      ipapwpolicy:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        maxlife: 90
+
+    - name: Ensure absence of group ops
+      ipagroup:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: ops
+        state: absent
+
+    - name: Ensure absence of pwpolicies for group ops
+      ipapwpolicy:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: ops
+        state: absent
+
+    - name: Ensure presence of group ops
+      ipagroup:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: ops
+        state: present
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: Ensure presence of pwpolicies for group ops
+      ipapwpolicy:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: ops
+        minlife: 7
+        maxlife: 49
+        history: 5
+        priority: 1
+        lockouttime: 300
+        minlength: 8
+        minclasses: 5
+        maxfail: 3
+        failinterval: 5
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: Ensure presence of pwpolicies for group ops again
+      ipapwpolicy:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: ops
+        minlife: 7
+        maxlife: 49
+        history: 5
+        priority: 1
+        lockouttime: 300
+        minlength: 8
+        minclasses: 5
+        maxfail: 3
+        failinterval: 5
+      register: result
+      failed_when: result.changed or result.failed
+
+    - name: Ensure maxlife of 49 for global_policy
+      ipapwpolicy:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        maxlife: 49
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: Ensure maxlife of 49 for global_policy again
+      ipapwpolicy:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        maxlife: 49
+      register: result
+      failed_when: result.changed or result.failed
+
+    - name: Ensure absence of pwpoliciy global_policy will fail
+      ipapwpolicy:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        state: absent
+      register: result
+      failed_when: not result.failed or "'global_policy' can not be made absent." not in result.msg
+
+    - name: Ensure absence of pwpolicies for group ops
+      ipapwpolicy:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: ops
+        state: absent
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: Ensure maxlife of 90 for global_policy
+      ipapwpolicy:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        maxlife: 90
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: Ensure absence of pwpolicies for group ops
+      ipapwpolicy:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: ops
+        state: absent
+      register: result
+      failed_when: result.changed or result.failed
+
+    when: groups['ipaclients'] is defined

--- a/tests/role/env_cleanup.yml
+++ b/tests/role/env_cleanup.yml
@@ -2,6 +2,7 @@
 - name: Ensure test user is absent.
   ipauser:
     ipaadmin_password: SomeADMINpassword
+    ipa_context: "{{ ipa_test_context | default('server') }}"
     name:
     - user01
     - user02
@@ -11,6 +12,7 @@
 - name: Ensure test group is absent.
   ipagroup:
     ipaadmin_password: SomeADMINpassword
+    ipa_context: "{{ ipa_test_context | default('server') }}"
     name:
     - group01
     - group02
@@ -19,6 +21,7 @@
 - name: Ensure test hostgroup is absent.
   ipahostgroup:
     ipaadmin_password: SomeADMINpassword
+    ipa_context: "{{ ipa_test_context | default('server') }}"
     name:
     - hostgroup01
     - hostgroup02
@@ -27,6 +30,7 @@
 - name: Ensure test host is absent.
   ipahost:
     ipaadmin_password: SomeADMINpassword
+    ipa_context: "{{ ipa_test_context | default('server') }}"
     name:
     - "{{ host1_fqdn }}"
     - "{{ host2_fqdn }}"
@@ -35,6 +39,7 @@
 - name: Ensure test service is absent.
   ipaservice:
     ipaadmin_password: SomeADMINpassword
+    ipa_context: "{{ ipa_test_context | default('server') }}"
     name:
     - "service01/{{ host1_fqdn }}"
     - "service02/{{ host2_fqdn }}"
@@ -43,6 +48,7 @@
 - name: Ensure test roles are absent.
   iparole:
     ipaadmin_password: SomeADMINpassword
+    ipa_context: "{{ ipa_test_context | default('server') }}"
     name:
     - renamerole
     - testrole

--- a/tests/role/env_facts.yml
+++ b/tests/role/env_facts.yml
@@ -7,7 +7,7 @@
 - name: Set fact for realm name
   set_fact:
     ipaserver_realm: "{{ ipaserver_domain }}  | upper"
-  when: ipaserver_domain is not defined
+  when: ipaserver_realm is not defined
 
 - name: Create FQDN for host01
   set_fact:

--- a/tests/role/env_setup.yml
+++ b/tests/role/env_setup.yml
@@ -5,6 +5,7 @@
 - name: Ensure test user is present.
   ipauser:
     ipaadmin_password: SomeADMINpassword
+    ipa_context: "{{ ipa_test_context | default('server') }}"
     users:
     - name: user01
       first: First
@@ -19,6 +20,7 @@
 - name: Ensure test group is present.
   ipagroup:
     ipaadmin_password: SomeADMINpassword
+    ipa_context: "{{ ipa_test_context | default('server') }}"
     name: "{{ item }}"
   with_items:
   - group01
@@ -27,6 +29,7 @@
 - name: Ensure test host is present.
   ipahost:
     ipaadmin_password: SomeADMINpassword
+    ipa_context: "{{ ipa_test_context | default('server') }}"
     name: "{{ item }}"
     force: yes
   with_items:
@@ -36,6 +39,7 @@
 - name: Ensure test hostgroup is present.
   ipahostgroup:
     ipaadmin_password: SomeADMINpassword
+    ipa_context: "{{ ipa_test_context | default('server') }}"
     name: "{{ item[0] }}"
     host:
       - "{{ item[1] }}"
@@ -46,6 +50,7 @@
 - name: Ensure test service is present.
   ipaservice:
     ipaadmin_password: SomeADMINpassword
+    ipa_context: "{{ ipa_test_context | default('server') }}"
     name: "{{ item }}"
     force: yes
   with_items:

--- a/tests/role/test_role_client_context.yml
+++ b/tests/role/test_role_client_context.yml
@@ -1,0 +1,118 @@
+---
+- name: Test service member in role module.
+  hosts: ipaclients
+  become: yes
+  gather_facts: yes
+
+  tasks:
+  - block:  # only execute tests if groups['ipaclients'] is defined.
+
+    - name: Set environment facts.
+      import_tasks: env_facts.yml
+
+    - name: Define client context.
+      set_fact:
+        ipa_test_context: client
+
+    - name: Setup environment.
+      import_tasks: env_setup.yml
+
+    # tests
+
+    - name: Execute with server context in the client.
+      iparole:
+        ipaadmin_password: SomeADMINpassword
+        name: testrole
+      register: result
+      failed_when: not (result.failed and "No module named 'ipaserver'" in result.msg)
+    
+    - name: Ensure role with member service is present.
+      iparole:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: testrole
+        service:
+        - "service01/{{ host1_fqdn }}"
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: Ensure role with member service is present, again.
+      iparole:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: testrole
+        service:
+        - "service01/{{ host1_fqdn }}"
+        action: member
+      register: result
+      failed_when: result.changed or result.failed
+
+    - name: Ensure role has member service absent.
+      iparole:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: testrole
+        service:
+        - "service01/{{ host1_fqdn }}"
+        action: member
+        state: absent
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: Ensure role has member service absent, again.
+      iparole:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: testrole
+        service:
+        - "service01/{{ host1_fqdn }}"
+        action: member
+        state: absent
+      register: result
+      failed_when: result.changed or result.failed
+
+    - name: Ensure role has member service with principal name.
+      iparole:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: testrole
+        service:
+        - "service01/{{ host1_fqdn }}@{{ ipaserver_realm }}"
+        action: member
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: Ensure role has member service with principal name, again.
+      iparole:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: testrole
+        service:
+        - "service01/{{ host1_fqdn }}@{{ ipaserver_realm }}"
+        action: member
+      register: result
+      failed_when: result.changed or result.failed
+
+    - name: Ensure role is absent.
+      iparole:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: testrole
+        state: absent
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: Ensure role is absent, again.
+      iparole:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: testrole
+        state: absent
+      register: result
+      failed_when: result.changed or result.failed
+
+    # cleanup
+    - name: Cleanup environment.
+      include_tasks: env_cleanup.yml
+
+    when: groups['ipaclients'] is defined

--- a/tests/selfservice/test_selfservice_client_context.yml
+++ b/tests/selfservice/test_selfservice_client_context.yml
@@ -1,0 +1,186 @@
+---
+- name: Test selfservice
+  hosts: ipaclients
+  become: no
+  gather_facts: no
+
+  tasks:
+  - block:  # only execute tests if groups['ipaclients'] is defined.
+
+    # CLEANUP TEST ITEMS
+
+    - name: Ensure selfservice "Users can manage their own name details" is absent
+      ipaselfservice:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: "Users can manage their own name details"
+        state: absent
+
+    # CREATE TEST ITEMS
+
+    # TESTS
+    
+    - name: Execute with server context in the client.
+      ipaselfservice:
+        ipaadmin_password: SomeADMINpassword
+        name: "Users can manage their own name details"
+      register: result
+      failed_when: not (result.failed and "No module named 'ipaserver'" in result.msg)
+
+    - name: Ensure selfservice "Users can manage their own name details" is present
+      ipaselfservice:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: "Users can manage their own name details"
+        permission: write
+        attribute:
+        - givenname
+        - displayname
+        - title
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: Ensure selfservice "Users can manage their own name details" is present again
+      ipaselfservice:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: "Users can manage their own name details"
+        permission: write
+        attribute:
+        - givenname
+        - displayname
+        - title
+      register: result
+      failed_when: result.changed or result.failed
+
+    - name: Ensure selfservice "Users can manage their own name details" is present with different attribute initials
+      ipaselfservice:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: "Users can manage their own name details"
+        permission: write
+        attribute:
+        - initials
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: Ensure selfservice "Users can manage their own name details" is present with different attribute initials again
+      ipaselfservice:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: "Users can manage their own name details"
+        permission: write
+        attribute:
+        - initials
+      register: result
+      failed_when: result.changed or result.failed
+
+    - name: Ensure selfservice "Users can manage their own name details" member attributes givenname, displayname and title are present
+      ipaselfservice:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: "Users can manage their own name details"
+        attribute:
+        - givenname
+        - displayname
+        - title
+        action: member
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: Ensure selfservice "Users can manage their own name details" member attributes givenname, displayname and title are present again
+      ipaselfservice:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: "Users can manage their own name details"
+        attribute:
+        - givenname
+        - displayname
+        - title
+        action: member
+      register: result
+      failed_when: result.changed or result.failed
+
+    - name: Ensure selfservice "Users can manage their own name details" member attribute title is absent
+      ipaselfservice:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: "Users can manage their own name details"
+        attribute:
+        - title
+        action: member
+        state: absent
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: Ensure selfservice "Users can manage their own name details" member attribute title is absent again
+      ipaselfservice:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: "Users can manage their own name details"
+        attribute:
+        - title
+        action: member
+        state: absent
+      register: result
+      failed_when: result.changed or result.failed
+
+    # TEST permission change
+
+    - name: Ensure selfservice "Users can manage their own name details" is present with different read,write permission
+      ipaselfservice:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: "Users can manage their own name details"
+        permission: read,write
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: Ensure selfservice "Users can manage their own name details" is present with different read,write permission again
+      ipaselfservice:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: "Users can manage their own name details"
+        permission: read,write
+      register: result
+      failed_when: result.changed or result.failed
+
+    - name: Ensure selfservice "Users can manage their own name details" fails with bad permission read,read
+      ipaselfservice:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: "Users can manage their own name details"
+        permission: read,read
+      register: result
+      failed_when: not result.failed or "Invalid permission" not in result.msg
+
+    - name: Ensure selfservice "Users can manage their own name details" fails with bad permission read,write,write
+      ipaselfservice:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: "Users can manage their own name details"
+        permission: read,write,write
+      register: result
+      failed_when: not result.failed or "Invalid permission" not in result.msg
+
+    - name: Ensure selfservice "Users can manage their own name details" fails with bad attribute title,title
+      ipaselfservice:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: "Users can manage their own name details"
+        attribute:
+        - title
+        - title
+      register: result
+      failed_when: not result.failed or "Invalid attribute" not in result.msg
+
+    # CLEANUP TEST ITEMS
+
+    - name: Ensure selfservice "Users can manage their own name details" is absent
+      ipaselfservice:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: "Users can manage their own name details"
+        state: absent
+
+    when: groups['ipaclients'] is defined

--- a/tests/server/test_server_client_context.yml
+++ b/tests/server/test_server_client_context.yml
@@ -1,0 +1,160 @@
+---
+- name: Test server
+  hosts: ipaclients
+  become: no
+  gather_facts: yes
+
+  tasks:
+  - block:  # only execute tests if groups['ipaclients'] is defined.
+
+    # CLEANUP TEST ITEMS
+
+    - name: Ensure server "{{ 'ipaserver.' + ipaserver_domain }}" without location
+      ipaserver:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: "{{ 'ipaserver.' + ipaserver_domain }}"
+        location: ""
+
+    - name: Ensure server "{{ 'ipaserver.' + ipaserver_domain }}" without service weight
+      ipaserver:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: "{{ 'ipaserver.' + ipaserver_domain }}"
+        service_weight: -1
+
+    - name: Ensure location "mylocation" is absent
+      ipalocation:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: mylocation
+        state: absent
+
+  # CREATE TEST ITEMS
+
+    - name: Ensure location "mylocation" is present
+      ipalocation:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: mylocation
+      register: result
+      failed_when: not result.changed or result.failed
+
+    # TESTS
+
+    - name: Execute with server context in the client.
+      ipaserver:
+        ipaadmin_password: SomeADMINpassword
+        name: "{{ 'ipaserver.' + ipaserver_domain }}"
+      register: result
+      failed_when: not (result.failed and "No module named 'ipaserver'" in result.msg)
+
+    - name: Ensure server "{{ 'ipaserver.' + ipaserver_domain }}" is present
+      ipaserver:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: "{{ 'ipaserver.' + ipaserver_domain }}"
+      register: result
+      failed_when: result.changed or result.failed
+
+    - name: Ensure server "{{ 'ipaserver.' + ipaserver_domain }}" with location "mylocation"
+      ipaserver:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: "{{ 'ipaserver.' + ipaserver_domain }}"
+        location: "mylocation"
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: Ensure server "{{ 'ipaserver.' + ipaserver_domain }}" with location "mylocation" again
+      ipaserver:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: "{{ 'ipaserver.' + ipaserver_domain }}"
+        location: "mylocation"
+      register: result
+      failed_when: result.changed or result.failed
+
+    - name: Ensure server "{{ 'ipaserver.' + ipaserver_domain }}" without location
+      ipaserver:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: "{{ 'ipaserver.' + ipaserver_domain }}"
+        location: ""
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: Ensure server "{{ 'ipaserver.' + ipaserver_domain }}" without location again
+      ipaserver:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: "{{ 'ipaserver.' + ipaserver_domain }}"
+        location: ""
+      register: result
+      failed_when: result.changed or result.failed
+
+    - name: Ensure server "{{ 'ipaserver.' + ipaserver_domain }}" with service weight 1
+      ipaserver:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: "{{ 'ipaserver.' + ipaserver_domain }}"
+        service_weight: 1
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: Ensure server "{{ 'ipaserver.' + ipaserver_domain }}" with service weight 1 again
+      ipaserver:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: "{{ 'ipaserver.' + ipaserver_domain }}"
+        service_weight: 1
+      register: result
+      failed_when: result.changed or result.failed
+
+    - name: Ensure server "{{ 'ipaserver.' + ipaserver_domain }}" without service weight
+      ipaserver:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: "{{ 'ipaserver.' + ipaserver_domain }}"
+        service_weight: -1
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: Ensure server "{{ 'ipaserver.' + ipaserver_domain }}" without service weight again
+      ipaserver:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: "{{ 'ipaserver.' + ipaserver_domain }}"
+        service_weight: -1
+      register: result
+      failed_when: result.changed or result.failed
+
+    # hidden requires an additional server, not tested
+
+    # absent requires an additional server, only sanity test with absent server
+
+    - name: Ensure server "{{ 'absent.' + ipaserver_domain }}" is absent
+      ipaserver:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: "{{ 'absent.' + ipaserver_domain }}"
+        state: absent
+      register: result
+      failed_when: result.changed or result.failed
+
+    # ignore_last_of_role requires an additional server, not tested
+
+    # ignore_topology_disconnect requires an additional server, not tested
+
+    # CLEANUP TEST ITEMS
+
+    - name: Ensure location "mylocation" is absent
+      ipalocation:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: mylocation
+        state: absent
+      register: result
+      failed_when: not result.changed or result.failed
+
+    when: groups['ipaclients'] is defined

--- a/tests/service/env_cleanup.yml
+++ b/tests/service/env_cleanup.yml
@@ -3,6 +3,7 @@
 - name: Ensure services are absent.
   ipaservice:
     ipaadmin_password: SomeADMINpassword
+    ipa_context: "{{ ipa_test_context | default('server') }}"
     name:
       - "HTTP/{{ svc_fqdn }}"
       - "HTTP/{{ nohost_fqdn }}"
@@ -16,6 +17,7 @@
 - name: Ensure host "{{ svc_fqdn }}" is absent
   ipahost:
     ipaadmin_password: SomeADMINpassword
+    ipa_context: "{{ ipa_test_context | default('server') }}"
     name: "{{ svc_fqdn }}"
     update_dns: yes
     state: absent
@@ -23,6 +25,7 @@
 - name: Ensure host is absent
   ipahost:
     ipaadmin_password: SomeADMINpassword
+    ipa_context: "{{ ipa_test_context | default('server') }}"
     name:
       - "{{ host1_fqdn }}"
       - "{{ host2_fqdn }}"
@@ -34,6 +37,7 @@
 - name: Ensure testing users are absent.
   ipauser:
     ipaadmin_password: SomeADMINpassword
+    ipa_context: "{{ ipa_test_context | default('server') }}"
     name:
     - user01
     - user02
@@ -42,6 +46,7 @@
 - name: Ensure testing groups are absent.
   ipagroup:
     ipaadmin_password: SomeADMINpassword
+    ipa_context: "{{ ipa_test_context | default('server') }}"
     name:
     - group01
     - group02
@@ -50,6 +55,7 @@
 - name: Ensure testing hostgroup hostgroup01 is absent.
   ipagroup:
     ipaadmin_password: SomeADMINpassword
+    ipa_context: "{{ ipa_test_context | default('server') }}"
     name:
       - hostgroup01
     state: absent
@@ -57,6 +63,7 @@
 - name: Ensure testing hostgroup hostgroup02 is absent.
   ipagroup:
     ipaadmin_password: SomeADMINpassword
+    ipa_context: "{{ ipa_test_context | default('server') }}"
     name:
       - hostgroup02
     state: absent
@@ -64,6 +71,7 @@
 - name: Remove IP address for "nohost" host.
   ipadnsrecord:
     ipaadmin_password: SomeADMINpassword
+    ipa_context: "{{ ipa_test_context | default('server') }}"
     zone_name: "{{ test_domain }}."
     name: nohost
     del_all: yes

--- a/tests/service/env_setup.yml
+++ b/tests/service/env_setup.yml
@@ -10,6 +10,7 @@
 - name: Add IP address for "nohost" host.
   ipadnsrecord:
     ipaadmin_password: SomeADMINpassword
+    ipa_context: "{{ ipa_test_context | default('server') }}"
     zone_name: "{{ test_domain }}."
     name: nohost
     a_ip_address: "{{ ipv4_prefix + '.100' }}"
@@ -17,6 +18,7 @@
 - name: Add hosts for tests.
   ipahost:
     ipaadmin_password: SomeADMINpassword
+    ipa_context: "{{ ipa_test_context | default('server') }}"
     hosts:
       - name: "{{ host1_fqdn }}"
         ip_address: "{{ ipv4_prefix + '.101' }}"
@@ -31,6 +33,7 @@
 - name: Ensure testing user user01 is present.
   ipauser:
     ipaadmin_password: SomeADMINpassword
+    ipa_context: "{{ ipa_test_context | default('server') }}"
     name: user01
     first: user01
     last: last
@@ -38,6 +41,7 @@
 - name: Ensure testing user user02 is present.
   ipauser:
     ipaadmin_password: SomeADMINpassword
+    ipa_context: "{{ ipa_test_context | default('server') }}"
     name: user02
     first: user02
     last: last
@@ -45,19 +49,23 @@
 - name: Ensure testing group group01 is present.
   ipagroup:
     ipaadmin_password: SomeADMINpassword
+    ipa_context: "{{ ipa_test_context | default('server') }}"
     name: group01
 
 - name: Ensure testing group group02 is present.
   ipagroup:
     ipaadmin_password: SomeADMINpassword
+    ipa_context: "{{ ipa_test_context | default('server') }}"
     name: group02
 
 - name: Ensure testing hostgroup hostgroup01 is present.
   ipahostgroup:
     ipaadmin_password: SomeADMINpassword
+    ipa_context: "{{ ipa_test_context | default('server') }}"
     name: hostgroup01
 
 - name: Ensure testing hostgroup hostgroup02 is present.
   ipahostgroup:
     ipaadmin_password: SomeADMINpassword
+    ipa_context: "{{ ipa_test_context | default('server') }}"
     name: hostgroup02

--- a/tests/service/test_service_client_context.yml
+++ b/tests/service/test_service_client_context.yml
@@ -1,0 +1,389 @@
+---
+- name: Test service using client context.
+  hosts: ipaclients
+  become: no
+  gather_facts: yes
+
+  tasks:
+
+  - block:  # only execute tests if groups['ipaclients'] is defined.
+
+    # setup
+    - name: Setup test context.
+      set_fact:
+        ipa_test_context: client
+
+    - name: Setup test environment
+      include_tasks: env_setup.yml
+
+    # tests
+    - name: Execute with server context in the client.
+      ipaservice:
+        ipaadmin_password: SomeADMINpassword
+        name: "HTTP/{{ svc_fqdn }}"
+      register: result
+      failed_when: not (result.failed and "No module named 'ipaserver'" in result.msg)
+
+    - name: Ensure service is present
+      ipaservice:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: "HTTP/{{ svc_fqdn }}"
+        pac_type:
+          - MS-PAC
+          - PAD
+        auth_ind: otp
+        force: no
+        requires_pre_auth: yes
+        ok_as_delegate: no
+        ok_to_auth_as_delegate: no
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: Ensure service is present, again
+      ipaservice:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: "HTTP/{{ svc_fqdn }}"
+        pac_type:
+          - MS-PAC
+          - PAD
+        auth_ind: otp
+        force: no
+        requires_pre_auth: yes
+        ok_as_delegate: no
+        ok_to_auth_as_delegate: no
+      register: result
+      failed_when: result.changed or result.failed
+
+    - name: Modify service.
+      ipaservice:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: "HTTP/{{ svc_fqdn }}"
+        pac_type: NONE
+        ok_as_delegate: yes
+        ok_to_auth_as_delegate: yes
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: Modify service, again.
+      ipaservice:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: "HTTP/{{ svc_fqdn }}"
+        pac_type: NONE
+        ok_as_delegate: yes
+        ok_to_auth_as_delegate: yes
+      register: result
+      failed_when: result.changed or result.failed
+
+    - name: Ensure service is present, with host not in DNS.
+      ipaservice:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: HTTP/svc.ihavenodns.info
+        force: yes
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: Ensure service is present, with host not in DNS, again.
+      ipaservice:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: HTTP/svc.ihavenodns.info
+        force: yes
+      register: result
+      failed_when: result.changed or result.failed
+
+    - name: Principal host/test.example.com present in service.
+      ipaservice:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: "HTTP/{{ svc_fqdn }}"
+        principal:
+          - host/test.example.com
+        action: member
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: Principal host/test.example.com present in service, again.
+      ipaservice:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: "HTTP/{{ svc_fqdn }}"
+        principal:
+          - host/test.example.com
+        action: member
+      register: result
+      failed_when:
+        result.changed or (result.failed and "already contains one or more values" not in result.msg)
+
+    - name: Principal host/test.example.com absent in service.
+      ipaservice:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: "HTTP/{{ svc_fqdn }}"
+        principal:
+          - host/test.example.com
+        action: member
+        state: absent
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: Principal host/test.example.com absent in service, again.
+      ipaservice:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: "HTTP/{{ svc_fqdn }}"
+        principal:
+          - host/test.example.com
+        action: member
+        state: absent
+      register: result
+      failed_when:
+        result.changed or (result.failed and "does not contain 'one or more values to remove'" not in result.msg)
+
+    - name: Ensure host can manage service.
+      ipaservice:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: "HTTP/{{ svc_fqdn }}"
+        host:
+        - "{{ host1_fqdn }}"
+        - "{{ host2_fqdn }}"
+        action: member
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: Ensure host can manage service, again.
+      ipaservice:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: "HTTP/{{ svc_fqdn }}"
+        host: "{{ host1_fqdn }}"
+        action: member
+      register: result
+      failed_when: result.changed or result.failed
+
+    - name: Ensure host cannot manage service.
+      ipaservice:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: "HTTP/{{ svc_fqdn }}"
+        host:
+        - "{{ host1_fqdn }}"
+        - "{{ host2_fqdn }}"
+        action: member
+        state: absent
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: Ensure host cannot manage service, again.
+      ipaservice:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: "HTTP/{{ svc_fqdn }}"
+        host:
+        - "{{ host1_fqdn }}"
+        - "{{ host2_fqdn }}"
+        action: member
+        state: absent
+      register: result
+      failed_when: result.changed or result.failed
+
+    - name: Service "HTTP/{{ svc_fqdn }}" members allow_create_keytab present for users, groups, hosts and hostgroups.
+      ipaservice:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: "HTTP/{{ svc_fqdn }}"
+        allow_create_keytab_user:
+        - user01
+        - user02
+        allow_create_keytab_group:
+        - group01
+        - group02
+        allow_create_keytab_host:
+        - "{{ host1_fqdn }}"
+        - "{{ host2_fqdn }}"
+        allow_create_keytab_hostgroup:
+        - hostgroup01
+        - hostgroup02
+        action: member
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: Service "HTTP/{{ svc_fqdn }}" members allow_create_keytab present for users, groups, hosts and hostgroups, again.
+      ipaservice:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: "HTTP/{{ svc_fqdn }}"
+        allow_create_keytab_user:
+        - user01
+        - user02
+        allow_create_keytab_group:
+        - group01
+        - group02
+        allow_create_keytab_host:
+        - "{{ host1_fqdn }}"
+        - "{{ host2_fqdn }}"
+        allow_create_keytab_hostgroup:
+        - hostgroup01
+        - hostgroup02
+        action: member
+      register: result
+      failed_when: result.changed or result.failed
+
+    - name: Service "HTTP/{{ svc_fqdn }}" members allow_create_keytab absent for users, groups, hosts and hostgroups.
+      ipaservice:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: "HTTP/{{ svc_fqdn }}"
+        allow_create_keytab_user:
+        - user01
+        - user02
+        allow_create_keytab_group:
+        - group01
+        - group02
+        allow_create_keytab_host:
+        - "{{ host1_fqdn }}"
+        - "{{ host2_fqdn }}"
+        allow_create_keytab_hostgroup:
+        - hostgroup01
+        - hostgroup02
+        action: member
+        state: absent
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: Service "HTTP/{{ svc_fqdn }}" members allow_create_keytab absent for users, groups, hosts and hostgroups, again.
+      ipaservice:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: "HTTP/{{ svc_fqdn }}"
+        allow_create_keytab_user:
+        - user01
+        - user02
+        allow_create_keytab_group:
+        - group01
+        - group02
+        allow_create_keytab_host:
+        - "{{ host1_fqdn }}"
+        - "{{ host2_fqdn }}"
+        allow_create_keytab_hostgroup:
+        - hostgroup01
+        - hostgroup02
+        action: member
+        state: absent
+      register: result
+      failed_when: result.changed or result.failed
+
+    - name: Service "HTTP/{{ svc_fqdn }}" members allow_retrieve_keytab present for users, groups, hosts and hostgroups
+      ipaservice:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: "HTTP/{{ svc_fqdn }}"
+        allow_retrieve_keytab_user:
+        - user01
+        - user02
+        allow_retrieve_keytab_group:
+        - group01
+        - group02
+        allow_retrieve_keytab_host:
+        - "{{ host1_fqdn }}"
+        - "{{ host2_fqdn }}"
+        allow_retrieve_keytab_hostgroup:
+        - hostgroup01
+        - hostgroup02
+        action: member
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: Service "HTTP/{{ svc_fqdn }}" members allow_retrieve_keytab present for users, groups, hosts and hostgroups, again.
+      ipaservice:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: "HTTP/{{ svc_fqdn }}"
+        allow_retrieve_keytab_user:
+        - user01
+        - user02
+        allow_retrieve_keytab_group:
+        - group01
+        - group02
+        allow_retrieve_keytab_host:
+        - "{{ host1_fqdn }}"
+        - "{{ host2_fqdn }}"
+        allow_retrieve_keytab_hostgroup:
+        - hostgroup01
+        - hostgroup02
+        action: member
+      register: result
+      failed_when: result.changed or result.failed
+
+    - name: Service "HTTP/{{ svc_fqdn }}" members allow_retrieve_keytab absent for users, groups, hosts and hostgroups.
+      ipaservice:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: "HTTP/{{ svc_fqdn }}"
+        allow_retrieve_keytab_user:
+        - user01
+        - user02
+        allow_retrieve_keytab_group:
+        - group01
+        - group02
+        allow_retrieve_keytab_host:
+        - "{{ host1_fqdn }}"
+        - "{{ host2_fqdn }}"
+        allow_retrieve_keytab_hostgroup:
+        - hostgroup01
+        - hostgroup02
+        action: member
+        state: absent
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: Service "HTTP/{{ svc_fqdn }}" members allow_retrieve_keytab absent for users, groups, hosts and hostgroups, again.
+      ipaservice:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: "HTTP/{{ svc_fqdn }}"
+        allow_retrieve_keytab_user:
+        - user01
+        - user02
+        allow_retrieve_keytab_group:
+        - group01
+        - group02
+        allow_retrieve_keytab_host:
+        - "{{ host1_fqdn }}"
+        - "{{ host2_fqdn }}"
+        allow_retrieve_keytab_hostgroup:
+        - hostgroup01
+        - hostgroup02
+        action: member
+        state: absent
+      register: result
+      failed_when: result.changed or result.failed
+
+    #
+    - name: Ensure service is absent
+      ipaservice:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: "HTTP/{{ svc_fqdn }}"
+        continue: yes
+        state: absent
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: Ensure service is absent, again
+      ipaservice:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: "HTTP/{{ svc_fqdn }}"
+        state: absent
+      register: result
+      failed_when: result.changed or result.failed
+
+    # cleanup
+    - name: Cleanup test environment
+      include_tasks: env_cleanup.yml

--- a/tests/sudocmd/test_sudocmd_client_context.yml
+++ b/tests/sudocmd/test_sudocmd_client_context.yml
@@ -1,0 +1,146 @@
+---
+- name: Test sudocmd
+  hosts: ipaclients
+  become: no
+  gather_facts: no
+
+  tasks:
+  - block:  # only execute tests if groups['ipaclients'] is defined.
+
+    - name: Execute with server context in the client.
+      ipasudocmd:
+        ipaadmin_password: SomeADMINpassword
+        name:
+        - /usr/bin/su
+      register: result
+      failed_when: not (result.failed and "No module named 'ipaserver'" in result.msg)
+
+    - name: Ensure sudocmds are absent
+      ipasudocmd:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name:
+        - /usr/bin/su
+        - /usr/sbin/ifconfig
+        - /usr/sbin/iwlist
+        state: absent
+
+    - name: Ensure sudocmd is present
+      ipasudocmd:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: /usr/bin/su
+        state: present
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: Ensure sudocmd is present again
+      ipasudocmd:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: /usr/bin/su
+        state: present
+      register: result
+      failed_when: result.changed or result.failed
+
+    - name: Ensure sudocmd is absent
+      ipasudocmd:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: /usr/bin/su
+        state: absent
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: Ensure sudocmd is absent again
+      ipasudocmd:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: /usr/bin/su
+        state: absent
+      register: result
+      failed_when: result.changed or result.failed
+
+    - name: Ensure multiple sudocmd are present
+      ipasudocmd:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name:
+        - /usr/sbin/ifconfig
+        - /usr/sbin/iwlist
+        state: present
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: Ensure multiple sudocmd are present again
+      ipasudocmd:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name:
+        - /usr/sbin/ifconfig
+        - /usr/sbin/iwlist
+        state: present
+      register: result
+      failed_when: result.changed or result.failed
+
+    - name: Ensure multiple sudocmd are absent
+      ipasudocmd:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name:
+        - /usr/sbin/ifconfig
+        - /usr/sbin/iwlist
+        state: absent
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: Ensure multiple sudocmd are absent again
+      ipasudocmd:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name:
+        - /usr/sbin/ifconfig
+        - /usr/sbin/iwlist
+        state: absent
+      register: result
+      failed_when: result.changed or result.failed
+
+    - name: Ensure sudocmds are absent
+      ipasudocmd:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name:
+        - /usr/bin/su
+        - /usr/sbin/ifconfig
+        - /usr/sbin/iwlist
+        state: absent
+
+    - name: Ensure sudocmds are absent
+      ipasudocmd:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name:
+        - /usr/sbin/ifconfig
+        state: absent
+
+    - name: Ensure sudocmds are present
+      ipasudocmd:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name:
+        - /usr/sbin/iwlist
+        state: present
+
+    - name: Ensure multiple sudocmd are absent when only one was present
+      ipasudocmd:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name:
+        - /usr/sbin/ifconfig
+        - /usr/sbin/iwlist
+        state: absent
+      register: result
+      failed_when: not result.changed or result.failed
+
+    when: groups['ipaclients'] is defined
+

--- a/tests/sudocmdgroup/test_sudocmdgroup_client_context.yml
+++ b/tests/sudocmdgroup/test_sudocmdgroup_client_context.yml
@@ -1,0 +1,240 @@
+---
+- name: Test sudocmdgroup
+  hosts: ipaclients
+  become: no
+  gather_facts: no
+
+  tasks:
+  - block:  # only execute tests if groups['ipaclients'] is defined.
+
+    - name: Ensure sudocmds are present
+      ipasudocmd:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name:
+        - /usr/bin/su
+        - /usr/sbin/ifconfig
+        - /usr/sbin/iwlist
+        state: present
+
+    - name: Execute with server context in the client.
+      ipasudocmdgroup:
+        ipaadmin_password: SomeADMINpassword
+        name: network
+      register: result
+      failed_when: not (result.failed and "No module named 'ipaserver'" in result.msg)
+
+    - name: Ensure sudocmdgroup is absent
+      ipasudocmdgroup:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: network
+        state: absent
+
+    - name: Ensure sudocmdgroup is present
+      ipasudocmdgroup:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: network
+        state: present
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: Ensure sudocmdgroup is present again
+      ipasudocmdgroup:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: network
+        state: present
+      register: result
+      failed_when: result.changed or result.failed
+
+    - name: Ensure sudocmdgroup is absent
+      ipasudocmdgroup:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: network
+        state: absent
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: Ensure sudocmdgroup is absent again
+      ipasudocmdgroup:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: network
+        state: absent
+      register: result
+      failed_when: result.changed or result.failed
+
+    - name: Ensure sudocmdgroup is present, with sudocmds.
+      ipasudocmdgroup:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: network
+        sudocmd:
+        - /usr/sbin/ifconfig
+        - /usr/sbin/iwlist
+        state: present
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: Ensure sudocmdgroup is present, with sudocmds, again.
+      ipasudocmdgroup:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: network
+        sudocmd:
+        - /usr/sbin/ifconfig
+        - /usr/sbin/iwlist
+        state: present
+      register: result
+      failed_when: result.changed or result.failed
+
+    - name: Verify sudocmdgroup creation with sudocmds
+      shell: |
+        echo SomeADMINpassword | kinit -c verify_sudocmdgroup admin
+        KRB5CCNAME="verify_sudocmdgroup" ipa sudocmdgroup-show network --all
+        kdestroy -A -q -c verify_sudocmdgroup
+      register: result
+      failed_when: result.failed or not("/usr/sbin/ifconfig" in result.stdout and "/usr/sbin/iwlist" in result.stdout)
+
+    - name: Ensure sudocmdgroup, with sudocmds, is absent
+      ipasudocmdgroup:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: network
+        state: absent
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: Ensure sudocmdgroup, with sudocmds, is absent again
+      ipasudocmdgroup:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: network
+        state: absent
+      register: result
+      failed_when: result.changed or result.failed
+
+    - name: Ensure testing sudocmdgroup is present
+      ipasudocmdgroup:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: network
+        state: present
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: Ensure sudo commands are present in existing sudocmdgroup
+      ipasudocmdgroup:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: network
+        sudocmd:
+        - /usr/sbin/ifconfig
+        - /usr/sbin/iwlist
+        action: member
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: Ensure sudo commands are present in existing sudocmdgroup, again
+      ipasudocmdgroup:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: network
+        sudocmd:
+        - /usr/sbin/ifconfig
+        - /usr/sbin/iwlist
+        action: member
+      register: result
+      failed_when: result.changed or result.failed
+
+    - name: Ensure sudo commands are absent in existing sudocmdgroup
+      ipasudocmdgroup:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: network
+        sudocmd:
+        - /usr/sbin/ifconfig
+        - /usr/sbin/iwlist
+        action: member
+        state: absent
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: Ensure sudo commands are absent in existing sudocmdgroup, again
+      ipasudocmdgroup:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: network
+        sudocmd:
+        - /usr/sbin/ifconfig
+        - /usr/sbin/iwlist
+        action: member
+        state: absent
+      register: result
+      failed_when: result.changed or result.failed
+
+    - name: Ensure sudo commands are present in sudocmdgroup
+      ipasudocmdgroup:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: network
+        sudocmd:
+        - /usr/sbin/ifconfig
+        - /usr/sbin/iwlist
+        action: member
+        state: present
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: Ensure one sudo command is not present in sudocmdgroup
+      ipasudocmdgroup:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: network
+        sudocmd:
+        - /usr/sbin/ifconfig
+        action: member
+        state: absent
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: Ensure one sudo command is present in sudocmdgroup
+      ipasudocmdgroup:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: network
+        sudocmd:
+        - /usr/sbin/ifconfig
+        action: member
+        state: present
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: Ensure the other sudo command is not present in sudocmdgroup
+      ipasudocmdgroup:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: network
+        sudocmd:
+        - /usr/sbin/iwlist
+        action: member
+        state: absent
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: Ensure the other sudo commandsis not present in sudocmdgroup, again
+      ipasudocmdgroup:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: network
+        sudocmd:
+        - /usr/sbin/iwlist
+        action: member
+        state: absent
+      register: result
+      failed_when: result.changed or result.failed
+
+    when: groups['ipaclients'] is defined

--- a/tests/sudorule/test_sudorule_client_context.yml
+++ b/tests/sudorule/test_sudorule_client_context.yml
@@ -1,0 +1,295 @@
+---
+- name: Test sudorule in client context
+  hosts: ipaclients
+  become: yes
+  gather_facts: yes
+
+  tasks:
+  - block:  # only execute tests if groups['ipaclients'] is defined.
+
+    - name: Get Domain from the server name
+      set_fact:
+        ipaserver_domain: "{{ ansible_facts['fqdn'].split('.')[1:] | join ('.') }}"
+
+    - name: Ensure sudorules are absent
+      ipasudorule:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name:
+        - allusers
+        state: absent
+
+    - name: Execute with server context in the client.
+      ipasudorule:
+        ipaadmin_password: SomeADMINpassword
+        name: allusers
+        usercategory: all
+      register: result
+      failed_when: not (result.failed and "No module named 'ipaserver'" in result.msg)
+
+    - name: Ensure sudorule is present, with usercategory 'all'
+      ipasudorule:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: allusers
+        usercategory: all
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: Ensure sudorule is present, with usercategory 'all', again.
+      ipasudorule:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: allusers
+        usercategory: all
+      register: result
+      failed_when: result.changed or result.failed
+
+    - name: Ensure sudorule is present, with no usercategory.
+      ipasudorule:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: allusers
+        usercategory: ""
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: Ensure sudorule is present, with no usercategory, again.
+      ipasudorule:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: allusers
+        usercategory: ""
+      register: result
+      failed_when: result.changed or result.failed
+
+    - name: Ensure sudorule is present, with hostcategory 'all'
+      ipasudorule:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: allusers
+        hostcategory: all
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: Ensure sudorule is present, with hostcategory 'all', again.
+      ipasudorule:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: allusers
+        hostcategory: all
+      register: result
+      failed_when: result.changed or result.failed
+
+    - name: Ensure sudorule is present, with no usercategory.
+      ipasudorule:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: allusers
+        hostcategory: ""
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: Ensure sudorule is present, with no hostcategory, again.
+      ipasudorule:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: allusers
+        hostcategory: ""
+      register: result
+      failed_when: result.changed or result.failed
+
+    - name: Ensure sudorule is present, with cmdcategory 'all'
+      ipasudorule:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: allusers
+        cmdcategory: all
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: Ensure sudorule is present, with cmdcategory 'all', again.
+      ipasudorule:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: allusers
+        cmdcategory: all
+      register: result
+      failed_when: result.changed or result.failed
+
+    - name: Ensure sudorule is present, with no cmdcategory.
+      ipasudorule:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: allusers
+        cmdcategory: ""
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: Ensure sudorule is present, with no cmdcategory, again.
+      ipasudorule:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: allusers
+        cmdcategory: ""
+      register: result
+      failed_when: result.changed or result.failed
+
+    - name: Ensure sudorule is present, with runasusercategory 'all'
+      ipasudorule:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: allusers
+        runasusercategory: all
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: Ensure sudorule is present, with runasusercategory 'all', again.
+      ipasudorule:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: allusers
+        runasusercategory: all
+      register: result
+      failed_when: result.changed or result.failed
+
+    - name: Ensure sudorule is present, with no runasusercategory.
+      ipasudorule:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: allusers
+        runasusercategory: ""
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: Ensure sudorule is present, with no runasusercategory, again.
+      ipasudorule:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: allusers
+        runasusercategory: ""
+      register: result
+      failed_when: result.changed or result.failed
+
+    - name: Ensure sudorule is present, with runasgroupcategory 'all'
+      ipasudorule:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: allusers
+        runasgroupcategory: all
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: Ensure sudorule is present, with runasgroupcategory 'all', again.
+      ipasudorule:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: allusers
+        runasgroupcategory: all
+      register: result
+      failed_when: result.changed or result.failed
+
+    - name: Ensure sudorule is present, with no runasgroupcategory.
+      ipasudorule:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: allusers
+        runasgroupcategory: ""
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: Ensure sudorule is present, with no runasgroupcategory, again.
+      ipasudorule:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: allusers
+        runasgroupcategory: ""
+      register: result
+      failed_when: result.changed or result.failed
+
+    - name: Ensure sudorules are absent
+      ipasudorule:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name:
+        - allusers
+        state: absent
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: Ensure `host` cannot be added if hostcategory is `all`.
+      ipasudorule:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: allusers
+        description: sudo rule
+        host: "{{ 'shouldfail.' + ipaserver_domain }}"
+        hostcategory: "all"
+      register: result
+      failed_when: not result.failed or "Hosts cannot be added when host category='all'" not in result.msg
+
+    - name: Ensure `hostgroup` cannot be added if hostcategory is `all`.
+      ipasudorule:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: allusers
+        description: sudo rule
+        hostgroup: shouldfail_hostgroup
+        hostcategory: "all"
+      register: result
+      failed_when: not result.failed or "Hosts cannot be added when host category='all'" not in result.msg
+
+    - name: Ensure `user` cannot be added if usercategory is `all`.
+      ipasudorule:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: allusers
+        description: sudo rule
+        user: "shouldfail01"
+        usercategory: "all"
+      register: result
+      failed_when: not result.failed or "Users cannot be added when user category='all'" not in result.msg
+
+    - name: Ensure `group` cannot be added if usercategory is `all`.
+      ipasudorule:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: allusers
+        description: sudo rule
+        group: "shouldfail01"
+        usercategory: "all"
+      register: result
+      failed_when: not result.failed or "Users cannot be added when user category='all'" not in result.msg
+
+    - name: Ensure `command` cannot be added if cmdcategory is `all`.
+      ipasudorule:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: allusers
+        description: sudo rule
+        allow_sudocmd: "/bin/shouldfail"
+        cmdcategory: "all"
+      register: result
+      failed_when: not result.failed or "Commands cannot be added when command category='all'" not in result.msg
+
+    - name: Ensure `command group` cannot be added if cmdcategory is `all`.
+      ipasudorule:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: allusers
+        description: sudo rule
+        allow_sudocmdgroup: shouldfail_cmdgroup
+        cmdcategory: "all"
+      register: result
+      failed_when: not result.failed or "Commands cannot be added when command category='all'" not in result.msg
+
+    # cleanup
+    - name: Ensure sudorules are absent
+      ipasudorule:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name:
+        - allusers
+        state: absent
+
+    when: groups['ipaclients'] is defined

--- a/tests/trust/test_trust_client_context.yml
+++ b/tests/trust/test_trust_client_context.yml
@@ -1,0 +1,70 @@
+---
+- name: find trust
+  hosts: ipaclients
+  become: no
+  gather_facts: no
+
+  tasks:
+
+  - block:
+
+    - name: Execute with server context in the client.
+      ipatrust:
+        ipaadmin_password: SomeADMINpassword
+        realm: windows.local
+      register: result
+      failed_when: not (result.failed and "No module named 'ipaserver'" in result.msg)
+
+    - name: delete trust
+      ipatrust:
+        ipaadmin_password: SomeADMINpassword
+        realm: windows.local
+        state: absent
+      register: del_trust
+
+    - name: check for trust
+      shell: |
+        echo 'SomeADMINpassword' | kinit admin
+        ipa trust-find windows.local
+      register: check_find_trust
+      failed_when: "'0 trusts matched' not in check_find_trust.stdout"
+
+    - name: delete id range
+      shell: |
+        echo 'SomeADMINpassword' | kinit admin
+        ipa idrange-del WINDOWS.LOCAL_id_range
+      when: del_trust['changed'] | bool
+
+    - name: check for range
+      shell: |
+        echo 'SomeADMINpassword' | kinit admin
+        ipa idrange-find WINDOWS.LOCAL_id_range
+      register: check_del_idrange
+      failed_when: "'0 ranges matched' not in check_del_idrange.stdout"
+
+    - name: add trust
+      ipatrust:
+        ipaadmin_password: SomeADMINpassword
+        realm: windows.local
+        admin: Administrator
+        password: secret_ad_pw
+        state: present
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: check for trust
+      shell: |
+        echo 'SomeADMINpassword' | kinit admin
+        ipa trust-find windows.local
+      register: check_add_trust
+      failed_when: "'1 trust matched' not in check_add_trust.stdout"
+
+    - name: delete trust
+      ipatrust:
+        ipaadmin_password: SomeADMINpassword
+        realm: windows.local
+        state: absent
+      register: del_trust
+      failed_when: not result.changed or result.failed
+
+    when: (trust_test_is_supported | default(false)) and groups['ipaclients'] is defined

--- a/tests/user/test_user_client_context.yml
+++ b/tests/user/test_user_client_context.yml
@@ -1,0 +1,295 @@
+---
+- name: Test user
+  hosts: ipaclients
+  become: no
+  gather_facts: no
+
+  tasks:
+  - block:  # only execute tests if groups['ipaclients'] is defined.
+
+    - name: Remove test users
+      ipauser:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: manager1,manager2,manager3,pinky,pinky2
+        state: absent
+
+    - name: Execute with server context in the client.
+      ipauser:
+        ipaadmin_password: SomeADMINpassword
+        name: manager1
+        first: Manager
+        last: One
+      register: result
+      failed_when: not (result.failed and "No module named 'ipaserver'" in result.msg)
+
+    - name: User manager1 present
+      ipauser:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: manager1
+        first: Manager
+        last: One
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: User manager2 present
+      ipauser:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: manager2
+        first: Manager
+        last: One
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: User manager3 present
+      ipauser:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: manager3
+        first: Manager
+        last: One
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: User pinky present
+      ipauser:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: pinky
+        uid: 10001
+        gid: 100
+        phone: "+555123457"
+        email: pinky@acme.com
+        principalexpiration: "20220119235959"
+        #passwordexpiration: "2022-01-19 23:59:59"
+        first: pinky
+        last: Acme
+        initials: pa
+        #password: foo2
+        principal: pa
+        random: yes
+        city: PinkyCity
+        userstate: PinkyState
+        postalcode: PinkyZip
+        mobile: "+555123458,+555123459"
+        pager: "+555123450,+555123451"
+        fax: "+555123452,+555123453"
+        orgunit: PinkyOrgUnit
+        manager: manager1,manager2
+        update_password: on_create
+        carlicense: PinkyCarLicense1,PinkyCarLicense2
+        # sshpubkey
+        userauthtype: password,radius,otp
+        userclass: PinkyUserClass
+        #radius: "http://some.link/"
+        #radiususer: PinkyRadiusUser
+        departmentnumber: "1234"
+        employeenumber: "0815"
+        employeetype: "PinkyExmployeeType"
+        preferredlanguage: "en"
+        # certificate
+        noprivate: yes
+        nomembers: false
+        #issuer: PinkyIssuer
+        #subject: PinkySubject
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: User pinky present with changed settings
+      ipauser:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: pinky
+        first: pinky
+        last: Acme
+        manager: []
+        principal: []
+        sshpubkey:
+        - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCqmVDpEX5gnSjKuv97AyzOhaUMMKz8ahOA3GY77tVC4o68KNgMCmDSEG1/kOIaElngNLaCha3p/2iAcU9Bi1tLKUlm2bbO5NHNwHfRxY/3cJtq+/7D1vxJzqThYwI4F9vr1WxyY2+mMTv3pXbfAJoR8Mu06XaEY5PDetlDKjHLuNWF+/O7ZU8PsULTa1dJZFrtXeFpmUoLoGxQBvlrlcPI1zDciCSU24t27Zan5Py2l5QchyI7yhCyMM77KDtj5+AFVpmkb9+zq50rYJAyFVeyUvwjzErvQrKJzYpA0NyBp7vskWbt36M16/M/LxEK7HA6mkcakO3ESWx5MT1LAjvdlnxbWG3787MxweHXuB8CZU+9bZPFBaJ+VQtOfJ7I8eH0S16moPC4ak8FlcFvOH8ERDPWLFDqfy09yaZ7bVIF0//5ZI7Nf3YDe3S7GrBX5ieYuECyP6UNkTx9BRsAQeVvXEc6otzB7iCSnYBMGUGzCqeigoAWaVQUONsSR3Uatks= pinky@ipaserver.el81.local
+        - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDc8MIjaSrxLYHvu+hduoF4m6NUFSlXZWzYbd3BK4L47/U4eiXoOS6dcfuZJDjmLfOipc7XVp7NADwAgA1yBOAjbeVpXr2tC8w8saZibl75WBOEjDfNroiOh/f/ojrwwHg05QTVSZHs27sU1HBPyCQM/FHVM6EnRfmyiBkEBA/3ca0PJ9UJhWb2XisCaz6y6QcTh4gQnvHzgmEmK31GwiKnmBSEQuj8P5NGCO8RlN3cq3zpRpMDEoBRCjQYicllf/5P43r5OGvS1LhTiAMfyqE37URezNQa7aozBpH1GhIwAmjAtm84jXQjxUgZPYC0aSLuADYErScOP4792r6koH9t/DM5/M+jG2c4PNWynDczUw6Eaxl5E3hU0Ee9UN0Oee7iBnVenS/QMeZNyo5lMA/HXT5lrYiJGTYM0shRjGXXYBbJZhWerguSWDAdUd1gvuGP1nb7/+/Cvb46+HX7zYouS5Ojo0yPzMZ07X142jnKAfx9LnKdMUCwBJzbtoJ91Zc= pinky@ipaserver.el81.local
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: User pinky add manager manager1
+      ipauser:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: pinky
+        manager: manager1
+        action: member
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: User pinky add manager manager1 again
+      ipauser:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: pinky
+        manager: manager1
+        action: member
+      register: result
+      failed_when: result.changed or result.failed
+
+    - name: User pinky add manager manager2, manager3
+      ipauser:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: pinky
+        manager: manager2,manager3
+        action: member
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: User pinky add manager manager2, manager3 again
+      ipauser:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: pinky
+        manager: manager2,manager3
+        action: member
+      register: result
+      failed_when: result.changed or result.failed
+
+    - name: User pinky remove manager manager1
+      ipauser:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: pinky
+        manager: manager1
+        action: member
+        state: absent
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: User pinky remove manager manager1 again
+      ipauser:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: pinky
+        manager: manager1
+        action: member
+        state: absent
+      register: result
+      failed_when: result.changed or result.failed
+
+    - name: User pinky add principal pa
+      ipauser:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: pinky
+        principal: pa
+        action: member
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: User pinky add principal pa again
+      ipauser:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: pinky
+        principal: pa
+        action: member
+      register: result
+      failed_when: result.changed or result.failed
+
+    - name: User pinky add principal pa1
+      ipauser:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: pinky
+        principal: pa1
+        action: member
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: User pinky remove principal pa1
+      ipauser:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: pinky
+        principal: pa1
+        action: member
+        state: absent
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: User pinky remove principal pa1 again
+      ipauser:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: pinky
+        principal: pa1
+        action: member
+        state: absent
+      register: result
+      failed_when: result.changed or result.failed
+
+    - name: User pinky remove principal pa
+      ipauser:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: pinky
+        principal: pa
+        action: member
+        state: absent
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: User pinky remove principal non-existing pa2
+      ipauser:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: pinky
+        principal: pa2
+        action: member
+        state: absent
+      register: result
+      failed_when: result.changed or result.failed
+
+    - name: User pinky absent and preserved
+      ipauser:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: pinky
+        preserve: yes
+        state: absent
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: User pinky undeleted (preserved before)
+      ipauser:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: pinky
+        state: undeleted
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: Users pinky disabled
+      ipauser:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: pinky
+        state: disabled
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: User pinky enabled
+      ipauser:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: pinky
+        state: enabled
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: Remove test users
+      ipauser:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: manager1,manager2,manager3,pinky,pinky2
+        state: absent
+
+    when: groups['ipaclients'] is defined

--- a/utils/new_module
+++ b/utils/new_module
@@ -154,25 +154,25 @@ mkdir -p $dest
 
 src=ipamodule.py.in
 [ $member == 1 ] && src=ipamodule+member.py.in
-template $src $dest/ipa$name.py
+template $src $dest/ipa${name}.py
 
 # README
 
 src=README-module.md.in
 [ $member == 1 ] && src=README-module+member.md.in
-template $src README-$name.md
+template $src README-${name}.md
 
 # PLAYBOOKS
 
 dest=playbooks/$name
 mkdir -p $dest
 
-template module-present.yml.in $dest/$name-present.yml
-template module-absent.yml.in $dest/$name-absent.yml
+template module-present.yml.in $dest/${name}-present.yml
+template module-absent.yml.in $dest/${name}-absent.yml
 
 if [ $member == 1 ]; then
-    template module-member-present.yml.in $dest/$name-member-present.yml
-    template module-member-absent.yml.in $dest/$name-member-absent.yml
+    template module-member-present.yml.in $dest/${name}-member-present.yml
+    template module-member-absent.yml.in $dest/${name}-member-absent.yml
 fi
 
 # TESTS
@@ -182,4 +182,5 @@ mkdir -p $dest
 
 src=test_module.yml.in
 [ $member == 1 ] && src=test_module+member.yml.in
-template $src $dest/test_$name.yml
+template $src $dest/test_${name}.yml
+template test_module_client_context.yml.in $dest/test_${name}_client_context.yml

--- a/utils/templates/README-module+member.md.in
+++ b/utils/templates/README-module+member.md.in
@@ -119,6 +119,7 @@ Variable | Description | Required
 -------- | ----------- | --------
 `ipaadmin_principal` | The admin principal is a string and defaults to `admin` | no
 `ipaadmin_password` | The admin password is a string and is required if there is no admin ticket available on the node | no
+`ipa_context` | The context in which the module will execute. Executing in a server context is preferred, use `client` to execute in a client context if the server cannot be accessed. Valid values are `server`, `client`. Default to `server`. | no
 `name` \| `ALIAS` | The list of $name name strings. | yes
 `PARAMETER1` \| `API_PARAMETER_NAME` | DESCRIPTION | BOOL
 `PARAMETER2` \| `API_PARAMETER_NAME` | DESCRIPTION | BOOL

--- a/utils/templates/README-module.md.in
+++ b/utils/templates/README-module.md.in
@@ -84,6 +84,7 @@ Variable | Description | Required
 -------- | ----------- | --------
 `ipaadmin_principal` | The admin principal is a string and defaults to `admin` | no
 `ipaadmin_password` | The admin password is a string and is required if there is no admin ticket available on the node | no
+`ipa_context` | The context in which the module will execute. Executing in a server context is preferred, use `client` to execute in a client context if the server cannot be accessed. Valid values are `server`, `client`. Default to `server`. | no
 `name` \| `ALIAS` | The list of $name name strings. | yes
 `PARAMETER1` \| `API_PARAMETER_NAME` | DESCRIPTION | BOOL
 `PARAMETER2` \| `API_PARAMETER_NAME` | DESCRIPTION | BOOL

--- a/utils/templates/ipamodule+member.py.in
+++ b/utils/templates/ipamodule+member.py.in
@@ -38,6 +38,13 @@ options:
   ipaadmin_password:
     description: The admin password.
     required: false
+  ipa_context:
+    description: |
+      The context in which the module will execute. Executing in a server
+      context is preferred, use `client` to execute in a client context if
+      the server cannot be accessed.
+    choices: ["server", "client"]
+    default: server
   name:
     description: The list of $name name strings.
     required: true
@@ -97,9 +104,10 @@ RETURN = """
 
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.ansible_freeipa_module import \
-    temp_kinit, temp_kdestroy, valid_creds, api_connect, api_command, \
+from ansible.module_utils.ansible_freeipa_module import (
+    CCache, api_command, connect_to_api, disconnect_from_api,
     compare_args_ipa, module_params_get, gen_add_del_lists
+)
 import six
 
 if six.PY3:
@@ -137,6 +145,8 @@ def main():
             # general
             ipaadmin_principal=dict(type="str", default="admin"),
             ipaadmin_password=dict(type="str", required=False, no_log=True),
+            ipa_context=dict(type="str", required=False, default="server",
+                             choices=["server", "client"]),
 
             name=dict(type="list", aliases=["API_PARAMETER_NAME"],
                       default=None, required=True),
@@ -159,9 +169,6 @@ def main():
     # Get parameters
 
     # general
-    ipaadmin_principal = module_params_get(ansible_module,
-                                           "ipaadmin_principal")
-    ipaadmin_password = module_params_get(ansible_module, "ipaadmin_password")
     names = module_params_get(ansible_module, "name")
 
     # present
@@ -200,13 +207,9 @@ def main():
 
     changed = False
     exit_args = {}
-    ccache_dir = None
-    ccache_name = None
+    ccache = CCache(None, None)
     try:
-        if not valid_creds(ansible_module, ipaadmin_principal):
-            ccache_dir, ccache_name = temp_kinit(ipaadmin_principal,
-                                                 ipaadmin_password)
-        api_connect()
+        ccache = connect_to_api(ansible_module)
 
         commands = []
         for name in names:
@@ -324,7 +327,7 @@ def main():
         ansible_module.fail_json(msg=str(e))
 
     finally:
-        temp_kdestroy(ccache_dir, ccache_name)
+        disconnect_from_api(ansible_module, ccache)
 
     # Done
 

--- a/utils/templates/ipamodule.py.in
+++ b/utils/templates/ipamodule.py.in
@@ -38,6 +38,13 @@ options:
   ipaadmin_password:
     description: The admin password.
     required: false
+  ipa_context:
+    description: |
+      The context in which the module will execute. Executing in a server
+      context is preferred, use `client` to execute in a client context if
+      the server cannot be accessed.
+    choices: ["server", "client"]
+    default: server
   name:
     description: The list of $name name strings.
     required: true
@@ -79,9 +86,10 @@ RETURN = """
 
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.ansible_freeipa_module import \
-    temp_kinit, temp_kdestroy, valid_creds, api_connect, api_command, \
-    compare_args_ipa, module_params_get
+from ansible.module_utils.ansible_freeipa_module import (
+    CCache, api_command, connect_to_api, disconnect_from_api,
+    compare_args_ipa, module_params_get, gen_add_del_lists
+)
 import six
 
 if six.PY3:
@@ -114,6 +122,8 @@ def main():
             # general
             ipaadmin_principal=dict(type="str", default="admin"),
             ipaadmin_password=dict(type="str", required=False, no_log=True),
+            ipa_context=dict(type="str", required=False, default="server",
+                             choices=["server", "client"]),
 
             name=dict(type="list", aliases=["API_PARAMETER_NAME"],
                       default=None, required=True),
@@ -134,9 +144,6 @@ def main():
     # Get parameters
 
     # general
-    ipaadmin_principal = module_params_get(ansible_module,
-                                           "ipaadmin_principal")
-    ipaadmin_password = module_params_get(ansible_module, "ipaadmin_password")
     names = module_params_get(ansible_module, "name")
 
     # present
@@ -170,13 +177,9 @@ def main():
 
     changed = False
     exit_args = {}
-    ccache_dir = None
-    ccache_name = None
+    ccache = CCache(None, None)
     try:
-        if not valid_creds(ansible_module, ipaadmin_principal):
-            ccache_dir, ccache_name = temp_kinit(ipaadmin_principal,
-                                                 ipaadmin_password)
-        api_connect()
+        ccache = connect_to_api(ansible_module)
 
         commands = []
         for name in names:
@@ -230,7 +233,7 @@ def main():
         ansible_module.fail_json(msg=str(e))
 
     finally:
-        temp_kdestroy(ccache_dir, ccache_name)
+        disconnect_from_api(ansible_module, ccache)
 
     # Done
 

--- a/utils/templates/test_module+member.yml.in
+++ b/utils/templates/test_module+member.yml.in
@@ -1,7 +1,8 @@
 ---
 - name: Test $name
   hosts: ipaserver
-  become: true
+  become: no
+  gather_facts: no
 
   tasks:
 

--- a/utils/templates/test_module.yml.in
+++ b/utils/templates/test_module.yml.in
@@ -1,7 +1,8 @@
 ---
 - name: Test $name
   hosts: ipaserver
-  become: true
+  become: no
+  gather_facts: no
 
   tasks:
 

--- a/utils/templates/test_module_client_context.yml.in
+++ b/utils/templates/test_module_client_context.yml.in
@@ -1,0 +1,74 @@
+---
+- name: Test $name
+  hosts: ipaclients
+  become: no
+  gather_facts: no
+
+  tasks:
+  - block:  # only execute tests if groups['ipaclients'] is defined.
+    # CLEANUP TEST ITEMS
+
+    - name: Ensure $name NAME is absent
+      ipa$name:
+        ipaadmin_password: SomeADMINpassword
+        name: NAME
+        state: absent
+
+    # CREATE TEST ITEMS
+
+    # TESTS
+    - name: Execute with server context in the client.
+      ipa$name:
+        ipaadmin_password: SomeADMINpassword
+        name: NAME
+      register: result
+      failed_when: not (result.failed and "No module named 'ipaserver'" in result.msg)
+
+    - name: Ensure $name NAME is present
+      ipa$name:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: NAME
+        # Add needed parameters here
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: Ensure $name NAME is present again
+      ipa$name:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: NAME
+        # Add needed parameters here
+      register: result
+      failed_when: result.changed or result.failed
+
+    # more tests here
+
+    - name: Ensure $name NAME is absent
+      ipa$name:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: NAME
+        state: absent
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: Ensure $name NAME is absent again
+      ipa$name:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: NAME
+        state: absent
+      register: result
+      failed_when: result.changed or result.failed
+
+    # CLEANUP TEST ITEMS
+
+    - name: Ensure $name NAME is absent
+      ipa$name:
+        ipaadmin_password: SomeADMINpassword
+        ipa_context: client
+        name: NAME
+        state: absent
+
+    when: groups['ipaclients'] is defined


### PR DESCRIPTION
All ansible-freeipa modules are required to run on an IPA server. The Ansible community modules use JSON API and allow the execution on other environments. This patch allows the execution of ansible-freeipa modules using IPA's Python API on an IPA client host

A new optional attribute, `ipa_context`, is added to the modules that allow the execution in a client context. The valid values for this attribute are `server` (default) and `client`. All current modules can be executed in a client context, but `ipavault` module, currently, does not support the attribute, as it always execute in a client context.

Related to: https://bugzilla.redhat.com/show_bug.cgi?id=1918025
