### PR TITLE
ipasudorule: Fix documentation attribute.

### DIFF
--- a/plugins/modules/ipasudorule.py
+++ b/plugins/modules/ipasudorule.py
@@ -53,7 +53,7 @@ options:
     required: false
     choices: ["all", ""]
     aliases: ["usercat"]
-  usergroup:
+  group:
     description: List of user groups assigned to the sudo rule.
     required: false
   runasgroupcategory:


### PR DESCRIPTION
Change, in the module documentation, the attribute named 'usergroup'
to 'group', as it is used in the code.

Fixes #580