### PR TITLE
pylint: Upgrade to version 2.10.2.

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -73,5 +73,5 @@ jobs:
           python-version: "3.x"
       - name: Run pylint
         run: |
-            pip install pylint==2.8.2
+            pip install pylint==2.10.2
             pylint plugins --disable=import-error

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,7 +22,7 @@ repos:
   hooks:
   - id: pydocstyle
 - repo: https://github.com/pycqa/pylint
-  rev: v2.9.5
+  rev: v2.10.2
   hooks:
   - id: pylint
     args:

--- a/plugins/module_utils/ansible_freeipa_module.py
+++ b/plugins/module_utils/ansible_freeipa_module.py
@@ -104,7 +104,7 @@ else:
     try:
         from collections.abc import Mapping  # noqa
     except ImportError:
-        from collections import Mapping  # noqa
+        from collections import Mapping  # pylint: disable=deprecated-class
 
     if six.PY3:
         unicode = str

--- a/plugins/modules/ipaautomountlocation.py
+++ b/plugins/modules/ipaautomountlocation.py
@@ -78,15 +78,14 @@ class AutomountLocation(FreeIPABaseModule):
     ipa_param_mapping = {}
 
     def get_location(self, location):
-        response = dict()
         try:
             response = self.api_command("automountlocation_show",
                                         location,
                                         {})
         except ipalib_errors.NotFound:
-            pass
-
-        return response.get("result", None)
+            return None
+        else:
+            return response.get("result", None)
 
     def check_ipa_params(self):
         if len(self.ipa_params.name) == 0:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,3 +2,4 @@
 ipdb
 pre-commit
 flake8-bugbear
+pylint==2.10.2

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,6 +34,9 @@ ignore = D1,D212,D203
 
 [pylint.MASTER]
 disable =
+    unspecified-encoding, # open() does not provide `encoding` in Python2
+    use-maxsplit-arg,
+    redundant-u-string-prefix,
     c-extension-no-member,
     missing-module-docstring,
     missing-class-docstring,


### PR DESCRIPTION
This PR sets pylint to version 2.10.2 in all linter actions, and
fixes code in plugins so that this version new checks are either
satisfied or ignored if needed.