### PR TITLE
Added support for AlmaLinux and Rocky Linux (Fix #573)

### DIFF
--- a/roles/ipabackup/vars/AlmaLinux-8.yml
+++ b/roles/ipabackup/vars/AlmaLinux-8.yml
@@ -1,0 +1,1 @@
+RedHat-8.yml

--- a/roles/ipabackup/vars/Rocky-8.yml
+++ b/roles/ipabackup/vars/Rocky-8.yml
@@ -1,0 +1,1 @@
+RedHat-8.yml

--- a/roles/ipaclient/vars/AlmaLinux-8.yml
+++ b/roles/ipaclient/vars/AlmaLinux-8.yml
@@ -1,0 +1,1 @@
+RedHat-8.yml

--- a/roles/ipaclient/vars/Rocky-8.yml
+++ b/roles/ipaclient/vars/Rocky-8.yml
@@ -1,0 +1,1 @@
+RedHat-8.yml

--- a/roles/ipareplica/vars/AlmaLinux-8.yml
+++ b/roles/ipareplica/vars/AlmaLinux-8.yml
@@ -1,0 +1,1 @@
+RedHat-8.yml

--- a/roles/ipareplica/vars/Rocky-8.yml
+++ b/roles/ipareplica/vars/Rocky-8.yml
@@ -1,0 +1,1 @@
+RedHat-8.yml

--- a/roles/ipaserver/vars/AlmaLinux-8.yml
+++ b/roles/ipaserver/vars/AlmaLinux-8.yml
@@ -1,0 +1,1 @@
+RedHat-8.yml

--- a/roles/ipaserver/vars/Rocky-8.yml
+++ b/roles/ipaserver/vars/Rocky-8.yml
@@ -1,0 +1,1 @@
+RedHat-8.yml


### PR DESCRIPTION
This pull request adds symlinks for distro-specific vars of AlmaLinux and Rocky Linux pointing to Red Hat vars files, thus fixing #573 