### PR TITLE
Fix task name in selfservice example playbook.

### DIFF
--- a/playbooks/selfservice/selfservice-member-absent.yml
+++ b/playbooks/selfservice/selfservice-member-absent.yml
@@ -4,7 +4,7 @@
   become: true
 
   tasks:
-  - name: Ensure selfservice "basic manager attributes" member attributes employeenumber and employeetype are absent
+  - name: Ensure selfservice "basic manager attributes" member attributes businesscategory and departmentnumber are absent
     ipaselfservice:
       ipaadmin_password: SomeADMINpassword
       name: "basic manager attributes"


### PR DESCRIPTION
A task name referenced attributes not used is the task.