### PR TITLE
Use execute ipa commands

### DIFF
--- a/plugins/modules/ipaautomember.py
+++ b/plugins/modules/ipaautomember.py
@@ -390,32 +390,16 @@ def main():
                     commands.append([None, 'automember_rebuild',
                                     {"hosts": rebuild_hosts}])
 
-        # Check mode exit
-        if ansible_module.check_mode:
-            ansible_module.exit_json(changed=len(commands) > 0, **exit_args)
+        # Execute commands
 
-        for name, command, args in commands:
-            try:
-                if name is None:
-                    result = ansible_module.ipa_command_no_name(command, args)
-                else:
-                    result = ansible_module.ipa_command(command, name, args)
+        changed = ansible_module.execute_ipa_commands(commands)
 
-                if "completed" in result:
-                    if result["completed"] > 0:
-                        changed = True
-                else:
-                    changed = True
-            except Exception as ex:
-                ansible_module.fail_json(msg="%s: %s: %s" % (command, name,
-                                                             str(ex)))
-
-            # result["failed"] is used only for INCLUDE_RE, EXCLUDE_RE
-            # if entries could not be added that are already there and
-            # it entries could not be removed that are not there.
-            # All other issues like invalid attributes etc. are handled
-            # as exceptions. Therefore the error section is not here as
-            # in other modules.
+        # result["failed"] is used only for INCLUDE_RE, EXCLUDE_RE
+        # if entries could not be added that are already there and
+        # if entries could not be removed that are not there.
+        # All other issues like invalid attributes etc. are handled
+        # as exceptions. Therefore the error section is not here as
+        # in other modules.
 
     # Done
     ansible_module.exit_json(changed=changed, **exit_args)

--- a/plugins/modules/ipadelegation.py
+++ b/plugins/modules/ipadelegation.py
@@ -289,23 +289,9 @@ def main():
             else:
                 ansible_module.fail_json(msg="Unkown state '%s'" % state)
 
-        # Check mode exit
-        if ansible_module.check_mode:
-            ansible_module.exit_json(changed=len(commands) > 0, **exit_args)
-
         # Execute commands
 
-        for name, command, args in commands:
-            try:
-                result = ansible_module.ipa_command(command, name, args)
-                if "completed" in result:
-                    if result["completed"] > 0:
-                        changed = True
-                else:
-                    changed = True
-            except Exception as e:
-                ansible_module.fail_json(msg="%s: %s: %s" % (command, name,
-                                                             str(e)))
+        changed = ansible_module.execute_ipa_commands(commands)
 
     # Done
 

--- a/plugins/modules/ipagroup.py
+++ b/plugins/modules/ipagroup.py
@@ -658,34 +658,10 @@ def main():
             else:
                 ansible_module.fail_json(msg="Unkown state '%s'" % state)
 
-        # Check mode exit
-        if ansible_module.check_mode:
-            ansible_module.exit_json(changed=len(commands) > 0, **exit_args)
-
         # Execute commands
 
-        for name, command, args in commands:
-            try:
-                result = ansible_module.ipa_command(command, name, args)
-                if "completed" in result:
-                    if result["completed"] > 0:
-                        changed = True
-                else:
-                    changed = True
-            except Exception as e:
-                ansible_module.fail_json(msg="%s: %s: %s" % (command, name,
-                                                             str(e)))
-            # Get all errors
-            # result are ignored. All others are reported.
-            errors = []
-            for failed_item in result.get("failed", []):
-                failed = result["failed"][failed_item]
-                for member_type in failed:
-                    for member, failure in failed[member_type]:
-                        errors.append("%s: %s %s: %s" % (
-                            command, member_type, member, failure))
-            if len(errors) > 0:
-                ansible_module.fail_json(msg=", ".join(errors))
+        changed = ansible_module.execute_ipa_commands(
+            commands, fail_on_member_errors=True)
 
     # Done
 

--- a/plugins/modules/ipahbacrule.py
+++ b/plugins/modules/ipahbacrule.py
@@ -595,35 +595,10 @@ def main():
             else:
                 ansible_module.fail_json(msg="Unkown state '%s'" % state)
 
-        # Check mode exit
-        if ansible_module.check_mode:
-            ansible_module.exit_json(changed=len(commands) > 0, **exit_args)
-
         # Execute commands
 
-        errors = []
-        for name, command, args in commands:
-            try:
-                result = ansible_module.ipa_command(command, name, args)
-                if "completed" in result:
-                    if result["completed"] > 0:
-                        changed = True
-                else:
-                    changed = True
-            except Exception as e:
-                ansible_module.fail_json(msg="%s: %s: %s" % (command, name,
-                                                             str(e)))
-            # Get all errors
-            # result are ignored. All others are reported.
-            if "failed" in result and len(result["failed"]) > 0:
-                for item in result["failed"]:
-                    failed_item = result["failed"][item]
-                    for member_type in failed_item:
-                        for member, failure in failed_item[member_type]:
-                            errors.append("%s: %s %s: %s" % (
-                                command, member_type, member, failure))
-        if len(errors) > 0:
-            ansible_module.fail_json(msg=", ".join(errors))
+        changed = ansible_module.execute_ipa_commands(
+            commands, fail_on_member_errors=True)
 
     # Done
 

--- a/plugins/modules/ipahbacsvc.py
+++ b/plugins/modules/ipahbacsvc.py
@@ -180,19 +180,9 @@ def main():
             else:
                 ansible_module.fail_json(msg="Unkown state '%s'" % state)
 
-        # Check mode exit
-        if ansible_module.check_mode:
-            ansible_module.exit_json(changed=len(commands) > 0, **exit_args)
-
         # Execute commands
 
-        for name, command, args in commands:
-            try:
-                ansible_module.ipa_command(command, name, args)
-                changed = True
-            except Exception as e:
-                ansible_module.fail_json(msg="%s: %s: %s" % (command, name,
-                                                             str(e)))
+        changed = ansible_module.execute_ipa_commands(commands)
 
     # Done
 

--- a/plugins/modules/ipahostgroup.py
+++ b/plugins/modules/ipahostgroup.py
@@ -490,34 +490,10 @@ def main():
             else:
                 ansible_module.fail_json(msg="Unkown state '%s'" % state)
 
-        # Check mode exit
-        if ansible_module.check_mode:
-            ansible_module.exit_json(changed=len(commands) > 0, **exit_args)
-
         # Execute commands
-        for name, command, args in commands:
-            try:
-                result = ansible_module.ipa_command(command, name, args)
-                if "completed" in result:
-                    if result["completed"] > 0:
-                        changed = True
-                else:
-                    changed = True
-            except Exception as e:
-                ansible_module.fail_json(msg="%s: %s: %s" % (command, name,
-                                                             str(e)))
-            # Get all errors
-            # All "already a member" and "not a member" failures in the
-            # result are ignored. All others are reported.
-            errors = []
-            for failed_item in result.get("failed", []):
-                failed = result["failed"][failed_item]
-                for member_type in failed:
-                    for member, failure in failed[member_type]:
-                        errors.append("%s: %s %s: %s" % (
-                            command, member_type, member, failure))
-            if len(errors) > 0:
-                ansible_module.fail_json(msg=", ".join(errors))
+
+        changed = ansible_module.execute_ipa_commands(
+            commands, fail_on_member_errors=True)
 
     # Done
 

--- a/plugins/modules/ipalocation.py
+++ b/plugins/modules/ipalocation.py
@@ -168,23 +168,8 @@ def main():
             else:
                 ansible_module.fail_json(msg="Unkown state '%s'" % state)
 
-        # Check mode exit
-        if ansible_module.check_mode:
-            ansible_module.exit_json(changed=len(commands) > 0, **exit_args)
-
         # Execute commands
-
-        for name, command, args in commands:
-            try:
-                result = ansible_module.ipa_command(command, name, args)
-                if "completed" in result:
-                    if result["completed"] > 0:
-                        changed = True
-                else:
-                    changed = True
-            except Exception as e:
-                ansible_module.fail_json(msg="%s: %s: %s" % (command, name,
-                                                             str(e)))
+        changed = ansible_module.execute_ipa_commands(commands)
 
     # Done
 

--- a/plugins/modules/ipapermission.py
+++ b/plugins/modules/ipapermission.py
@@ -180,6 +180,22 @@ def gen_args(right, attrs, bindtype, subtree,
     return _args
 
 
+# pylint: disable=unused-argument
+def result_handler(module, result, command, name, args, errors):
+    # Get all errors
+    # All "already a member" and "not a member" failures in the
+    # result are ignored. All others are reported.
+    for failed_item in result.get("failed", []):
+        failed = result["failed"][failed_item]
+        for member_type in failed:
+            for member, failure in failed[member_type]:
+                if "already a member" in failure \
+                   or "not a member" in failure:
+                    continue
+                errors.append("%s: %s %s: %s" % (
+                    command, member_type, member, failure))
+
+
 def main():
     ansible_module = IPAAnsibleModule(
         argument_spec=dict(
@@ -425,38 +441,9 @@ def main():
             else:
                 ansible_module.fail_json(msg="Unknown state '%s'" % state)
 
-        # Check mode exit
-        if ansible_module.check_mode:
-            ansible_module.exit_json(changed=len(commands) > 0, **exit_args)
-
         # Execute commands
 
-        for name, command, args in commands:
-            try:
-                result = ansible_module.ipa_command(command, name, args)
-                if "completed" in result:
-                    if result["completed"] > 0:
-                        changed = True
-                else:
-                    changed = True
-            except Exception as e:
-                ansible_module.fail_json(msg="%s: %s: %s" % (command, name,
-                                                             str(e)))
-            # Get all errors
-            # All "already a member" and "not a member" failures in the
-            # result are ignored. All others are reported.
-            errors = []
-            for failed_item in result.get("failed", []):
-                failed = result["failed"][failed_item]
-                for member_type in failed:
-                    for member, failure in failed[member_type]:
-                        if "already a member" in failure \
-                           or "not a member" in failure:
-                            continue
-                        errors.append("%s: %s %s: %s" % (
-                            command, member_type, member, failure))
-            if len(errors) > 0:
-                ansible_module.fail_json(msg=", ".join(errors))
+        changed = ansible_module.execute_ipa_commands(commands, result_handler)
 
     # Done
 

--- a/plugins/modules/ipapwpolicy.py
+++ b/plugins/modules/ipapwpolicy.py
@@ -272,19 +272,9 @@ def main():
             else:
                 ansible_module.fail_json(msg="Unkown state '%s'" % state)
 
-        # Check mode exit
-        if ansible_module.check_mode:
-            ansible_module.exit_json(changed=len(commands) > 0, **exit_args)
-
         # Execute commands
 
-        for name, command, args in commands:
-            try:
-                ansible_module.ipa_command(command, name, args)
-                changed = True
-            except Exception as e:
-                ansible_module.fail_json(msg="%s: %s: %s" % (command, name,
-                                                             str(e)))
+        changed = ansible_module.execute_ipa_commands(commands)
 
     # Done
 

--- a/plugins/modules/ipaselfservice.py
+++ b/plugins/modules/ipaselfservice.py
@@ -278,17 +278,7 @@ def main():
 
         # Execute commands
 
-        for name, command, args in commands:
-            try:
-                result = ansible_module.ipa_command(command, name, args)
-                if "completed" in result:
-                    if result["completed"] > 0:
-                        changed = True
-                else:
-                    changed = True
-            except Exception as e:
-                ansible_module.fail_json(msg="%s: %s: %s" % (command, name,
-                                                             str(e)))
+        changed = ansible_module.execute_ipa_commands(commands)
 
     # Done
 

--- a/plugins/modules/ipaserver.py
+++ b/plugins/modules/ipaserver.py
@@ -391,17 +391,7 @@ def main():
 
         # Execute commands
 
-        for name, command, args in commands:
-            try:
-                result = ansible_module.ipa_command(command, name, args)
-                if "completed" in result:
-                    if result["completed"] > 0:
-                        changed = True
-                else:
-                    changed = True
-            except Exception as e:
-                ansible_module.fail_json(msg="%s: %s: %s" % (command, name,
-                                                             str(e)))
+        changed = ansible_module.execute_ipa_commands(commands)
 
     # Done
 

--- a/plugins/modules/ipaservice.py
+++ b/plugins/modules/ipaservice.py
@@ -409,6 +409,23 @@ def init_ansible_module():
     return ansible_module
 
 
+# pylint: disable=unused-argument
+def result_handler(module, result, command, name, args, errors):
+    # Get all errors
+    # All "already a member" and "not a member" failures in the
+    # result are ignored. All others are reported.
+    if "failed" in result and len(result["failed"]) > 0:
+        for item in result["failed"]:
+            failed_item = result["failed"][item]
+            for member_type in failed_item:
+                for member, failure in failed_item[member_type]:
+                    if "already a member" in failure \
+                       or "not a member" in failure:
+                        continue
+                    errors.append("%s: %s %s: %s" % (
+                        command, member_type, member, failure))
+
+
 def main():
     ansible_module = init_ansible_module()
 
@@ -831,34 +848,8 @@ def main():
             ansible_module.exit_json(changed=len(commands) > 0, **exit_args)
 
         # Execute commands
-        errors = []
-        for name, command, args in commands:
-            try:
-                result = ansible_module.ipa_command(command, name, args)
 
-                if "completed" in result:
-                    if result["completed"] > 0:
-                        changed = True
-                else:
-                    changed = True
-            except Exception as ex:
-                ansible_module.fail_json(msg="%s: %s: %s" % (command, name,
-                                                             str(ex)))
-            # Get all errors
-            # All "already a member" and "not a member" failures in the
-            # result are ignored. All others are reported.
-            if "failed" in result and len(result["failed"]) > 0:
-                for item in result["failed"]:
-                    failed_item = result["failed"][item]
-                    for member_type in failed_item:
-                        for member, failure in failed_item[member_type]:
-                            if "already a member" in failure \
-                               or "not a member" in failure:
-                                continue
-                            errors.append("%s: %s %s: %s" % (
-                                command, member_type, member, failure))
-        if len(errors) > 0:
-            ansible_module.fail_json(msg=", ".join(errors))
+        changed = ansible_module.execute_ipa_commands(commands, result_handler)
 
     # Done
     ansible_module.exit_json(changed=changed, **exit_args)

--- a/plugins/modules/ipasudorule.py
+++ b/plugins/modules/ipasudorule.py
@@ -824,36 +824,10 @@ def main():
             else:
                 ansible_module.fail_json(msg="Unkown state '%s'" % state)
 
-        # Check mode exit
-        if ansible_module.check_mode:
-            ansible_module.exit_json(changed=len(commands) > 0, **exit_args)
-
         # Execute commands
 
-        errors = []
-        for name, command, args in commands:
-            try:
-                result = ansible_module.ipa_command(command, name, args)
-
-                if "completed" in result:
-                    if result["completed"] > 0:
-                        changed = True
-                else:
-                    changed = True
-            except Exception as ex:
-                ansible_module.fail_json(msg="%s: %s: %s" % (command, name,
-                                                             str(ex)))
-            # Get all errors
-            # result are ignored. All others are reported.
-            if "failed" in result and len(result["failed"]) > 0:
-                for item in result["failed"]:
-                    failed_item = result["failed"][item]
-                    for member_type in failed_item:
-                        for member, failure in failed_item[member_type]:
-                            errors.append("%s: %s %s: %s" % (
-                                command, member_type, member, failure))
-        if len(errors) > 0:
-            ansible_module.fail_json(msg=", ".join(errors))
+        changed = ansible_module.execute_ipa_commands(
+            commands, fail_on_member_errors=True)
 
     # Done
 

--- a/utils/templates/ipamodule+member.py.in
+++ b/utils/templates/ipamodule+member.py.in
@@ -286,38 +286,34 @@ def main():
             else:
                 ansible_module.fail_json(msg="Unkown state '%s'" % state)
 
-        # Check mode exit
-        if ansible_module.check_mode:
-            ansible_module.exit_json(changed=len(commands) > 0, **exit_args)
 
         # Execute commands
 
-        for name, command, args in commands:
-            try:
-                result = ansible_module.ipa_command(command, name, args)
-                if "completed" in result:
-                    if result["completed"] > 0:
-                        changed = True
-                else:
-                    changed = True
-            except Exception as e:
-                ansible_module.fail_json(msg="%s: %s: %s" % (command, name,
-                                                             str(e)))
-            # Get all errors
-            # All "already a member" and "not a member" failures in the
-            # result are ignored. All others are reported.
-            errors = []
-            for failed_item in result.get("failed", []):
-                failed = result["failed"][failed_item]
-                for member_type in failed:
-                    for member, failure in failed[member_type]:
-                        if "already a member" in failure \
-                           or "not a member" in failure:
-                            continue
-                        errors.append("%s: %s %s: %s" % (
-                            command, member_type, member, failure))
-            if len(errors) > 0:
-                ansible_module.fail_json(msg=", ".join(errors))
+        #
+        # To handle default member errors there is a static method
+        # IPAAnsibleModule.handle_member_errors. It can be enabled with
+        # fail_on_member_failures=True for execute_ipa_commands.
+        # There might be cases in which this needs to be either done
+        # manually or extended.
+        #
+        # Example:
+        #
+        # pylint: disable=unused-argument
+        # def result_handler(module, result, command, name, args, errors):
+        #     # Get all errors
+        #     IPAAnsibleModule.handle_member_errors(module, result, command,
+        #                                           name, args, errors)
+        #     if "MY ERROR" in result.get("failed",[]):
+        #         errors.append("My error")
+        #
+        # # Execute commands
+        #
+        # changed = ansible_module.execute_ipa_commands(commands,
+        #                                               result_handler)
+        #
+
+        changed = ansible_module.execute_ipa_commands(
+            commands, fail_on_member_failures=True)
 
     # Done
 

--- a/utils/templates/ipamodule.py.in
+++ b/utils/templates/ipamodule.py.in
@@ -194,23 +194,9 @@ def main():
             else:
                 ansible_module.fail_json(msg="Unkown state '%s'" % state)
 
-        # Check mode exit
-        if ansible_module.check_mode:
-            ansible_module.exit_json(changed=len(commands) > 0, **exit_args)
-
         # Execute commands
 
-        for name, command, args in commands:
-            try:
-                result = ansible_module.ipa_command(command, name, args)
-                if "completed" in result:
-                    if result["completed"] > 0:
-                        changed = True
-                else:
-                    changed = True
-            except Exception as e:
-                ansible_module.fail_json(msg="%s: %s: %s" % (command, name,
-                                                             str(e)))
+        changed = ansible_module.execute_ipa_commands(commands)
 
     # Done
 


### PR DESCRIPTION
execute_ipa_commands replces the check mode exit, the loop over the
generated commands and also in the member failure handling for modules
with member support.
