### PR TITLE
Remove ignore_errors from pwpolicy tests.

### DIFF
--- a/tests/pwpolicy/test_pwpolicy.yml
+++ b/tests/pwpolicy/test_pwpolicy.yml
@@ -81,8 +81,7 @@
       ipaadmin_password: SomeADMINpassword
       state: absent
     register: result
-    ignore_errors: True
-    failed_when: (result is defined and result) or result.failed
+    failed_when: not result.failed or "'global_policy' can not be made absent." not in result.msg
 
   - name: Ensure absence of pwpolicies for group ops
     ipapwpolicy:


### PR DESCRIPTION
Instead of ignoring errors it is better that we specific evaluate
errors provided by negative tests. This patche removes the an
occurrence of 'ignore_errors: true' in ansible-freeipa tests.