### PR TITLE
CI: Test modules against Ansible core 2.11 and latest Ansible

### DIFF
--- a/molecule/resources/playbooks/prepare-common.yml
+++ b/molecule/resources/playbooks/prepare-common.yml
@@ -1,7 +1,7 @@
 ---
 # IPA depends on IPv6 and without it dirsrv service won't start.
 - name: Ensure IPv6 is ENABLED
-  sysctl:
+  ansible.posix.sysctl:
     name: "{{ item.name }}"
     value: "{{ item.value }}"
     sysctl_set: yes
@@ -19,14 +19,14 @@
 #   This is needed in some IPA versions in order to get KRA enabled.
 #   See https://pagure.io/freeipa/issue/7906 for more information.
 - name: stat protected_regular
-  stat:
+  ansible.builtin.stat:
     path: /proc/sys/fs/protected_regular
   register: result
 
 - name: Ensure fs.protected_regular is disabled
-  sysctl:
+  ansible.posix.sysctl:
     name: fs.protected_regular
-    value: '0'
+    value: 0
     sysctl_set: yes
     state: present
     reload: yes

--- a/molecule/resources/playbooks/prepare.yml
+++ b/molecule/resources/playbooks/prepare.yml
@@ -11,7 +11,7 @@
   #
   # To avoid this problem we create the directories before starting IPA.
   - name: Ensure lock dirs for DS exists
-    file:
+    ansible.builtin.file:
       state: directory
       owner: dirsrv
       group: dirsrv
@@ -22,6 +22,6 @@
       - /var/lock/dirsrv/slapd-TEST-LOCAL/
 
   - name: Ensure IPA server is up an running
-    service:
+    ansible.builtin.service:
       name: ipa
       state: started

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -3,5 +3,4 @@ pytest>=2.7
 pytest-sourceorder>=0.5
 pytest-split-tests>=1.0.3
 pytest-testinfra>=5.0
-jmespath>=0.9  # needed for the `json_query` filter
 pyyaml>=3

--- a/tests/azure/azure-pipelines.yml
+++ b/tests/azure/azure-pipelines.yml
@@ -1,43 +1,41 @@
-# Using Ansible 2.10.0a1 under Azure there might happen that the output of a
-# task is changed if a module uses no_log = True for an attribute.
-#
-# For example, if the output of the module should contain "changed: True", and
-# an attribute with no_log set contains the value `hang` it might happen that
-# the output is modified to "c******ed: True", and if this output is further
-# processed (registering the result and comparing the value of `changed`),
-# the test might fail, but not because of module code, but because of unexpected
-# output processing.
-#
-# This behavior was, currently, only reproduced with Ansible 2.10.0a1 running
-# under Azure.
 ---
 trigger:
 - master
 
 pool:
-  vmImage: 'ubuntu-20.04'
+  vmImage: 'ubuntu-latest'
 
 stages:
-- stage: Centos7
-  dependsOn: []
-  jobs:
-  - template: templates/group_tests.yml
-    parameters:
-      build_number: $(Build.BuildNumber)
-      scenario: centos-7
 
-- stage: Centos8
-  dependsOn: []
-  jobs:
-  - template: templates/group_tests.yml
-    parameters:
-      build_number: $(Build.BuildNumber)
-      scenario: centos-8
+# Fedora
 
-- stage: FedoraLatest
+- stage: FedoraLatest_Ansible_2_9
   dependsOn: []
   jobs:
   - template: templates/group_tests.yml
     parameters:
       build_number: $(Build.BuildNumber)
       scenario: fedora-latest
+      ansible_version: ">=2.9,<2.10"
+
+# CentOS 8
+
+- stage: CentOS8_Ansible_2_9
+  dependsOn: []
+  jobs:
+  - template: templates/group_tests.yml
+    parameters:
+      build_number: $(Build.BuildNumber)
+      scenario: centos-8
+      ansible_version: ">=2.9,<2.10"
+
+# CentOS 7
+
+- stage: CentOS7_Ansible_2_9
+  dependsOn: []
+  jobs:
+  - template: templates/group_tests.yml
+    parameters:
+      build_number: $(Build.BuildNumber)
+      scenario: centos-7
+      ansible_version: ">=2.9,<2.10"

--- a/tests/azure/nightly.yml
+++ b/tests/azure/nightly.yml
@@ -1,0 +1,102 @@
+---
+schedules:
+- cron: "0 19 * * *"
+  displayName: Nightly Builds
+  branches:
+    include:
+    - master
+  always: true
+
+trigger: none
+
+pool:
+  vmImage: 'ubuntu-latest'
+
+stages:
+
+# Fedora
+
+- stage: FedoraLatest_Ansible_2_9
+  dependsOn: []
+  jobs:
+  - template: templates/group_tests.yml
+    parameters:
+      build_number: $(Build.BuildNumber)
+      scenario: fedora-latest
+      ansible_version: ">=2.9,<2.10"
+
+- stage: FedoraLatest_Ansible_Core_2_11
+  dependsOn: []
+  jobs:
+  - template: templates/group_tests.yml
+    parameters:
+      build_number: $(Build.BuildNumber)
+      scenario: fedora-latest
+      ansible_version: "-core >=2.11,<2.12"
+
+- stage: FedoraLatest_Ansible_latest
+  dependsOn: []
+  jobs:
+  - template: templates/group_tests.yml
+    parameters:
+      build_number: $(Build.BuildNumber)
+      scenario: fedora-latest
+      ansible_version: ""
+
+# CentOS 8
+
+- stage: CentOS8_Ansible_2_9
+  dependsOn: []
+  jobs:
+  - template: templates/group_tests.yml
+    parameters:
+      build_number: $(Build.BuildNumber)
+      scenario: centos-8
+      ansible_version: ">=2.9,<2.10"
+
+- stage: CentOS8_Ansible_Core_2_11
+  dependsOn: []
+  jobs:
+  - template: templates/group_tests.yml
+    parameters:
+      build_number: $(Build.BuildNumber)
+      scenario: centos-8
+      ansible_version: "-core >=2.11,<2.12"
+
+- stage: CentOS8_Ansible_latest
+  dependsOn: []
+  jobs:
+  - template: templates/group_tests.yml
+    parameters:
+      build_number: $(Build.BuildNumber)
+      scenario: centos-8
+      ansible_version: ""
+
+# CentOS 7
+
+- stage: CentOS7_Ansible_2_9
+  dependsOn: []
+  jobs:
+  - template: templates/group_tests.yml
+    parameters:
+      build_number: $(Build.BuildNumber)
+      scenario: centos-7
+      ansible_version: ">=2.9,<2.10"
+
+- stage: CentOS7_Ansible_Core_2_11
+  dependsOn: []
+  jobs:
+  - template: templates/group_tests.yml
+    parameters:
+      build_number: $(Build.BuildNumber)
+      scenario: centos-7
+      ansible_version: "-core >=2.11,<2.12"
+
+- stage: CentOS7_Ansible_latest
+  dependsOn: []
+  jobs:
+  - template: templates/group_tests.yml
+    parameters:
+      build_number: $(Build.BuildNumber)
+      scenario: centos-7
+      ansible_version: ""

--- a/tests/azure/templates/group_tests.yml
+++ b/tests/azure/templates/group_tests.yml
@@ -5,6 +5,9 @@ parameters:
     default: centos-8
   - name: build_number
     type: string
+  - name: ansible_version
+    type: string
+    default: ""
 
 jobs:
 - template: playbook_tests.yml
@@ -13,6 +16,7 @@ jobs:
     number_of_groups: 3
     build_number: ${{ parameters.build_number }}
     scenario: ${{ parameters.scenario }}
+    ansible_version: ${{ parameters.ansible_version }}
 
 - template: playbook_tests.yml
   parameters:
@@ -20,6 +24,7 @@ jobs:
     number_of_groups: 3
     build_number: ${{ parameters.build_number }}
     scenario: ${{ parameters.scenario }}
+    ansible_version: ${{ parameters.ansible_version }}
 
 - template: playbook_tests.yml
   parameters:
@@ -27,6 +32,7 @@ jobs:
     number_of_groups: 3
     build_number: ${{ parameters.build_number }}
     scenario: ${{ parameters.scenario }}
+    ansible_version: ${{ parameters.ansible_version }}
 
 - template: pytest_tests.yml
   parameters:

--- a/tests/azure/templates/playbook_tests.yml
+++ b/tests/azure/templates/playbook_tests.yml
@@ -11,7 +11,7 @@ parameters:
     default: centos-8
   - name: ansible_version
     type: string
-    default: ">=2.9,<2.10"
+    default: ""
   - name: python_version
     type: string
     default: 3.6
@@ -34,8 +34,8 @@ jobs:
         "ansible${{ parameters.ansible_version }}"
     displayName: Install molecule and Ansible
 
-  - script: |
-      ansible-galaxy collection install community.docker
+  - script: ansible-galaxy collection install community.docker ansible.posix
+    displayName: Install Ansible collections
 
   - script: pip install -r requirements-tests.txt
     displayName: Install dependencies

--- a/tests/azure/templates/pytest_tests.yml
+++ b/tests/azure/templates/pytest_tests.yml
@@ -1,15 +1,15 @@
 ---
 parameters:
-- name: build_number
-  type: string
-- name: scenario
-  type: string
-- name: ansible_version
-  type: string
-  default: ">=2.9,<2.10"
-- name: python_version
-  type: string
-  default: 3.6
+  - name: build_number
+    type: string
+  - name: scenario
+    type: string
+  - name: ansible_version
+    type: string
+    default: ""
+  - name: python_version
+    type: string
+    default: 3.6
 
 jobs:
 - job: Test_PyTests
@@ -26,8 +26,8 @@ jobs:
         "ansible${{ parameters.ansible_version }}"
     displayName: Install molecule and Ansible
 
-  - script: |
-      ansible-galaxy collection install community.docker
+  - script: ansible-galaxy collection install community.docker ansible.posix
+    displayName: Install Ansible collections
 
   - script: pip install -r requirements-tests.txt
     displayName: Install dependencies


### PR DESCRIPTION
Currently, upstream CI test documentation against different Ansible
versions, but playbook tests are only executed with Ansible 2.9 series.
This patch add support for running playbook tests using ansible-core
version 2.11 and the latest version of Ansible.

All Ansible installations is done through Python's PIP.

See the [Checks Tab](https://github.com/freeipa/ansible-freeipa/pull/612/checks) for the resulting pipelines.

Total time for running tests is now more than 3h, using the maximum
parallelization allowed by Azure for open source projects (10 instances).