### PR TITLE
templates: Use `become: no` in tests by default.

### DIFF
--- a/utils/templates/README-module+member.md.in
+++ b/utils/templates/README-module+member.md.in
@@ -45,7 +45,7 @@ Example playbook to make sure $name "NAME" is present:
 ---
 - name: Playbook to manage IPA $name.
   hosts: ipaserver
-  become: yes
+  become: no
 
   tasks:
   - ipa$name:
@@ -60,7 +60,7 @@ Example playbook to make sure $name "NAME" member PARAMETER2 VALUE is present:
 ---
 - name: Playbook to manage IPA $name PARAMETER2 member.
   hosts: ipaserver
-  become: yes
+  become: no
 
   tasks:
   - ipa$name:
@@ -78,7 +78,7 @@ Example playbook to make sure $name "NAME" member PARAMETER2 VALUE is absent:
 ---
 - name: Playbook to manage IPA $name PARAMETER2 member.
   hosts: ipaserver
-  become: yes
+  become: no
 
   tasks:
   - ipa$name:
@@ -96,7 +96,7 @@ Example playbook to make sure $name "NAME" is absent:
 ---
 - name: Playbook to manage IPA $name.
   hosts: ipaserver
-  become: yes
+  become: no
 
   tasks:
   - ipa$name:

--- a/utils/templates/README-module.md.in
+++ b/utils/templates/README-module.md.in
@@ -45,7 +45,7 @@ Example playbook to make sure $name "NAME" is present:
 ---
 - name: Playbook to manage IPA $name.
   hosts: ipaserver
-  become: yes
+  become: no
 
   tasks:
   - ipa$name:
@@ -61,7 +61,7 @@ Example playbook to make sure $name "NAME" is absent:
 ---
 - name: Playbook to manage IPA $name.
   hosts: ipaserver
-  become: yes
+  become: no
 
   tasks:
   - ipa$name:

--- a/utils/templates/module-absent.yml.in
+++ b/utils/templates/module-absent.yml.in
@@ -1,7 +1,7 @@
 ---
 - name: ${name^} absent example
   hosts: ipaserver
-  become: true
+  become: no
 
   tasks:
   - name: Ensure $name NAME is absent

--- a/utils/templates/module-member-absent.yml.in
+++ b/utils/templates/module-member-absent.yml.in
@@ -1,7 +1,7 @@
 ---
 - name: ${name^} absent example
   hosts: ipaserver
-  become: true
+  become: no
 
   tasks:
   - name: Ensure $name NAME is absent

--- a/utils/templates/module-member-present.yml.in
+++ b/utils/templates/module-member-present.yml.in
@@ -1,7 +1,7 @@
 ---
 - name: ${name^} member present example
   hosts: ipaserver
-  become: true
+  become: no
 
   tasks:
   - name: Ensure $name NAME is present

--- a/utils/templates/module-present.yml.in
+++ b/utils/templates/module-present.yml.in
@@ -1,7 +1,7 @@
 ---
 - name: ${name^} present example
   hosts: ipaserver
-  become: true
+  become: no
 
   tasks:
   - name: Ensure $name NAME is present

--- a/utils/templates/test_module+member.yml.in
+++ b/utils/templates/test_module+member.yml.in
@@ -1,7 +1,7 @@
 ---
 - name: Test $name
   hosts: ipaserver
-  become: true
+  become: no
 
   tasks:
 

--- a/utils/templates/test_module.yml.in
+++ b/utils/templates/test_module.yml.in
@@ -1,7 +1,7 @@
 ---
 - name: Test $name
   hosts: ipaserver
-  become: true
+  become: no
 
   tasks:
 


### PR DESCRIPTION
ansible-freeipa modules should work without superuser privileges in
most cases, and to reflect this, the module tests should avoid using
`become: yes`.

This PR change the test playbook templates to use `become: no` by
default, so only modules that require superuser privileges will need
to change this variable.