### PR TITLE
ipapermission: Add 'new_name' as an alias to 'rename'.

### DIFF
--- a/README-permission.md
+++ b/README-permission.md
@@ -175,7 +175,7 @@ Variable | Description | Required
 `targetgroup` | User group to apply permissions to (sets target) | no
 `object_type` | Type of IPA object (sets subtree and objectClass targetfilter) | no
 `no_members` | Suppress processing of membership | no
-`rename` | Rename the permission object | no
+`rename` \| `new_name` | Rename the permission object | no
 `action` | Work on permission or member level. It can be on of `member` or `permission` and defaults to `permission`. | no
 `state` | The state to ensure. It can be one of `present`, `absent`, or `renamed` default: `present`. | no
 

--- a/plugins/modules/ipapermission.py
+++ b/plugins/modules/ipapermission.py
@@ -102,6 +102,7 @@ options:
   rename:
     description: Rename the permission object
     required: false
+    aliases: ["new_name"]
   action:
     description: Work on permission or member privilege level.
     choices: ["permission", "member"]
@@ -226,8 +227,8 @@ def main():
             object_type=dict(type="str", aliases=["type"], default=None,
                              required=False),
             no_members=dict(type=bool, default=None, require=False),
-            rename=dict(type="str", default=None, required=False),
-
+            rename=dict(type="str", default=None, required=False,
+                        aliases=["new_name"]),
             action=dict(type="str", default="permission",
                         choices=["member", "permission"]),
             # state


### PR DESCRIPTION
Modules that support `state: renamed` have `new_name` as an alias
for the `rename` variable. This patch makes ipapermission consistent
with other modules.