### PR TITLE
fix problem with python3-ipalib

### DIFF
--- a/roles/ipaclient/vars/Ubuntu-18.04.yml
+++ b/roles/ipaclient/vars/Ubuntu-18.04.yml
@@ -1,0 +1,5 @@
+# defaults file for ipaclient
+# vars/Ubuntu-18.04.yml
+---
+ipaclient_packages: [ "freeipa-client" ]
+ansible_python_interpreter: '/usr/bin/python2'

--- a/roles/ipaclient/vars/Ubuntu-20.04.yml
+++ b/roles/ipaclient/vars/Ubuntu-20.04.yml
@@ -1,0 +1,4 @@
+# defaults file for ipaclient
+# vars/Ubuntu-20.04.yml
+---
+ipaclient_packages: [ "freeipa-client" ]


### PR DESCRIPTION
Ubuntu Bionic with Python3 is unavailable python3-ipalib and ipatest.py fail

https://github.com/freeipa/ansible-freeipa/issues/299

"module_stdout": "Traceback (most recent call last):\r\n  File \"/home/ansible/.ansible/tmp/ansible-tmp-1633714513.6763046-876-175966862504860/AnsiballZ_ipaclient_test.py\", line 100, in <module>\r\n    _ansiballz_main()\r\n  File \"/home/ansible/.ansible/tmp/ansible-tmp-1633714513.6763046-876-175966862504860/AnsiballZ_ipaclient_test.py\", line 92, in _ansiballz_main\r\n    invoke_module(zipped_mod, temp_path, ANSIBALLZ_PARAMS)\r\n  File \"/home/ansible/.ansible/tmp/ansible-tmp-1633714513.6763046-876-175966862504860/AnsiballZ_ipaclient_test.py\", line 41, in invoke_module\r\n    run_name='__main__', alter_sys=True)\r\n  File \"/usr/lib/python3.6/runpy.py\", line 205, in run_module\r\n    return _run_module_code(code, init_globals, run_name, mod_spec)\r\n  File \"/usr/lib/python3.6/runpy.py\", line 96, in _run_module_code\r\n    mod_name, mod_spec, pkg_name, script_name)\r\n  File \"/usr/lib/python3.6/runpy.py\", line 85, in _run_code\r\n    exec(code, run_globals)\r\n  File \"/tmp/ansible_ipaclient_test_payload_afx8d7sk/ansible_ipaclient_test_payload.zip/ansible/modules/ipaclient_test.py\", line 205, in <module>\r\n  File \"/tmp/ansible_ipaclient_test_payload_afx8d7sk/ansible_ipaclient_test_payload.zip/ansible/module_utils/ansible_ipa_client.py\", line 57, in <module>\r\nModuleNotFoundError: No module named 'ipapython'\r\n"

https://packages.ubuntu.com/search?keywords=python3-ipalib
https://packages.ubuntu.com/search?keywords=python-ipalib
