### PR TITLE
ansible-lint: Add paths and files to exclude list.

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,7 +1,14 @@
 exclude_paths:
-  - roles
-  - .tox
-  - .venv
+  - .ansible-freeipa-tests/
+  - .cache/
+  - .github/
+  - .pre-commit-config.yaml
+  - .tox/
+  - .venv/
+  - .yamllint
+  - molecule/
+  - tests/azure/
+
 
 parseable: true
 


### PR DESCRIPTION
Some YAML files used in the project are not Ansible playbooks and
should not be evaluated by ansible-lint. This change add the paths
and files that should not be evaluated to an exclude list, that
affects linter operations in CI and pre-commit scripts.