### PR TITLE
Fix module templates README and invalid parameter tests.

### DIFF
--- a/utils/templates/README-module+member.md.in
+++ b/utils/templates/README-module+member.md.in
@@ -119,6 +119,8 @@ Variable | Description | Required
 -------- | ----------- | --------
 `ipaadmin_principal` | The admin principal is a string and defaults to `admin` | no
 `ipaadmin_password` | The admin password is a string and is required if there is no admin ticket available on the node | no
+`ipaapi_context` | The context in which the module will execute. Executing in a server context is preferred. If not provided context will be determined by the execution environment. Valid values are `server` and `client`. | no
+`ipaapi_ldap_cache` | Use LDAP cache for IPA connection. The bool setting defaults to yes. (bool) | no
 `name` \| `ALIAS` | The list of $name name strings. | yes
 `PARAMETER1` \| `API_PARAMETER_NAME` | DESCRIPTION | BOOL
 `PARAMETER2` \| `API_PARAMETER_NAME` | DESCRIPTION | BOOL

--- a/utils/templates/README-module.md.in
+++ b/utils/templates/README-module.md.in
@@ -84,6 +84,8 @@ Variable | Description | Required
 -------- | ----------- | --------
 `ipaadmin_principal` | The admin principal is a string and defaults to `admin` | no
 `ipaadmin_password` | The admin password is a string and is required if there is no admin ticket available on the node | no
+`ipaapi_context` | The context in which the module will execute. Executing in a server context is preferred. If not provided context will be determined by the execution environment. Valid values are `server` and `client`. | no
+`ipaapi_ldap_cache` | Use LDAP cache for IPA connection. The bool setting defaults to yes. (bool) | no
 `name` \| `ALIAS` | The list of $name name strings. | yes
 `PARAMETER1` \| `API_PARAMETER_NAME` | DESCRIPTION | BOOL
 `PARAMETER2` \| `API_PARAMETER_NAME` | DESCRIPTION | BOOL

--- a/utils/templates/ipamodule+member.py.in
+++ b/utils/templates/ipamodule+member.py.in
@@ -185,11 +185,7 @@ def main():
         if action == "$name":
             invalid.append("PARAMETER2")
 
-    for x in invalid:
-        if vars()[x] is not None:
-            ansible_module.fail_json(
-                msg="Argument '%s' can not be used with action "
-                "'%s' and state '%s'" % (x, action, state))
+    ansible_module.params_fail_used_invalid(invalid, state, action)
 
     # Init
 

--- a/utils/templates/ipamodule.py.in
+++ b/utils/templates/ipamodule.py.in
@@ -151,11 +151,7 @@ def main():
             ansible_module.fail_json(msg="No name given.")
         invalid = ["PARAMETER1", "PARAMETER2"]
 
-    for x in invalid:
-        if vars()[x] is not None:
-            ansible_module.fail_json(
-                msg="Argument '%s' can not be used with state '%s'" %
-                (x, state))
+    ansible_module.params_fail_used_invalid(invalid, state)
 
     # Init
 


### PR DESCRIPTION
Fix the module templates README by adding description for
`ipaapi_context` and `ipaapi_ldap_cache` variables.

Fix the module templates code by using IPAAnsibleModule method
`params_fail_used_invalid` to check for invalid parameters use for
a given state/action.