### PR TITLE
Fix documentation and usage of IPAAnsibleModule

### DIFF
--- a/plugins/module_utils/ansible_freeipa_module.py
+++ b/plugins/module_utils/ansible_freeipa_module.py
@@ -559,9 +559,9 @@ else:
 
                 # Execute command
                 if state == "present":
-                    ansible_module.ipa_command(["command_add", name, {}])
+                    ansible_module.ipa_command("command_add", name, {})
                 else:
-                    ansible_module.ipa_command(["command_del", name, {}])
+                    ansible_module.ipa_command("command_del", name, {})
 
             # Done
 

--- a/plugins/modules/ipatopologysuffix.py
+++ b/plugins/modules/ipatopologysuffix.py
@@ -89,8 +89,7 @@ def main():
 
     with ansible_module.ipa_connect():
         # Execute command
-        ansible_module.ipa_command(["topologysuffix_verify", suffix,
-                                    {}])
+        ansible_module.ipa_command("topologysuffix_verify", suffix, {})
 
     # Done
 


### PR DESCRIPTION
The same error exists is the IPAAnsibleModule class documentation
and on the `ipatopologysuffix` plugin.

In the call to IPAAnsibleModule.ipa_command, a list was being used
as a single parameter, instead of its data being used as a parameter
list.

To test `ipatopologysuffix` the example playbook `verify-topologysuffix.yml`
was used against a single server environment (RHEL 8.4).