### PR TITLE
Use Ansible fact "os_family" as fallback, when distro is not directly suppported.

### DIFF
--- a/roles/ipabackup/tasks/restore.yml
+++ b/roles/ipabackup/tasks/restore.yml
@@ -9,6 +9,13 @@
     - "{{ role_path }}/vars/{{ ansible_facts['distribution'] }}-{{ ansible_facts['distribution_version'] }}.yml"
     - "{{ role_path }}/vars/{{ ansible_facts['distribution'] }}-{{ ansible_facts['distribution_major_version'] }}.yml"
     - "{{ role_path }}/vars/{{ ansible_facts['distribution'] }}.yml"
+    # os_family is used as a fallback for distros which are not currently
+    # supported, but are based on a supported distro family. For example,
+    # Oracle, Rocky, Alma and Alibaba linux, which are all "RedHat" based.
+    - "vars/{{ ansible_facts['os_family'] }}-{{ ansible_facts['distribution_version'] }}.yml"
+    - "vars/{{ ansible_facts['os_family'] }}-{{ ansible_facts['distribution_major_version'] }}.yml"
+    - "vars/{{ ansible_facts['os_family'] }}.yml"
+    # If neither distro nor family is supported, try a default configuration.
     - "{{ role_path }}/vars/default.yml"
 
 ### GET SERVICES FROM BACKUP

--- a/roles/ipabackup/vars/CentOS-7.yml
+++ b/roles/ipabackup/vars/CentOS-7.yml
@@ -1,6 +1,0 @@
-# defaults file for ipaserver
-# vars/rhel.yml
-ipaserver_packages: [ "ipa-server", "libselinux-python" ]
-ipaserver_packages_dns: [ "ipa-server-dns" ]
-ipaserver_packages_adtrust: [ "ipa-server-trust-ad" ]
-ipaserver_packages_firewalld: [ "firewalld" ]

--- a/roles/ipabackup/vars/CentOS-8.yml
+++ b/roles/ipabackup/vars/CentOS-8.yml
@@ -1,1 +1,0 @@
-RedHat-8.yml

--- a/roles/ipabackup/vars/OracleLinux-7.yml
+++ b/roles/ipabackup/vars/OracleLinux-7.yml
@@ -1,1 +1,0 @@
-RedHat-7.yml

--- a/roles/ipabackup/vars/OracleLinux-8.yml
+++ b/roles/ipabackup/vars/OracleLinux-8.yml
@@ -1,1 +1,0 @@
-RedHat-8.yml

--- a/roles/ipabackup/vars/RedHat-7.3.yml
+++ b/roles/ipabackup/vars/RedHat-7.3.yml
@@ -1,6 +1,0 @@
-# defaults file for ipaserver
-# vars/rhel.yml
-ipaserver_packages: [ "ipa-server", "libselinux-python" ]
-ipaserver_packages_dns: [ "ipa-server-dns" ]
-ipaserver_packages_adtrust: [ "ipa-server-trust-ad" ]
-ipaserver_packages_firewalld: [ "firewalld" ]

--- a/roles/ipaclient/tasks/main.yml
+++ b/roles/ipaclient/tasks/main.yml
@@ -7,6 +7,13 @@
     - "{{ role_path }}/vars/{{ ansible_facts['distribution'] }}-{{ ansible_facts['distribution_version'] }}.yml"
     - "{{ role_path }}/vars/{{ ansible_facts['distribution'] }}-{{ ansible_facts['distribution_major_version'] }}.yml"
     - "{{ role_path }}/vars/{{ ansible_facts['distribution'] }}.yml"
+    # os_family is used as a fallback for distros which are not currently
+    # supported, but are based on a supported distro family. For example,
+    # Oracle, Rocky, Alma and Alibaba linux, which are all "RedHat" based.
+    - "vars/{{ ansible_facts['os_family'] }}-{{ ansible_facts['distribution_version'] }}.yml"
+    - "vars/{{ ansible_facts['os_family'] }}-{{ ansible_facts['distribution_major_version'] }}.yml"
+    - "vars/{{ ansible_facts['os_family'] }}.yml"
+    # If neither distro nor family is supported, try a default configuration.
     - "{{ role_path }}/vars/default.yml"
 
 - name: Install IPA client

--- a/roles/ipaclient/vars/CentOS-7.yml
+++ b/roles/ipaclient/vars/CentOS-7.yml
@@ -1,4 +1,0 @@
-# defaults file for ipaclient
-# vars/rhel.yml
-ipaclient_packages: [ "ipa-client", "libselinux-python" ]
-#ansible_python_interpreter: '/usr/bin/python2'

--- a/roles/ipaclient/vars/CentOS-8.yml
+++ b/roles/ipaclient/vars/CentOS-8.yml
@@ -1,1 +1,0 @@
-RedHat-8.yml

--- a/roles/ipaclient/vars/OracleLinux-7.yml
+++ b/roles/ipaclient/vars/OracleLinux-7.yml
@@ -1,1 +1,0 @@
-RedHat-7.yml

--- a/roles/ipaclient/vars/OracleLinux-8.yml
+++ b/roles/ipaclient/vars/OracleLinux-8.yml
@@ -1,1 +1,0 @@
-RedHat-8.yml

--- a/roles/ipaclient/vars/Ubuntu.yml
+++ b/roles/ipaclient/vars/Ubuntu.yml
@@ -1,2 +1,0 @@
-# vars/Ubuntu.yml
-ipaclient_packages: [ "freeipa-client" ]

--- a/roles/ipareplica/tasks/main.yml
+++ b/roles/ipareplica/tasks/main.yml
@@ -7,6 +7,13 @@
     - "vars/{{ ansible_facts['distribution'] }}-{{ ansible_facts['distribution_version'] }}.yml"
     - "vars/{{ ansible_facts['distribution'] }}-{{ ansible_facts['distribution_major_version'] }}.yml"
     - "vars/{{ ansible_facts['distribution'] }}.yml"
+    # os_family is used as a fallback for distros which are not currently
+    # supported, but are based on a supported distro family. For example,
+    # Oracle, Rocky, Alma and Alibaba linux, which are all "RedHat" based.
+    - "vars/{{ ansible_facts['os_family'] }}-{{ ansible_facts['distribution_version'] }}.yml"
+    - "vars/{{ ansible_facts['os_family'] }}-{{ ansible_facts['distribution_major_version'] }}.yml"
+    - "vars/{{ ansible_facts['os_family'] }}.yml"
+    # If neither distro nor family is supported, try a default configuration.
     - "vars/default.yml"
 
 - name: Install IPA replica

--- a/roles/ipareplica/vars/CentOS-7.yml
+++ b/roles/ipareplica/vars/CentOS-7.yml
@@ -1,6 +1,0 @@
-# defaults file for ipareplica
-# vars/RedHat-7.yml
-ipareplica_packages: [ "ipa-server", "libselinux-python" ]
-ipareplica_packages_dns: [ "ipa-server-dns" ]
-ipareplica_packages_adtrust: [ "ipa-server-trust-ad" ]
-ipareplica_packages_firewalld: [ "firewalld" ]

--- a/roles/ipareplica/vars/CentOS-8.yml
+++ b/roles/ipareplica/vars/CentOS-8.yml
@@ -1,1 +1,0 @@
-RedHat-8.yml

--- a/roles/ipareplica/vars/OracleLinux-7.yml
+++ b/roles/ipareplica/vars/OracleLinux-7.yml
@@ -1,1 +1,0 @@
-RedHat-7.yml

--- a/roles/ipareplica/vars/OracleLinux-8.yml
+++ b/roles/ipareplica/vars/OracleLinux-8.yml
@@ -1,1 +1,0 @@
-RedHat-8.yml

--- a/roles/ipareplica/vars/RedHat-7.3.yml
+++ b/roles/ipareplica/vars/RedHat-7.3.yml
@@ -1,6 +1,0 @@
-# defaults file for ipareplica
-# vars/RedHat-7.3.yml
-ipareplica_packages: [ "ipa-server", "libselinux-python" ]
-ipareplica_packages_dns: [ "ipa-server-dns" ]
-ipareplica_packages_adtrust: [ "ipa-server-trust-ad" ]
-ipareplica_packages_firewalld: [ "firewalld" ]

--- a/roles/ipaserver/tasks/main.yml
+++ b/roles/ipaserver/tasks/main.yml
@@ -7,6 +7,13 @@
     - "vars/{{ ansible_facts['distribution'] }}-{{ ansible_facts['distribution_version'] }}.yml"
     - "vars/{{ ansible_facts['distribution'] }}-{{ ansible_facts['distribution_major_version'] }}.yml"
     - "vars/{{ ansible_facts['distribution'] }}.yml"
+    # os_family is used as a fallback for distros which are not currently
+    # supported, but are based on a supported distro family. For example,
+    # Oracle, Rocky, Alma and Alibaba linux, which are all "RedHat" based.
+    - "vars/{{ ansible_facts['os_family'] }}-{{ ansible_facts['distribution_version'] }}.yml"
+    - "vars/{{ ansible_facts['os_family'] }}-{{ ansible_facts['distribution_major_version'] }}.yml"
+    - "vars/{{ ansible_facts['os_family'] }}.yml"
+    # If neither distro nor family is supported, try a default configuration.
     - "vars/default.yml"
 
 - name: Install IPA server

--- a/roles/ipaserver/vars/CentOS-7.yml
+++ b/roles/ipaserver/vars/CentOS-7.yml
@@ -1,6 +1,0 @@
-# defaults file for ipaserver
-# vars/rhel.yml
-ipaserver_packages: [ "ipa-server", "libselinux-python" ]
-ipaserver_packages_dns: [ "ipa-server-dns" ]
-ipaserver_packages_adtrust: [ "ipa-server-trust-ad" ]
-ipaserver_packages_firewalld: [ "firewalld" ]

--- a/roles/ipaserver/vars/CentOS-8.yml
+++ b/roles/ipaserver/vars/CentOS-8.yml
@@ -1,1 +1,0 @@
-RedHat-8.yml

--- a/roles/ipaserver/vars/OracleLinux-7.yml
+++ b/roles/ipaserver/vars/OracleLinux-7.yml
@@ -1,1 +1,0 @@
-RedHat-7.yml

--- a/roles/ipaserver/vars/OracleLinux-8.yml
+++ b/roles/ipaserver/vars/OracleLinux-8.yml
@@ -1,1 +1,0 @@
-RedHat-8.yml

--- a/roles/ipaserver/vars/RedHat-7.3.yml
+++ b/roles/ipaserver/vars/RedHat-7.3.yml
@@ -1,6 +1,0 @@
-# defaults file for ipaserver
-# vars/rhel.yml
-ipaserver_packages: [ "ipa-server", "libselinux-python" ]
-ipaserver_packages_dns: [ "ipa-server-dns" ]
-ipaserver_packages_adtrust: [ "ipa-server-trust-ad" ]
-ipaserver_packages_firewalld: [ "firewalld" ]


### PR DESCRIPTION
When loading variables in all ansible-freeipa roles, it is expected
that a file with these variables is present for each supported Linux
distribution, and then, based on the information about the distribution
provided by Ansible, the correct file is loaded.

Previously, only the facts `distribution` and dinstribution version
related facts were used, which required specific files, or links to
files for distributions in the same "family", which will probably have
the same variables set.

This change adds searching for files based on the `os_family` fact,
allowing distributions that follow the same family rules to be
supported, without any changes to the codebase. It is still possible
that a specific distribution configuration overrides the default
behavior, as `os_family` has lower priority than `distribution`.

For example, distributions on the `RedHat` family, like Oracle Linux,
Alma Linux, and Rocky Linux, work withoutadding new files, or links to
files, to fill the `vars`.

Roles tested on version 8.4 of CentOS, Rocky Linux, and Oracle Linux.

Fix issue #573.
Fix issue #523. 
Fix issue #303.