### PR TITLE
ipadnszone: Accept localhost and localnet in allow_query.

### DIFF
--- a/plugins/modules/ipadnszone.py
+++ b/plugins/modules/ipadnszone.py
@@ -256,8 +256,7 @@ class DNSZoneModule(FreeIPABaseModule):
             if not any([
                 is_ip_address(ip),
                 is_ip_network_address(ip),
-                ip == "any",
-                ip == "none"
+                ip in ["any", "localhost", "localnets", "none"]
             ])
         ]
         if any(invalid_ips):


### PR DESCRIPTION
Bind allows localhost and localnet in allow query so we should accept it.