### PR TITLE
utils/build-galaxy-release: Fix doc_fragment prefix for galaxy

### DIFF
--- a/utils/build-galaxy-release.sh
+++ b/utils/build-galaxy-release.sh
@@ -28,6 +28,12 @@ sed -i -e "s/ansible.module_utils.ansible_freeipa_module/ansible_collections.${c
     ln -sf ../../roles/*/action_plugins/*.py .
 })
 
+echo "Fixing doc fragments in plugins/modules..."
+for file in plugins/modules/*.py; do
+    sed -i -e "s/- ipamodule_base_docs/- ${collection_prefix}.ipamodule_base_docs/" "$file"
+done
+echo -e "\033[AFixing doc framents in plugins/modules... \033[32;1mDONE\033[0m"
+
 echo "Fixing examples in plugins/modules..."
 find plugins/modules -name "*.py" -print0 |
     while IFS= read -d '' -r line; do


### PR DESCRIPTION
The items in extends_documentation_fragments of the modules need to
have the proper galaxy prefix.

The documentation fragment

  - ipamodule_base_docs

needs to be changed to

  - ${collection_prefix}.ipamodule_base_docs