### PR TITLE
dnszone: remove variable `serial`.

### DIFF
--- a/README-dnszone.md
+++ b/README-dnszone.md
@@ -84,7 +84,6 @@ Example playbook to create a DNS zone with all currently supported variables:
         - ip_address: 8.8.8.8
         - ip_address: 8.8.4.4
           port: 52
-      serial: 1234
       refresh: 3600
       retry: 900
       expire: 1209600
@@ -218,7 +217,6 @@ Variable | Description | Required
 `dnssec`| Allow inline DNSSEC signing of records in the zone | no
 `allow_transfer`| List of IP addresses or networks which are allowed to transfer the zone | no
 `allow_query`| List of IP addresses or networks which are allowed to issue queries | no
-`serial`| SOA record serial number | no
 `refresh`| SOA record refresh time | no
 `retry`| SOA record retry time | no
 `expire`| SOA record expire time | no

--- a/plugins/modules/ipadnszone.py
+++ b/plugins/modules/ipadnszone.py
@@ -103,10 +103,6 @@ options:
     description: List of IP addresses or networks which are allowed to issue queries
     required: false
     type: bool
-  serial:
-    description: SOA record serial number
-    required: false
-    type: int
   refresh:
     description: SOA record refresh time
     required: false
@@ -171,7 +167,6 @@ EXAMPLES = """
       - ip_address: 8.8.8.8
       - ip_address: 8.8.4.4
         port: 52
-    serial: 1234
     refresh: 3600
     retry: 900
     expire: 1209600
@@ -228,7 +223,6 @@ class DNSZoneModule(FreeIPABaseModule):
     ipa_param_mapping = {
         # Direct Mapping
         "idnsforwardpolicy": "forward_policy",
-        "idnssoaserial": "serial",
         "idnssoarefresh": "refresh",
         "idnssoaretry": "retry",
         "idnssoaexpire": "expire",
@@ -451,10 +445,6 @@ class DNSZoneModule(FreeIPABaseModule):
             # Look for existing zone in IPA
             zone, is_zone_active = self.get_zone(zone_name)
             args = self.get_ipa_command_args(zone=zone)
-            set_serial = self.ipa_params.serial is not None
-
-            if set_serial:
-                del args["idnssoaserial"]
 
             if self.ipa_params.state in ["present", "enabled", "disabled"]:
                 if not zone:
@@ -478,26 +468,6 @@ class DNSZoneModule(FreeIPABaseModule):
 
             if self.ipa_params.state == "absent" and zone is not None:
                 self.add_ipa_command("dnszone_del", zone_name)
-
-            # Due to a bug in FreeIPA dnszone-add won't set
-            # SOA Serial in the creation of a zone, or if
-            # another field is modified along with it.
-            # As a workaround, we set only the SOA serial,
-            # with dnszone-mod, after other changes.
-            # See:
-            #   - https://pagure.io/freeipa/issue/8227
-            #   - https://pagure.io/freeipa/issue/8489
-            # Only set SOA Serial if it is not set already.
-            if (set_serial and
-                (zone is None
-                 or "idnssoaserial" not in zone
-                 or zone["idnssoaserial"] is None
-                 or zone["idnssoaserial"][0] != str(self.ipa_params.serial)
-                 )):
-                args = {
-                    "idnssoaserial": self.ipa_params.serial,
-                }
-                self.add_ipa_command("dnszone_mod", zone_name, args)
 
     def process_command_result(self, name, command, args, result):
         # pylint: disable=super-with-arguments
@@ -552,7 +522,6 @@ def get_argument_spec():
         dnssec=dict(type="bool", required=False, default=None),
         allow_transfer=dict(type="list", required=False, default=None),
         allow_query=dict(type="list", required=False, default=None),
-        serial=dict(type="int", required=False, default=None),
         refresh=dict(type="int", required=False, default=None),
         retry=dict(type="int", required=False, default=None),
         expire=dict(type="int", required=False, default=None),

--- a/tests/dnszone/test_dnszone_mod.yml
+++ b/tests/dnszone/test_dnszone_mod.yml
@@ -10,81 +10,6 @@
   - name: Setup testing environment
     include_tasks: env_setup.yml
 
-  # Tests
-  - name: Verify if zone can be created with a specific SOA serial.
-    block:
-    - name: Create zone with serial, refresh, retry and expire.
-      ipadnszone:
-        ipaadmin_password: SomeADMINpassword
-        name: testzone.local
-        serial: 4567
-        refresh: 70
-        retry: 89
-        expire: 200
-
-    - name: Verify zone was created with correct values.
-      shell: |
-         echo SomeADMINpassword | kinit -c {{ KRB5CCNAME }} admin
-         KRB5CCNAME={{ KRB5CCNAME }} ipa dnszone-show testzone.local
-         kdestroy -A -q -c {{ KRB5CCNAME }}
-      register: result
-      failed_when: |
-        result.failed or not (
-          "serial: 4567" in result.stdout
-          and "refresh: 70" in result.stdout
-          and "retry: 89" in result.stdout
-          and "expire: 200" in result.stdout
-        )
-
-    - name: Remove test zone.
-      ipadnszone:
-        ipaadmin_password: SomeADMINpassword
-        name: testzone.local
-        state: absent
-
-    vars:
-      KRB5CCNAME: verify_bz_1876896
-
-  - name: Verify if a zone can have the the SOA serial modified to a specific value.
-    block:
-    - name: Create zone.
-      ipadnszone:
-        ipaadmin_password: SomeADMINpassword
-        name: testzone.local
-        state: present
-
-    - name: Modify zone with serial, refresh, retry and expire.
-      ipadnszone:
-        ipaadmin_password: SomeADMINpassword
-        name: testzone.local
-        serial: 4567
-        refresh: 70
-        retry: 89
-        expire: 200
-
-    - name: Verify zone was modified to the correct values
-      shell: |
-         echo SomeADMINpassword | kinit -c {{ KRB5CCNAME }} admin
-         KRB5CCNAME={{ KRB5CCNAME }} ipa dnszone-show testzone.local
-         kdestroy -A -q -c {{ KRB5CCNAME }}
-      register: result
-      failed_when: |
-        result.failed or not (
-          "serial: 4567" in result.stdout
-          and "refresh: 70" in result.stdout
-          and "retry: 89" in result.stdout
-          and "expire: 200" in result.stdout
-        )
-
-    - name: Remove test zone.
-      ipadnszone:
-        ipaadmin_password: SomeADMINpassword
-        name: testzone.local
-        state: absent
-
-    vars:
-      KRB5CCNAME: verify_bz_1876896
-
   - name: Ensure zone is present.
     ipadnszone:
       ipaadmin_password: SomeADMINpassword
@@ -98,7 +23,6 @@
       allow_query:
         - 1.1.1.1
         - 2.2.2.2
-      serial: 1234
       refresh: 3600
       retry: 900
       expire: 1209600
@@ -112,14 +36,6 @@
       state: present
     register: result
     failed_when: not result.changed or result.failed
-
-  - name: Set serial to 1234, again.
-    ipadnszone:
-      ipaadmin_password: SomeADMINpassword
-      name: testzone.local
-      serial: 1234
-    register: result
-    failed_when: result.changed or result.failed
 
   - name: Set different nsec3param_rec.
     ipadnszone:
@@ -230,22 +146,6 @@
       ipaadmin_password: SomeADMINpassword
       name: testzone.local
       refresh: 4000
-    register: result
-    failed_when: result.changed or result.failed
-
-  - name: Set serial to 12345.
-    ipadnszone:
-      ipaadmin_password: SomeADMINpassword
-      name: testzone.local
-      serial: 12345
-    register: result
-    failed_when: not result.changed or result.failed
-
-  - name: Set serial to 12345, again.
-    ipadnszone:
-      ipaadmin_password: SomeADMINpassword
-      name: testzone.local
-      serial: 12345
     register: result
     failed_when: result.changed or result.failed
 

--- a/tests/pytests/dnszone/test_dnszone.py
+++ b/tests/pytests/dnszone/test_dnszone.py
@@ -78,7 +78,7 @@ class TestDNSZone(AnsibleFreeIPATestCase):
         self.check_details(["Active zone: TRUE"], "dnszone-find", [zone26])
 
     def test_dnszone_name_from_ip(self):
-        """TC-35: Add dns zone with reverse zone IP. Bug#1845056"""
+        """TC-35: Add dns zone with reverse zone IP. Bug#1845056."""
         zone = "8.192.in-addr.arpa."
         expected_msg = "Zone name: {0}".format(zone)
         self.check_notexists([expected_msg], "dnszone-find", [zone])
@@ -92,7 +92,7 @@ class TestDNSZone(AnsibleFreeIPATestCase):
         self.check_details([expected_msg], "dnszone-find", [zone])
 
     def test_dnszone_del_multiple(self):
-        """TC-33: Delete multiple DNS zones Bug#1845058"""
+        """TC-33: Delete multiple DNS zones Bug#1845058."""
         zone = ["delzone1.com", "delzone2.com", "delzone3.com"]
         for add_zone in zone:
             kinit_admin(self.master)
@@ -112,7 +112,7 @@ class TestDNSZone(AnsibleFreeIPATestCase):
             self.check_notexists([error], "dnszone-show", [add_zone])
 
     def test_dnszone_invalid_ip(self):
-        """TC-07: Update with invalid IP’s in allow_transfer. Bug#1845051"""
+        """TC-07: Update with invalid IP’s in allow_transfer. Bug#1845051."""
         invalid_zone_name = "invalidzone.test"
         invalid_zone_ip = "in.va.li.d"
         expected_error = "Invalid IP for DNS forwarder"
@@ -128,20 +128,3 @@ class TestDNSZone(AnsibleFreeIPATestCase):
         self.check_notexists(
             [invalid_zone_ip], "dnszone-show", [invalid_zone_name],
         )
-
-    def test_invalid_serial(self):
-        """TC-13: Update invalid Serial."""
-        invalid_zone_name = "invalidserialzone.test"
-        invalid_serial = "429496729599"
-        expected_error = "invalid 'serial': can be at most 4294967295"
-
-        self.mark_xfail_using_ansible_freeipa_version(
-            version="ansible-freeipa-0.1.12-5.el8.noarch",
-            reason="Fix is not available for BZ-1845058",
-        )
-
-        self.run_playbook_with_exp_msg(
-            BASE_PATH + "dnszone_invalid_serial.yaml", expected_error
-        )
-        cmd = "dnszone-show"
-        self.check_notexists([invalid_serial], cmd, [invalid_zone_name])


### PR DESCRIPTION
As of FreeIPA 4.9.7, setting SOA serial is deprecated, so this change
removes support for setting this variable in ipadnszone module.

As the behavior of SOA serial was unstable, at best, no effort was made
to allow its use with older versions of FreeIPA.