### PR TITLE
setup.py: Disable pylint rule import-error.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import setuptools
 # setuptools if some other modules registered functions in `atexit`.
 # solution from: http://bugs.python.org/issue15881#msg170215
 try:
-    import multiprocessing  # noqa
+    import multiprocessing  # noqa # pylint:disable=unused-import
 except ImportError:
     pass
 


### PR DESCRIPTION
When running pylint against 'setup.py' it warns that an import is
not used. While it is not directly used, this is a fix for an issue
with older versions of Python, so this change tells pylint to ignore
the error.