### PR TITLE
WIP: ansible_freeipa_module: Allow api_connect configuration.

### DIFF
--- a/plugins/modules/ipadnszone.py
+++ b/plugins/modules/ipadnszone.py
@@ -523,6 +523,7 @@ def get_argument_spec():
         ),
         ipaadmin_principal=dict(type="str", default="admin"),
         ipaadmin_password=dict(type="str", required=False, no_log=True),
+        ipaapi_ldap_cache=dict(type="bool", required=False),
         name=dict(
             type="list", default=None, required=False, aliases=["zone_name"]
         ),

--- a/plugins/modules/ipavault.py
+++ b/plugins/modules/ipavault.py
@@ -742,7 +742,7 @@ def main():
             if ccache_name is not None:
                 os.environ["KRB5CCNAME"] = ccache_name
 
-        api_connect(context='ansible-freeipa')
+        api_connect(context='client')
 
         commands = []
 

--- a/tests/dnszone/test_dnszone.yml
+++ b/tests/dnszone/test_dnszone.yml
@@ -14,6 +14,7 @@
   - name: Ensure zone is present.
     ipadnszone:
       ipaadmin_password: SomeADMINpassword
+      ipaapi_ldap_cache: no
       name: testzone.local
       state: present
     register: result

--- a/utils/new_module
+++ b/utils/new_module
@@ -183,3 +183,7 @@ mkdir -p $dest
 src=test_module.yml.in
 [ $member == 1 ] && src=test_module+member.yml.in
 template $src $dest/test_$name.yml
+
+src=test_module_client_context.yml.in
+[ $member == 1 ] && src=test_module+member.yml.in
+template $src $dest/test_${name}_client_context.yml

--- a/utils/templates/README-module+member.md.in
+++ b/utils/templates/README-module+member.md.in
@@ -119,6 +119,8 @@ Variable | Description | Required
 -------- | ----------- | --------
 `ipaadmin_principal` | The admin principal is a string and defaults to `admin` | no
 `ipaadmin_password` | The admin password is a string and is required if there is no admin ticket available on the node | no
+`ipaapi_context` | The context in which the module will execute. Executing in a server context is preferred, use `client` to execute in a client context if the server cannot be accessed. Valid values are `server`, `client`. Default to `server`. | no
+`ipaapi_ldap_cache` | Enable of disable the use of IPA API LDAP cache layer. (bool) | no
 `name` \| `ALIAS` | The list of $name name strings. | yes
 `PARAMETER1` \| `API_PARAMETER_NAME` | DESCRIPTION | BOOL
 `PARAMETER2` \| `API_PARAMETER_NAME` | DESCRIPTION | BOOL

--- a/utils/templates/README-module.md.in
+++ b/utils/templates/README-module.md.in
@@ -84,6 +84,8 @@ Variable | Description | Required
 -------- | ----------- | --------
 `ipaadmin_principal` | The admin principal is a string and defaults to `admin` | no
 `ipaadmin_password` | The admin password is a string and is required if there is no admin ticket available on the node | no
+`ipaapi_context` | The context in which the module will execute. Executing in a server context is preferred, use `client` to execute in a client context if the server cannot be accessed. Valid values are `server`, `client`. Default to `server`. | no
+`ipaapi_ldap_cache` | Enable of disable the use of IPA API LDAP cache layer. (bool) | no
 `name` \| `ALIAS` | The list of $name name strings. | yes
 `PARAMETER1` \| `API_PARAMETER_NAME` | DESCRIPTION | BOOL
 `PARAMETER2` \| `API_PARAMETER_NAME` | DESCRIPTION | BOOL

--- a/utils/templates/ipamodule+member.py.in
+++ b/utils/templates/ipamodule+member.py.in
@@ -38,6 +38,18 @@ options:
   ipaadmin_password:
     description: The admin password.
     required: false
+  ipaapi_context:
+    description: |
+      The context in which the module will execute. Executing in a server
+      context is preferred, use `client` to execute in a client context if
+      the server cannot be accessed.
+    choices: ["server", "client"]
+    default: server.
+    required: false
+  ipaapi_ldap_cache:
+    description: Enable of disable the use of IPA API LDAP cache layer.
+    type: bool
+    required: false
   name:
     description: The list of $name name strings.
     required: true
@@ -137,6 +149,9 @@ def main():
             # general
             ipaadmin_principal=dict(type="str", default="admin"),
             ipaadmin_password=dict(type="str", required=False, no_log=True),
+            ipaapi_context=dict(type="str", required=False, default="server",
+                                choices=["server", "client"]),
+            ipaapi_ldap_cache=dict(type="bool", required=False),
 
             name=dict(type="list", aliases=["API_PARAMETER_NAME"],
                       default=None, required=True),
@@ -162,6 +177,9 @@ def main():
     ipaadmin_principal = module_params_get(ansible_module,
                                            "ipaadmin_principal")
     ipaadmin_password = module_params_get(ansible_module, "ipaadmin_password")
+    ipaapi_context = module_params_get(ansible_module, "ipaapi_context")
+    ipaapi_ldap_cache = module_params_get(ansible_module, "ipaapi_ldap_cache")
+
     names = module_params_get(ansible_module, "name")
 
     # present
@@ -206,7 +224,7 @@ def main():
         if not valid_creds(ansible_module, ipaadmin_principal):
             ccache_dir, ccache_name = temp_kinit(ipaadmin_principal,
                                                  ipaadmin_password)
-        api_connect()
+        api_connect(context=ipaapi_context, ldap_cache=ipaapi_ldap_cache)
 
         commands = []
         for name in names:

--- a/utils/templates/ipamodule.py.in
+++ b/utils/templates/ipamodule.py.in
@@ -38,6 +38,18 @@ options:
   ipaadmin_password:
     description: The admin password.
     required: false
+  ipaapi_context:
+    description: |
+      The context in which the module will execute. Executing in a server
+      context is preferred, use `client` to execute in a client context if
+      the server cannot be accessed.
+    choices: ["server", "client"]
+    default: server.
+    required: false
+  ipaapi_ldap_cache:
+    description: Enable of disable the use of IPA API LDAP cache layer.
+    type: bool
+    required: false
   name:
     description: The list of $name name strings.
     required: true
@@ -114,6 +126,9 @@ def main():
             # general
             ipaadmin_principal=dict(type="str", default="admin"),
             ipaadmin_password=dict(type="str", required=False, no_log=True),
+            ipaapi_context=dict(type="str", required=False, default="server",
+                                choices=["server", "client"]),
+            ipaapi_ldap_cache=dict(type="bool", required=False),
 
             name=dict(type="list", aliases=["API_PARAMETER_NAME"],
                       default=None, required=True),
@@ -137,6 +152,8 @@ def main():
     ipaadmin_principal = module_params_get(ansible_module,
                                            "ipaadmin_principal")
     ipaadmin_password = module_params_get(ansible_module, "ipaadmin_password")
+    ipaapi_context = module_params_get(ansible_module, "ipaapi_context")
+    ipaapi_ldap_cache = module_params_get(ansible_module, "ipaapi_ldap_cache")
     names = module_params_get(ansible_module, "name")
 
     # present
@@ -176,7 +193,7 @@ def main():
         if not valid_creds(ansible_module, ipaadmin_principal):
             ccache_dir, ccache_name = temp_kinit(ipaadmin_principal,
                                                  ipaadmin_password)
-        api_connect()
+        api_connect(context=ipaapi_context, ldap_cache=ipaapi_ldap_cache)
 
         commands = []
         for name in names:

--- a/utils/templates/test_module+member_client_context.yml.in
+++ b/utils/templates/test_module+member_client_context.yml.in
@@ -1,0 +1,117 @@
+---
+- name: Test $name
+  hosts: ipaclients
+  become: true
+
+  tasks:
+  - block:  # only execute tests if groups['ipaclients'] is defined.
+      # CLEANUP TEST ITEMS
+
+      - name: Ensure $name NAME is absent
+        ipa$name:
+          ipaadmin_password: SomeADMINpassword
+          ipaapi_context: client
+          name: NAME
+          state: absent
+
+      # CREATE TEST ITEMS
+
+      # TESTS
+      - name: Execute with server context in the client.
+        ipa$name:
+          ipaadmin_password: SomeADMINpassword
+          ipaapi_context: server
+          name: NAME
+        register: result
+        failed_when: not (result.failed and "No module named 'ipaserver'" in result.msg)
+
+      - name: Ensure $name NAME is present
+        ipa$name:
+          ipaadmin_password: SomeADMINpassword
+          ipaapi_context: client
+          name: NAME
+          # Add needed parameters here
+        register: result
+        failed_when: not result.changed or result.failed
+
+      - name: Ensure $name NAME is present again
+        ipa$name:
+          ipaadmin_password: SomeADMINpassword
+          ipaapi_context: client
+          name: NAME
+          # Add needed parameters here
+        register: result
+        failed_when: result.changed or result.failed
+
+      - name: Ensure $name NAME member PARAMETER2 VALUE is present
+        ipa$name:
+          ipaadmin_password: SomeADMINpassword
+          ipaapi_context: client
+          name: NAME
+          PARAMETER2: VALUE
+          action: member
+        register: result
+        failed_when: not result.changed or result.failed
+
+      - name: Ensure $name NAME member PARAMETER2 VALUE is present again
+        ipa$name:
+          ipaadmin_password: SomeADMINpassword
+          ipaapi_context: client
+          name: NAME
+          PARAMETER2: VALUE
+          action: member
+        register: result
+        failed_when: result.changed or result.failed
+
+      - name: Ensure $name NAME member PARAMETER2 VALUE is absent
+        ipa$name:
+          ipaadmin_password: SomeADMINpassword
+          ipaapi_context: client
+          name: NAME
+          PARAMETER2: VALUE
+          action: member
+          state: absent
+        register: result
+        failed_when: not result.changed or result.failed
+
+      - name: Ensure $name NAME member PARAMETER2 VALUE is absent again
+        ipa$name:
+          ipaadmin_password: SomeADMINpassword
+          ipaapi_context: client
+          name: NAME
+          PARAMETER2: VALUE
+          action: member
+          state: absent
+        register: result
+        failed_when: result.changed or result.failed
+
+      # more tests here
+
+      - name: Ensure $name NAME is absent
+        ipa$name:
+          ipaadmin_password: SomeADMINpassword
+          ipaapi_context: client
+          name: NAME
+          state: absent
+        register: result
+        failed_when: not result.changed or result.failed
+
+      - name: Ensure $name NAME is absent again
+        ipa$name:
+          ipaadmin_password: SomeADMINpassword
+          ipaapi_context: client
+          name: NAME
+          state: absent
+        register: result
+        failed_when: result.changed or result.failed
+
+      # CLEANUP TEST ITEMS
+
+      - name: Ensure $name NAME is absent
+        ipa$name:
+          ipaadmin_password: SomeADMINpassword
+          ipaapi_context: client
+          name: NAME
+          state: absent
+
+  when: groups['ipaclients'] is defined

--- a/utils/templates/test_module_client_context.yml.in
+++ b/utils/templates/test_module_client_context.yml.in
@@ -1,0 +1,62 @@
+---
+- name: Test $name
+  hosts: ipaclients
+  become: true
+
+  tasks:
+    - block:  # only execute tests if groups['ipaclients'] is defined.
+      # CLEANUP TEST ITEMS
+
+      - name: Ensure $name NAME is absent
+        ipa$name:
+          ipaadmin_password: SomeADMINpassword
+          name: NAME
+          state: absent
+
+      # CREATE TEST ITEMS
+
+      # TESTS
+
+      - name: Ensure $name NAME is present
+        ipa$name:
+          ipaadmin_password: SomeADMINpassword
+          name: NAME
+          # Add needed parameters here
+        register: result
+        failed_when: not result.changed or result.failed
+
+      - name: Ensure $name NAME is present again
+        ipa$name:
+          ipaadmin_password: SomeADMINpassword
+          name: NAME
+          # Add needed parameters here
+        register: result
+        failed_when: result.changed or result.failed
+
+      # more tests here
+
+      - name: Ensure $name NAME is absent
+        ipa$name:
+          ipaadmin_password: SomeADMINpassword
+          name: NAME
+          state: absent
+        register: result
+        failed_when: not result.changed or result.failed
+
+      - name: Ensure $name NAME is absent again
+        ipa$name:
+          ipaadmin_password: SomeADMINpassword
+          name: NAME
+          state: absent
+        register: result
+        failed_when: result.changed or result.failed
+
+      # CLEANUP TEST ITEMS
+
+      - name: Ensure $name NAME is absent
+        ipa$name:
+          ipaadmin_password: SomeADMINpassword
+          name: NAME
+          state: absent
+
+  when: groups['ipaclients'] is defined


### PR DESCRIPTION
The function api_connect() is used to bootstrap the IPA API, and
configure the connection to the backend in this process. Currently,
only the `context` in which the commands will be executed, but other
attributes can also be set, like enabling/disabling LDAP cache layer.

By modifying ansible_freeipa_module.api_connect() to accept a set of
keyword arguments, it is possible to configure the bootstraping
process with the desired behavior.

The keyword arguments then have their type and values validated. Also,
if required, value mapping is applied, and, if not present, sensible
default values are provided.

If the argument type is invalid, or if an unexpected argument is given,
a TypeError is raised. If the value provided for the argument is not
in the list of accepted values a ValueError is raised.

Currently, the valid arguments are:
  - `context`: The context to run the module, accepts 'server',
    'client',or 'cli', the default is 'server', and 'client' is mapped
    to 'cli'.
  - `ldap_cache`: A bool value turning on/off the use LDAP caching
    layer for executing commands. Default is `True`.