### PR TITLE
hbacrule: Create FQDN from single hostnames

### DIFF
--- a/plugins/module_utils/ansible_freeipa_module.py
+++ b/plugins/module_utils/ansible_freeipa_module.py
@@ -370,6 +370,14 @@ else:
     def module_params_get(module, name):
         return _afm_convert(module.params.get(name))
 
+    def api_get_domain():
+        return api.env.domain
+
+    def ensure_fqdn(name, domain):
+        if "." not in name:
+            return "%s.%s" % (name, domain)
+        return name
+
     def api_get_realm():
         return api.env.realm
 

--- a/plugins/modules/ipahbacrule.py
+++ b/plugins/modules/ipahbacrule.py
@@ -159,7 +159,8 @@ RETURN = """
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.ansible_freeipa_module import temp_kinit, \
     temp_kdestroy, valid_creds, api_connect, api_command, compare_args_ipa, \
-    module_params_get, gen_add_del_lists, gen_add_list, gen_intersection_list
+    module_params_get, gen_add_del_lists, gen_add_list, \
+    gen_intersection_list, api_get_domain, ensure_fqdn
 
 
 def find_hbacrule(module, name):
@@ -324,6 +325,14 @@ def main():
             ccache_dir, ccache_name = temp_kinit(ipaadmin_principal,
                                                  ipaadmin_password)
         api_connect()
+
+        # Get default domain
+        default_domain = api_get_domain()
+
+        # Ensure fqdn host names, use default domain for simple names
+        if host is not None:
+            _host = [ensure_fqdn(x, default_domain) for x in host]
+            host = _host
 
         commands = []
 

--- a/tests/hbacrule/test_hbacrule.yml
+++ b/tests/hbacrule/test_hbacrule.yml
@@ -580,6 +580,28 @@
     register: result
     failed_when: result.changed or result.failed
 
+  # ENSURE SIMPLE HOSTNAMES MATCH
+
+  - name: Ensure HBAC rule hbacrule01 simple host members are usable
+    ipahbacrule:
+      ipaadmin_password: SomeADMINpassword
+      name: hbacrule01
+      host:
+      - "testhost01"
+      - "testhost03"
+    register: result
+    failed_when: not result.changed or result.failed
+
+  - name: Ensure HBAC rule hbacrule01 simple host members are usable again (and match)
+    ipahbacrule:
+      ipaadmin_password: SomeADMINpassword
+      name: hbacrule01
+      host:
+      - "testhost01"
+      - "testhost03"
+    register: result
+    failed_when: result.changed or result.failed
+
   # CLEANUP TEST ITEMS
 
   - name: Ensure test HBAC rule hbacrule01 is absent


### PR DESCRIPTION
Single hostnames can be used for hbacrule_add_host and will match fqdn
in IPA internally. Simple host names have to be extended to be FQDN to
be able to compare them for _host_add and _host_remove.

Two new functions have been added to ansible_freeipa_module:

- api_get_domain - Get the domain from the api
- ensure_fqdn - Extend a single name with the domain

This fixes #617 - hbacrule_add_host: already a member