### PR TITLE
ipaclient_setup_nss: Use proper nosssd_files list

### DIFF
--- a/roles/ipaclient/library/ipaclient_test.py
+++ b/roles/ipaclient/library/ipaclient_test.py
@@ -186,6 +186,10 @@ ipa_python_version:
   returned: always
   type: int
   sample: 040400
+nosssd_files:
+  description: >
+    The dist of nss_ldap or nss-pam-ldapd files if sssd is disabled
+  type: list
 '''
 
 import os
@@ -248,7 +252,7 @@ def get_ipa_conf():
     """
     parser = RawConfigParser()
     parser.read(paths.IPA_DEFAULT_CONF)
-    result = dict()
+    result = {}
     for item in ['basedn', 'realm', 'domain', 'server', 'host', 'xmlrpc_uri']:
         if parser.has_option('global', item):
             value = parser.get('global', item)
@@ -336,6 +340,7 @@ def main():
             validate_domain_name(options.domain_name)
 
         if options.realm_name:
+            # pylint: disable=deprecated-method
             argspec = inspect.getargspec(validate_domain_name)
             if "entity" in argspec.args:
                 # NUM_VERSION >= 40690:
@@ -457,7 +462,7 @@ def main():
         # global variables
         hostname = None
         hostname_source = None
-        nosssd_files = None
+        nosssd_files = {}
         dnsok = False
         cli_domain = None
         cli_server = None
@@ -573,7 +578,6 @@ def main():
                     rval=CLIENT_INSTALL_ERROR)
 
             (nssldap_installed, nosssd_files) = nssldap_exists()
-            (nssldap_installed, __temp) = nssldap_exists()
             if not nssldap_installed:
                 raise ScriptError(
                     "One of these packages must be installed: nss_ldap or "
@@ -617,6 +621,7 @@ def main():
                 rval=CLIENT_INSTALL_ERROR)
 
         # Create the discovery instance
+        # pylint: disable=invalid-name
         ds = ipadiscovery.IPADiscovery()
 
         ret = ds.search(
@@ -926,7 +931,8 @@ def main():
                      ntp_servers=options.ntp_servers,
                      ntp_pool=options.ntp_pool,
                      client_already_configured=client_already_configured,
-                     ipa_python_version=IPA_PYTHON_VERSION)
+                     ipa_python_version=IPA_PYTHON_VERSION,
+                     nosssd_files=nosssd_files)
 
 
 if __name__ == '__main__':

--- a/roles/ipaclient/module_utils/ansible_ipa_client.py
+++ b/roles/ipaclient/module_utils/ansible_ipa_client.py
@@ -40,7 +40,7 @@ __all__ = ["gssapi", "version", "ipadiscovery", "api", "errors", "x509",
            "configure_openldap_conf", "hardcode_ldap_server",
            "get_certs_from_ldap", "save_state", "create_ipa_nssdb",
            "configure_nisdomain", "configure_ldap_conf",
-           "configure_nslcd_conf", "nosssd_files", "configure_ssh_config",
+           "configure_nslcd_conf", "configure_ssh_config",
            "configure_sshd_config", "configure_automount",
            "configure_firefox", "sync_time", "check_ldap_conf",
            "sssd_enable_ifp"]
@@ -64,12 +64,14 @@ else:
     else:
         IPA_PYTHON_VERSION = NUM_VERSION
 
+    # pylint: disable=invalid-name,useless-object-inheritance
     class installer_obj(object):
         def __init__(self):
             pass
 
-        def set_logger(self, logger):
-            self.logger = logger
+        # pylint: disable=attribute-defined-outside-init
+        def set_logger(self, _logger):
+            self.logger = _logger
 
         # def __getattribute__(self, attr):
         #    value = super(installer_obj, self).__getattribute__(attr)
@@ -97,13 +99,14 @@ else:
     installer = installer_obj()
     # Create options
     options = installer
+    # pylint: disable=attribute-defined-outside-init
     options.interactive = False
     options.unattended = not options.interactive
 
     if NUM_VERSION >= 40400:
         # IPA version >= 4.4
 
-        import sys
+        # import sys
         import inspect
         import gssapi
         import logging
@@ -166,7 +169,7 @@ else:
                 CLIENT_ALREADY_CONFIGURED, nssldap_exists, remove_file, \
                 check_ip_addresses, print_port_conf_info, configure_ipa_conf, \
                 purge_host_keytab, configure_sssd_conf, configure_ldap_conf, \
-                configure_nslcd_conf, nosssd_files
+                configure_nslcd_conf
             get_ca_cert = None
         except ImportError:
             # Create temporary copy of ipa-client-install script (as
@@ -193,6 +196,7 @@ else:
             shutil.rmtree(temp_dir, ignore_errors=True)
             sys.path.remove(temp_dir)
 
+            # pylint: disable=deprecated-method
             argspec = inspect.getargspec(
                 ipa_client_install.configure_krb5_conf)
             if argspec.keywords is None:
@@ -200,6 +204,7 @@ else:
                         cli_realm, cli_domain, cli_server, cli_kdc, dnsok,
                         filename, client_domain, client_hostname, force=False,
                         configure_sssd=True):
+                    # pylint: disable=global-statement
                     global options
                     options.force = force
                     options.sssd = configure_sssd
@@ -236,13 +241,12 @@ else:
             if len(argspec.args) == 3:
                 configure_nisdomain = ipa_client_install.configure_nisdomain
             else:
-                def configure_nisdomain(options, domain, statestore=None):
-                    return ipa_client_install.configure_nisdomain(options,
+                def configure_nisdomain(_options, domain, _statestore=None):
+                    return ipa_client_install.configure_nisdomain(_options,
                                                                   domain)
 
             configure_ldap_conf = ipa_client_install.configure_ldap_conf
             configure_nslcd_conf = ipa_client_install.configure_nslcd_conf
-            nosssd_files = ipa_client_install.nosssd_files
 
             configure_ssh_config = ipa_client_install.configure_ssh_config
             configure_sshd_config = ipa_client_install.configure_sshd_config

--- a/roles/ipaclient/tasks/install.yml
+++ b/roles/ipaclient/tasks/install.yml
@@ -329,6 +329,7 @@
           "{{ ipassd_no_krb5_offline_passwords
               | default(ipasssd_no_krb5_offline_passwords) }}"
         no_dns_sshfp: "{{ ipaclient_no_dns_sshfp }}"
+        nosssd_files: "{{ result_ipaclient_test.nosssd_files }}"
 
     - name: Install - Configure SSH and SSHD
       ipaclient_setup_ssh:


### PR DESCRIPTION
ipaclient_setup_nss is using the nosssd_files dict if sssd is disabled
with no_sssd.

The nosssd_files dict is generated in ipaclient_test and used in
ipaclient_setup_nss. So far ipaclient_setup_nss was using nosssd_files
from ipaclient installer, which was always None.