### PR TITLE
automember: Verify condition keys

### DIFF
--- a/tests/automember/test_automember.yml
+++ b/tests/automember/test_automember.yml
@@ -164,6 +164,34 @@
     register: result
     failed_when: result.changed or result.failed
 
+  - name: Ensure testgroup group automember conditions fails on invalid inclusive key
+    ipaautomember:
+      ipaadmin_principal: admin
+      ipaadmin_password: SomeADMINpassword
+      name: testgroup
+      automember_type: group
+      inclusive:
+        - key: cns
+          expression: 'foo'
+      action: member
+    register: result
+    failed_when: result.changed or not result.failed or
+                 "Invalid automember condition key 'cns'" not in result.msg
+
+  - name: Ensure testgroup group automember conditions fails on invalid exlusive key
+    ipaautomember:
+      ipaadmin_principal: admin
+      ipaadmin_password: SomeADMINpassword
+      name: testgroup
+      automember_type: group
+      exclusive:
+        - key: cns
+          expression: 'foo'
+      action: member
+    register: result
+    failed_when: result.changed or not result.failed or
+                 "Invalid automember condition key 'cns'" not in result.msg
+
   - name: Ensure testhostgroup hostgroup automember rule is present
     ipaautomember:
       ipaadmin_password: SomeADMINpassword
@@ -281,6 +309,35 @@
           expression: 'cn'
     register: result
     failed_when: result.changed or result.failed
+
+
+  - name: Ensure testhostgroup hostgroup automember conditions fails on invalid inclusive key
+    ipaautomember:
+      ipaadmin_principal: admin
+      ipaadmin_password: SomeADMINpassword
+      name: testhostgroup
+      automember_type: hostgroup
+      inclusive:
+        - key: cns
+          expression: 'foo'
+      action: member
+    register: result
+    failed_when: result.changed or not result.failed or
+                 "Invalid automember condition key 'cns'" not in result.msg
+
+  - name: Ensure testhostgroup hostgroup automember conditions fails on invalid exlusive key
+    ipaautomember:
+      ipaadmin_principal: admin
+      ipaadmin_password: SomeADMINpassword
+      name: testhostgroup
+      automember_type: hostgroup
+      exclusive:
+        - key: cns
+          expression: 'foo'
+      action: member
+    register: result
+    failed_when: result.changed or not result.failed or
+                 "Invalid automember condition key 'cns'" not in result.msg
 
   # CLEANUP TEST ITEMS
 


### PR DESCRIPTION
The automember_add_condition and automember_remove_condition commands
are not verifying condition keys in all cases. This is for example not
done in the removal case if a condition is not part of the automember
rule.

For consistent behaviour this needs to be done in the automember module
now. The condition keys are verified with the user and group aciattrs
returned by the API command json_metadata now.

Related: RHBZ#1976926