### PR TITLE
[WIP] ipavault: add support for `continue` variable.

### DIFF
--- a/README-vault.md
+++ b/README-vault.md
@@ -243,6 +243,7 @@ Variable | Description | Required
 `out` \| `datafile_out` | Path to file to store data retrieved from the vault. | no
 `action` | Work on vault or member level. It can be on of `member` or `vault` and defaults to `vault`. | no
 `state` | The state to ensure. It can be one of `present`, `absent` or `retrieved`, default: `present`. | no
+`continue` \| `delete_continue` | Continuous mode: Don't stop on errors. (bool) | no
 
 
 Return Values

--- a/tests/vault/test_vault_asymmetric.yml
+++ b/tests/vault/test_vault_asymmetric.yml
@@ -226,6 +226,7 @@
     ipavault:
       ipaadmin_password: SomeADMINpassword
       name: asymvault
+      continue: no
       state: absent
     register: result
     failed_when: not result.changed or result.failed
@@ -234,6 +235,7 @@
     ipavault:
       ipaadmin_password: SomeADMINpassword
       name: asymvault
+      continue: no
       state: absent
     register: result
     failed_when: result.changed or result.failed
@@ -286,6 +288,7 @@
     ipavault:
       ipaadmin_password: SomeADMINpassword
       name: asymvault
+      continue: yes
       state: absent
     register: result
     failed_when: not result.changed or result.failed
@@ -294,6 +297,7 @@
     ipavault:
       ipaadmin_password: SomeADMINpassword
       name: asymvault
+      continue: yes
       state: absent
     register: result
     failed_when: result.changed or result.failed

--- a/tests/vault/test_vault_standard.yml
+++ b/tests/vault/test_vault_standard.yml
@@ -125,6 +125,7 @@
     ipavault:
       ipaadmin_password: SomeADMINpassword
       name: stdvault
+      continue: yes
       state: absent
     register: result
     failed_when: not result.changed or result.failed
@@ -133,6 +134,7 @@
     ipavault:
       ipaadmin_password: SomeADMINpassword
       name: stdvault
+      continue: yes
       state: absent
     register: result
     failed_when: result.changed or result.failed

--- a/tests/vault/test_vault_symmetric.yml
+++ b/tests/vault/test_vault_symmetric.yml
@@ -137,6 +137,7 @@
     ipavault:
       ipaadmin_password: SomeADMINpassword
       name: symvault
+      continue: yes
       state: absent
     register: result
     failed_when: result.failed or not result.changed
@@ -145,6 +146,7 @@
     ipavault:
       ipaadmin_password: SomeADMINpassword
       name: symvault
+      continue: yes
       state: absent
     register: result
     failed_when: result.failed or result.changed
@@ -292,6 +294,7 @@
     ipavault:
       ipaadmin_password: SomeADMINpassword
       name: symvault
+      continue: no
       state: absent
     register: result
     failed_when: result.failed or not result.changed
@@ -300,6 +303,7 @@
     ipavault:
       ipaadmin_password: SomeADMINpassword
       name: symvault
+      continue: no
       state: absent
     register: result
     failed_when: result.failed or result.changed


### PR DESCRIPTION
This patch add support for continuous mode, when deleting a vault,
by setting`continue: yes`.

Fixes: #592