### PR TITLE
Fix execution of client context tests.

### DIFF
--- a/tests/automember/test_automember_client_context.yml
+++ b/tests/automember/test_automember_client_context.yml
@@ -36,3 +36,5 @@
 - name: Test automember using client context, in server host.
   import_playbook: test_automember.yml
   when: groups['ipaclients'] is not defined or not groups['ipaclients']
+  vars:
+    ipa_context: client

--- a/tests/automount/test_automountlocation_client_context.yml
+++ b/tests/automount/test_automountlocation_client_context.yml
@@ -35,3 +35,5 @@
 - name: Test automountlocation using client context, in server host.
   import_playbook: test_automountlocation.yml
   when: groups['ipaclients'] is not defined or not groups['ipaclients']
+  vars:
+    ipa_context: client

--- a/tests/config/test_config_client_context.yml
+++ b/tests/config/test_config_client_context.yml
@@ -34,3 +34,5 @@
 - name: Test config using client context, in server host.
   import_playbook: test_config.yml
   when: groups['ipaclients'] is not defined or not groups['ipaclients']
+  vars:
+    ipa_context: client

--- a/tests/delegation/test_delegation_client_context.yml
+++ b/tests/delegation/test_delegation_client_context.yml
@@ -35,3 +35,5 @@
 - name: Test delegation using client context, in server host.
   import_playbook: test_delegation.yml
   when: groups['ipaclients'] is not defined or not groups['ipaclients']
+  vars:
+    ipa_context: client

--- a/tests/dnsconfig/test_dnsconfig_client_context.yml
+++ b/tests/dnsconfig/test_dnsconfig_client_context.yml
@@ -35,3 +35,5 @@
 - name: Test dnsconfig using client context, in server host.
   import_playbook: test_dnsconfig.yml
   when: groups['ipaclients'] is not defined or not groups['ipaclients']
+  vars:
+    ipa_context: client

--- a/tests/dnsforwardzone/test_dnsforwardzone_client_context.yml
+++ b/tests/dnsforwardzone/test_dnsforwardzone_client_context.yml
@@ -35,3 +35,5 @@
 - name: Test dnsforwardzone using client context, in server host.
   import_playbook: test_dnsforwardzone.yml
   when: groups['ipaclients'] is not defined or not groups['ipaclients']
+  vars:
+    ipa_context: client

--- a/tests/dnsrecord/test_dnsrecord_client_context.yml
+++ b/tests/dnsrecord/test_dnsrecord_client_context.yml
@@ -35,3 +35,5 @@
 - name: Test dnsrecord using client context, in server host.
   import_playbook: test_dnsrecord.yml
   when: groups['ipaclients'] is not defined or not groups['ipaclients']
+  vars:
+    ipa_context: client

--- a/tests/dnszone/test_dnszone_client_context.yml
+++ b/tests/dnszone/test_dnszone_client_context.yml
@@ -35,3 +35,5 @@
 - name: Test dnszone using client context, in server host.
   import_playbook: test_dnszone.yml
   when: groups['ipaclients'] is not defined or not groups['ipaclients']
+  vars:
+    ipa_context: client

--- a/tests/group/test_group_client_context.yml
+++ b/tests/group/test_group_client_context.yml
@@ -35,3 +35,5 @@
 - name: Test group using client context, in server host.
   import_playbook: test_group.yml
   when: groups['ipaclients'] is not defined or not groups['ipaclients']
+  vars:
+    ipa_context: client

--- a/tests/hbacrule/test_hbacrule_client_context.yml
+++ b/tests/hbacrule/test_hbacrule_client_context.yml
@@ -35,3 +35,5 @@
 - name: Test hbacrule using client context, in server host.
   import_playbook: test_hbacrule.yml
   when: groups['ipaclients'] is not defined or not groups['ipaclients']
+  vars:
+    ipa_context: client

--- a/tests/hbacsvc/test_hbacsvc_client_context.yml
+++ b/tests/hbacsvc/test_hbacsvc_client_context.yml
@@ -35,3 +35,5 @@
 - name: Test hbacsvc using client context, in server host.
   import_playbook: test_hbacsvc.yml
   when: groups['ipaclients'] is not defined or not groups['ipaclients']
+  vars:
+    ipa_context: client

--- a/tests/hbacsvcgroup/test_hbacsvcgroup_client_context.yml
+++ b/tests/hbacsvcgroup/test_hbacsvcgroup_client_context.yml
@@ -35,3 +35,5 @@
 - name: Test hbacsvcgroup using client context, in server host.
   import_playbook: test_hbacsvcgroup.yml
   when: groups['ipaclients'] is not defined or not groups['ipaclients']
+  vars:
+    ipa_context: client

--- a/tests/host/test_host_client_context.yml
+++ b/tests/host/test_host_client_context.yml
@@ -35,3 +35,5 @@
 - name: Test automember using client context, in server host.
   import_playbook: test_host.yml
   when: groups['ipaclients'] is not defined or not groups['ipaclients']
+  vars:
+    ipa_context: client

--- a/tests/hostgroup/test_hostgroup_client_context.yml
+++ b/tests/hostgroup/test_hostgroup_client_context.yml
@@ -35,3 +35,5 @@
 - name: Test hostgroup using client context, in server host.
   import_playbook: test_hostgroup.yml
   when: groups['ipaclients'] is not defined or not groups['ipaclients']
+  vars:
+    ipa_context: client

--- a/tests/location/test_location_client_context.yml
+++ b/tests/location/test_location_client_context.yml
@@ -35,3 +35,5 @@
 - name: Test location using client context, in server host.
   import_playbook: test_location.yml
   when: groups['ipaclients'] is not defined or not groups['ipaclients']
+  vars:
+    ipa_context: client

--- a/tests/permission/test_permission_client_context.yml
+++ b/tests/permission/test_permission_client_context.yml
@@ -35,3 +35,5 @@
 - name: Test permission using client context, in server host.
   import_playbook: test_permission.yml
   when: groups['ipaclients'] is not defined or not groups['ipaclients']
+  vars:
+    ipa_context: client

--- a/tests/privilege/test_privilege_client_context.yml
+++ b/tests/privilege/test_privilege_client_context.yml
@@ -35,3 +35,5 @@
 - name: Test privilege using client context, in server host.
   import_playbook: test_privilege.yml
   when: groups['ipaclients'] is not defined or not groups['ipaclients']
+  vars:
+    ipa_context: client

--- a/tests/pwpolicy/test_pwpolicy_client_context.yml
+++ b/tests/pwpolicy/test_pwpolicy_client_context.yml
@@ -35,3 +35,5 @@
 - name: Test pwpolicy using client context, in server host.
   import_playbook: test_pwpolicy.yml
   when: groups['ipaclients'] is not defined or not groups['ipaclients']
+  vars:
+    ipa_context: client

--- a/tests/role/test_role_client_context.yml
+++ b/tests/role/test_role_client_context.yml
@@ -35,3 +35,5 @@
 - name: Test role using client context, in server host.
   import_playbook: test_role.yml
   when: groups['ipaclients'] is not defined or not groups['ipaclients']
+  vars:
+    ipa_context: client

--- a/tests/selfservice/test_selfservice_client_context.yml
+++ b/tests/selfservice/test_selfservice_client_context.yml
@@ -35,3 +35,5 @@
 - name: Test selfservice using client context, in server host.
   import_playbook: test_selfservice.yml
   when: groups['ipaclients'] is not defined or not groups['ipaclients']
+  vars:
+    ipa_context: client

--- a/tests/server/test_server_client_context.yml
+++ b/tests/server/test_server_client_context.yml
@@ -35,3 +35,5 @@
 - name: Test server using client context, in server host.
   import_playbook: test_server.yml
   when: groups['ipaclients'] is not defined or not groups['ipaclients']
+  vars:
+    ipa_context: client

--- a/tests/service/test_service_client_context.yml
+++ b/tests/service/test_service_client_context.yml
@@ -35,3 +35,5 @@
 - name: Test service using client context, in server host.
   import_playbook: test_service.yml
   when: groups['ipaclients'] is not defined or not groups['ipaclients']
+  vars:
+    ipa_context: client

--- a/tests/sudocmd/test_sudocmd_client_context.yml
+++ b/tests/sudocmd/test_sudocmd_client_context.yml
@@ -35,3 +35,5 @@
 - name: Test sudocmd using client context, in server host.
   import_playbook: test_sudocmd.yml
   when: groups['ipaclients'] is not defined or not groups['ipaclients']
+  vars:
+    ipa_context: client

--- a/tests/sudocmdgroup/test_sudocmdgroup_client_context.yml
+++ b/tests/sudocmdgroup/test_sudocmdgroup_client_context.yml
@@ -35,3 +35,5 @@
 - name: Test sudocmdgroup using client context, in server host.
   import_playbook: test_sudocmdgroup.yml
   when: groups['ipaclients'] is not defined or not groups['ipaclients']
+  vars:
+    ipa_context: client

--- a/tests/sudorule/test_sudorule_client_context.yml
+++ b/tests/sudorule/test_sudorule_client_context.yml
@@ -35,3 +35,5 @@
 - name: Test sudorule using client context, in server host.
   import_playbook: test_sudorule.yml
   when: groups['ipaclients'] is not defined or not groups['ipaclients']
+  vars:
+    ipa_context: client

--- a/tests/trust/test_trust_client_context.yml
+++ b/tests/trust/test_trust_client_context.yml
@@ -35,3 +35,5 @@
 - name: Test trust using client context, in server host.
   import_playbook: test_trust.yml
   when: groups['ipaclients'] is not defined or not groups['ipaclients']
+  vars:
+    ipa_context: client

--- a/tests/user/test_user_client_context.yml
+++ b/tests/user/test_user_client_context.yml
@@ -35,3 +35,5 @@
 - name: Test user using client context, in server host.
   import_playbook: test_user.yml
   when: groups['ipaclients'] is not defined or not groups['ipaclients']
+  vars:
+    ipa_context: client


### PR DESCRIPTION
When running the tests that can be executed either on server or client
context, without defining 'ipa_context', the context is automatically
identified.

Currently, the tests in upstream CI run only on a server, and the
context is identified as "server" context, and in order to run the test
using a client context 'ipa_context' must be set to 'client'.

This patch fixes all the client context tests by correctly setting
ipa_context when running the client context tests in a server host.