### PR TITLE
ipaprivilege: Fix permissions handling.

### DIFF
--- a/plugins/modules/ipaprivilege.py
+++ b/plugins/modules/ipaprivilege.py
@@ -256,7 +256,8 @@ def main():
 
                         # Generate addition and removal lists
                         permission_add, permission_del = gen_add_del_lists(
-                                permission, res_find.get("member_permission"))
+                            permission, res_find.get("memberof_permission")
+                        )
 
                         # Add members
                         if len(permission_add) > 0:

--- a/tests/privilege/test_privilege.yml
+++ b/tests/privilege/test_privilege.yml
@@ -47,6 +47,20 @@
     register: result
     failed_when: not result.changed or result.failed
 
+  - name: Check if adding member permissions would cause a change (issue 669).
+    ipaprivilege:
+      ipaadmin_password: SomeADMINpassword
+      ipaapi_context: "{{ ipa_context | default(omit) }}"
+      name: Broad Privilege
+      permission:
+      - "Write IPA Configuration"
+      - "System: Write DNS Configuration"
+      - "System: Update DNS Entries"
+      action: member
+    check_mode: yes
+    register: result
+    failed_when: not result.changed or result.failed
+
   - name: Ensure privilege Broad Privilege has permissions
     ipaprivilege:
       ipaadmin_password: SomeADMINpassword
@@ -70,6 +84,20 @@
       - "System: Write DNS Configuration"
       - "System: Update DNS Entries"
       action: member
+    register: result
+    failed_when: result.changed or result.failed
+
+  - name: Check if existing member permissions would not cause a change (issue 669).
+    ipaprivilege:
+      ipaadmin_password: SomeADMINpassword
+      ipaapi_context: "{{ ipa_context | default(omit) }}"
+      name: Broad Privilege
+      permission:
+      - "Write IPA Configuration"
+      - "System: Write DNS Configuration"
+      - "System: Update DNS Entries"
+      action: member
+    check_mode: yes
     register: result
     failed_when: result.changed or result.failed
 
@@ -161,6 +189,17 @@
       name: Broad Privilege
       state: absent
 
+  - name: Check if creating privilege Broad Privilege with permission would issue a change. (issue 669)
+    ipaprivilege:
+      ipaadmin_password: SomeADMINpassword
+      ipaapi_context: "{{ ipa_context | default(omit) }}"
+      name: Broad Privilege
+      permission:
+      - "Write IPA Configuration"
+    check_mode: yes
+    register: result
+    failed_when: not result.changed or result.failed
+
   - name: Ensure privilege Broad Privilege is created with permission. (issue 529)
     ipaprivilege:
       ipaadmin_password: SomeADMINpassword
@@ -178,6 +217,17 @@
       name: Broad Privilege
       permission:
       - "Write IPA Configuration"
+    register: result
+    failed_when: result.changed or result.failed
+
+  - name: Check if exisintg privilege Broad Privilege with permission would not issue a change. (issue 669)
+    ipaprivilege:
+      ipaadmin_password: SomeADMINpassword
+      ipaapi_context: "{{ ipa_context | default(omit) }}"
+      name: Broad Privilege
+      permission:
+      - "Write IPA Configuration"
+    check_mode: yes
     register: result
     failed_when: result.changed or result.failed
 


### PR DESCRIPTION
This PR fixes ipaprivilege permission handling when using `action: privilege` and the use of the module when `check_mode: yes`.

As a result of fixing support for `check_mode`, the custom `result_handler` was removed in favor of the default handler in `IPAAnsibleModule` and the whole processing of comparing the arguments to the existing privilege was simplified.

Fixes #669