### PR TITLE
FreeIPA LDAP cache issue workaround

### DIFF
--- a/plugins/module_utils/ansible_freeipa_module.py
+++ b/plugins/module_utils/ansible_freeipa_module.py
@@ -172,7 +172,7 @@ else:
         if ccache_dir is not None:
             shutil.rmtree(ccache_dir, ignore_errors=True)
 
-    def api_connect(context=None):
+    def api_connect(context=None, **kwargs):
         """
         Initialize IPA API with the provided context.
 
@@ -180,6 +180,9 @@ else:
             * `server` (default)
             * `ansible-freeipa`
             * `cli_installer`
+
+        Other options can also be provided through kwargs:
+            * ldap_cache: Enable/Disable LDAP cache in FreeIPA 4.9.4+.
         """
         env = Env()
         env._bootstrap()
@@ -191,7 +194,12 @@ else:
         if context is None:
             context = 'server'
 
-        api.bootstrap(context=context, debug=env.debug, log=None)
+        api.bootstrap(
+            context=context,
+            debug=env.debug,
+            log=None,
+            **kwargs
+        )
         api.finalize()
 
         if api.env.in_server:

--- a/plugins/modules/ipaautomember.py
+++ b/plugins/modules/ipaautomember.py
@@ -238,7 +238,7 @@ def main():
         if not valid_creds(ansible_module, ipaadmin_principal):
             ccache_dir, ccache_name = temp_kinit(ipaadmin_principal,
                                                  ipaadmin_password)
-        api_connect()
+        api_connect(ldap_cache=False)
 
         commands = []
 


### PR DESCRIPTION
FreeIPA 4.9.4 has introduced a short term, per-connection LDAP cache
layer aiming to reduce load on the LDAP server by caching similar
queries executed in the same connection, and, although it works well
for most ansible-freeipa modules, the use of the cache layer may
trigger code paths, in FreeIPA, that don't work well with the way
queries are cached.

This patch introduce an option to allow for extra argument to configure
the connection to IPA API (through ansible_module_utils.api_connect),
and uses this change to disable the LDAP cache in ipaautomember
module.

Fixes #579