### PR TITLE
build_containers: build CI container images on Sundays.

### DIFF
--- a/tests/azure/build-containers.yml
+++ b/tests/azure/build-containers.yml
@@ -1,8 +1,8 @@
 ---
 
 schedules:
-- cron: "0 0 * * *"
-  displayName: Daily midnight build
+- cron: "0 0 * * 0"
+  displayName: Weekly Sunday midnight build
   branches:
     include:
     - master


### PR DESCRIPTION
Currently, we rebuild the container images everyday, at midnight,
which ensures that we have all the latest changes from every distro
supported in CI.

This approach works fine for the upstream CI, but if we want to use
the CI images to test modules in a local container, for example, as
proposed by PR #556, updating the images daily means that there will
be much more images download that would not be needed, as the public
cloud images of supported distros don't change so often.

This patch proposes to change the build rate from daily to weekly,
reducing the need to download images by users, while still using a
good update window.

It should be noted that, if required, the images can be rebuilt
manually, so any urgent fix is added to the CI images.