### PR TITLE
ipadnszone: add check mode support

### DIFF
--- a/plugins/module_utils/ansible_freeipa_module.py
+++ b/plugins/module_utils/ansible_freeipa_module.py
@@ -786,6 +786,10 @@ else:
 
         def _run_ipa_commands(self):
             """Execute commands in self.ipa_commands."""
+            if self.check_mode:
+                self.changed = len(self.ipa_commands) > 0
+                return
+
             result = None
 
             for name, command, args in self.ipa_commands:

--- a/plugins/modules/ipadnszone.py
+++ b/plugins/modules/ipadnszone.py
@@ -570,6 +570,7 @@ def main():
         argument_spec=get_argument_spec(),
         mutually_exclusive=[["name", "name_from_ip"]],
         required_one_of=[["name", "name_from_ip"]],
+        supports_check_mode=True,
     ).ipa_run()
 
 

--- a/tests/dnszone/test_dnszone.yml
+++ b/tests/dnszone/test_dnszone.yml
@@ -11,6 +11,24 @@
     include_tasks: env_setup.yml
 
   # Tests
+  - name: Check if zone is present, when in shouldn't be.
+    ipadnszone:
+      ipaadmin_password: SomeADMINpassword
+      name: testzone.local
+      state: present
+    check_mode: yes
+    register: result
+    failed_when: not result.changed or result.failed
+
+  - name: Check if zone is present again, when in shouldn't be.
+    ipadnszone:
+      ipaadmin_password: SomeADMINpassword
+      name: testzone.local
+      state: present
+    check_mode: yes
+    register: result
+    failed_when: not result.changed or result.failed
+
   - name: Ensure zone is present.
     ipadnszone:
       ipaadmin_password: SomeADMINpassword
@@ -18,6 +36,15 @@
       state: present
     register: result
     failed_when: not result.changed or result.failed
+
+  - name: Check if zone is present, when in should be.
+    ipadnszone:
+      ipaadmin_password: SomeADMINpassword
+      name: testzone.local
+      state: present
+    check_mode: yes
+    register: result
+    failed_when: result.changed or result.failed
 
   - name: Ensure zone is present, again.
     ipadnszone:


### PR DESCRIPTION
This patch adds the required support for implementing `check_mode`
in FreeIPABaseModule class, and adds support for `check_mode` in
ipadnszone module.

Tests for verifying behavior were also added.