### PR TITLE
Replace json_query in tests/user/test_users_absent.yml

### DIFF
--- a/tests/user/test_users_absent.yml
+++ b/tests/user/test_users_absent.yml
@@ -12,8 +12,13 @@
     include_vars:
       file: users.json
 
+  - name: Create dict with user names
+    set_fact:
+      user_names: "{{ user_names | default([]) + [{ 'name': item.name }] }}"
+    loop: "{{ users }}"
+
   - name: Users absent len:{{ users | length }}
     ipauser:
       ipaadmin_password: SomeADMINpassword
-      users: "{{ users | json_query('[*].{name: name}') }}"
+      users: "{{ user_names }}"
       state: absent


### PR DESCRIPTION
json_query is not part of Ansible Core. As this is the only used module
that is not in Core it has been replaced by constructig a new dict with
the needed user names from users dict using a loop and set_fact.