### PR TITLE
CI: pin ansible-core version for ansible-doc-test.

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -16,9 +16,22 @@ jobs:
         run: |
           python -m pip install "ansible < 2.10"
           ANSIBLE_LIBRARY="." ANSIBLE_DOC_FRAGMENT_PLUGINS="." python utils/ansible-doc-test -v roles plugins
-  
+
+  check_docs_2_11:
+    name: Check Ansible Documentation with ansible-core 2.11.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: '3.x'
+      - name: Run ansible-doc-test
+        run: |
+          python -m pip install "ansible-core >=2.11,<2.12"
+          ANSIBLE_LIBRARY="." ANSIBLE_DOC_FRAGMENT_PLUGINS="." python utils/ansible-doc-test -v roles plugins
+
   check_docs_latest:
-    name: Check Ansible Documentation with latest Ansible.
+    name: Check Ansible Documentation with latest Ansible version.
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -29,4 +42,3 @@ jobs:
         run: |
           python -m pip install ansible
           ANSIBLE_LIBRARY="." ANSIBLE_DOC_FRAGMENT_PLUGINS="." python utils/ansible-doc-test -v roles plugins
-


### PR DESCRIPTION
This patch pins ansible-core version to 2.11 when evaluating
documentation with ansible-doc-test, so both 2.9 (ansible) and
2.11 (ansible-core) are covered when testing documentation.