### PR TITLE
New meta/runtime.yml for galaxy for requires_ansible

### DIFF
--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,0 +1,1 @@
+requires_ansible: ">=2.9"


### PR DESCRIPTION
Galaxy now requires meta/runtime.yml to define requires_ansible.

runtime.yml has been added with requires_ansible: ">=2.9"