### PR TITLE
iparole: Add 'new_name' as an alias to 'rename'.

### DIFF
--- a/README-role.md
+++ b/README-role.md
@@ -247,7 +247,7 @@ Variable | Description | Required
 `ipaadmin_password` | The admin password is a string and is required if there is no admin ticket available on the node | no
 `name` \| `cn` | The list of role name strings. | yes
 `description` | A description for the role. | no
-`rename` | Rename the role object. | no
+`rename` \| `new_name` | Rename the role object. | no
 `privilege` | Privileges associated to this role. | no
 `user` | List of users to be assigned or not assigned to the role. | no
 `group` | List of groups to be assigned or not assigned to the role. | no

--- a/plugins/modules/iparole.py
+++ b/plugins/modules/iparole.py
@@ -50,6 +50,7 @@ options:
   rename:
     description: Rename the role object.
     required: false
+    aliases: ["new_name"]
   user:
     description: List of users.
     required: false
@@ -430,8 +431,8 @@ def create_module():
                       required=True),
             # present
             description=dict(required=False, type="str", default=None),
-            rename=dict(required=False, type="str", default=None),
-
+            rename=dict(required=False, type="str", default=None,
+                        aliases=["new_name"]),
             # members
             privilege=dict(required=False, type='list', default=None),
             user=dict(required=False, type='list', default=None),


### PR DESCRIPTION
Modules that support `state: renamed` have `new_name` as an alias
for the `rename` variable. This patch makes iparole consistent with
other modules.