### PR TITLE
[WIP] Case insensitive comparision of members.

### DIFF
--- a/plugins/module_utils/ansible_freeipa_module.py
+++ b/plugins/module_utils/ansible_freeipa_module.py
@@ -397,6 +397,14 @@ else:
     def module_params_get(module, name):
         return _afm_convert(module.params.get(name))
 
+    def module_params_get_lowercase(module, name):
+        value = _afm_convert(module.params.get(name))
+        if isinstance(value, list):
+            value = [v.lower() for v in value]
+        if isinstance(value, (str, unicode)):
+            value = value.lower()
+        return value
+
     def api_get_domain():
         return api.env.domain
 
@@ -698,6 +706,18 @@ else:
 
             """
             return module_params_get(self, name)
+
+        def params_get_lowercase(self, name):
+            """
+            Retrieve value set for module parameter as lowercase, if not None.
+
+            Parameters
+            ----------
+            name: string
+                The name of the parameter to retrieve.
+
+            """
+            return module_params_get_lowercase(self, name)
 
         def params_fail_used_invalid(self, invalid_params, state, action=None):
             """

--- a/plugins/modules/ipadelegation.py
+++ b/plugins/modules/ipadelegation.py
@@ -168,8 +168,8 @@ def main():
     # present
     permission = ansible_module.params_get("permission")
     attribute = ansible_module.params_get("attribute")
-    membergroup = ansible_module.params_get("membergroup")
-    group = ansible_module.params_get("group")
+    membergroup = ansible_module.params_get_lowercase("membergroup")
+    group = ansible_module.params_get_lowercase("group")
     action = ansible_module.params_get("action")
     # state
     state = ansible_module.params_get("state")
@@ -221,6 +221,17 @@ def main():
         for name in names:
             # Make sure delegation exists
             res_find = find_delegation(ansible_module, name)
+
+            # As CLI delegation commands are "case preserving", data
+            # from groups and membergroups need to be transformed so
+            # comparison work properly.
+            if res_find:
+                for _member in ["group", "memberof"]:
+                    if _member in res_find:
+                        _data = res_find[_member]
+                        if not isinstance(_data, (list, tuple)):
+                            _data = [_data]
+                        res_find[_member] = [v.lower() for v in _data]
 
             # Create command
             if state == "present":

--- a/plugins/modules/ipagroup.py
+++ b/plugins/modules/ipagroup.py
@@ -303,11 +303,13 @@ def main():
     external = ansible_module.params_get("external")
     posix = ansible_module.params_get("posix")
     nomembers = ansible_module.params_get("nomembers")
-    user = ansible_module.params_get("user")
-    group = ansible_module.params_get("group")
+    user = ansible_module.params_get_lowercase("user")
+    group = ansible_module.params_get_lowercase("group")
     service = ansible_module.params_get("service")
-    membermanager_user = ansible_module.params_get("membermanager_user")
-    membermanager_group = ansible_module.params_get("membermanager_group")
+    membermanager_user = \
+        ansible_module.params_get_lowercase("membermanager_user")
+    membermanager_group = \
+        ansible_module.params_get_lowercase("membermanager_group")
     externalmember = ansible_module.params_get("externalmember")
     action = ansible_module.params_get("action")
     # state
@@ -424,18 +426,31 @@ def main():
                     if not compare_args_ipa(ansible_module, member_args,
                                             res_find):
                         # Generate addition and removal lists
-                        user_add, user_del = gen_add_del_lists(
-                            user, res_find.get("member_user"))
+                        if user is not None:
+                            user_add, user_del = gen_add_del_lists(
+                                user, res_find.get("member_user"))
+                        else:
+                            user_add, user_del = [], []
 
-                        group_add, group_del = gen_add_del_lists(
-                            group, res_find.get("member_group"))
+                        if group is not None:
+                            group_add, group_del = gen_add_del_lists(
+                                group, res_find.get("member_group"))
+                        else:
+                            group_add, group_del = [], []
 
-                        service_add, service_del = gen_add_del_lists(
-                            service, res_find.get("member_service"))
+                        if service is not None:
+                            service_add, service_del = gen_add_del_lists(
+                                service, res_find.get("member_service"))
+                        else:
+                            service_add, service_del = [], []
 
-                        (externalmember_add,
-                         externalmember_del) = gen_add_del_lists(
-                            externalmember, res_find.get("member_external"))
+                        if externalmember is not None:
+                            (externalmember_add,
+                             externalmember_del) = gen_add_del_lists(
+                                externalmember, res_find.get("member_external")
+                            )
+                        else:
+                            externalmember_add, externalmember_del = [], []
 
                         # setup member args for add/remove members.
                         add_member_args = {
@@ -476,17 +491,25 @@ def main():
                                 [name, "group_remove_member", del_member_args]
                             )
 
-                    membermanager_user_add, membermanager_user_del = \
-                        gen_add_del_lists(
-                            membermanager_user,
-                            res_find.get("membermanager_user")
-                        )
+                    if membermanager_user is not None:
+                        membermanager_user_add, membermanager_user_del = \
+                            gen_add_del_lists(
+                                membermanager_user,
+                                res_find.get("membermanager_user")
+                            )
+                    else:
+                        membermanager_user_add = []
+                        membermanager_user_del = []
 
-                    membermanager_group_add, membermanager_group_del = \
-                        gen_add_del_lists(
-                            membermanager_group,
-                            res_find.get("membermanager_group")
-                        )
+                    if membermanager_group is not None:
+                        membermanager_group_add, membermanager_group_del = \
+                            gen_add_del_lists(
+                                membermanager_group,
+                                res_find.get("membermanager_group")
+                            )
+                    else:
+                        membermanager_group_add = []
+                        membermanager_group_del = []
 
                     if has_add_membermanager:
                         # Add membermanager users and groups

--- a/plugins/modules/ipahbacrule.py
+++ b/plugins/modules/ipahbacrule.py
@@ -235,12 +235,12 @@ def main():
     hostcategory = ansible_module.params_get("hostcategory")
     servicecategory = ansible_module.params_get("servicecategory")
     nomembers = ansible_module.params_get("nomembers")
-    host = ansible_module.params_get("host")
-    hostgroup = ansible_module.params_get("hostgroup")
-    hbacsvc = ansible_module.params_get("hbacsvc")
-    hbacsvcgroup = ansible_module.params_get("hbacsvcgroup")
-    user = ansible_module.params_get("user")
-    group = ansible_module.params_get("group")
+    host = ansible_module.params_get_lowercase("host")
+    hostgroup = ansible_module.params_get_lowercase("hostgroup")
+    hbacsvc = ansible_module.params_get_lowercase("hbacsvc")
+    hbacsvcgroup = ansible_module.params_get_lowercase("hbacsvcgroup")
+    user = ansible_module.params_get_lowercase("user")
+    group = ansible_module.params_get_lowercase("group")
     action = ansible_module.params_get("action")
     # state
     state = ansible_module.params_get("state")
@@ -304,7 +304,7 @@ def main():
 
         # Ensure fqdn host names, use default domain for simple names
         if host is not None:
-            _host = [ensure_fqdn(x, default_domain) for x in host]
+            _host = [ensure_fqdn(x, default_domain).lower() for x in host]
             host = _host
 
         commands = []
@@ -350,24 +350,42 @@ def main():
                         res_find = {}
 
                     # Generate addition and removal lists
-                    host_add, host_del = gen_add_del_lists(
-                        host, res_find.get("memberhost_host"))
+                    if host:
+                        host_add, host_del = gen_add_del_lists(
+                            host, res_find.get("memberhost_host"))
+                    else:
+                        host_add, host_del = [], []
 
-                    hostgroup_add, hostgroup_del = gen_add_del_lists(
-                        hostgroup, res_find.get("memberhost_hostgroup"))
+                    if hostgroup:
+                        hostgroup_add, hostgroup_del = gen_add_del_lists(
+                            hostgroup, res_find.get("memberhost_hostgroup"))
+                    else:
+                        hostgroup_add, hostgroup_del = [], []
 
-                    hbacsvc_add, hbacsvc_del = gen_add_del_lists(
-                        hbacsvc, res_find.get("memberservice_hbacsvc"))
+                    if hbacsvc:
+                        hbacsvc_add, hbacsvc_del = gen_add_del_lists(
+                            hbacsvc, res_find.get("memberservice_hbacsvc"))
+                    else:
+                        hbacsvc_add, hbacsvc_del = [], []
 
-                    hbacsvcgroup_add, hbacsvcgroup_del = gen_add_del_lists(
-                        hbacsvcgroup,
-                        res_find.get("memberservice_hbacsvcgroup"))
+                    if hbacsvcgroup:
+                        hbacsvcgroup_add, hbacsvcgroup_del = gen_add_del_lists(
+                            hbacsvcgroup,
+                            res_find.get("memberservice_hbacsvcgroup"))
+                    else:
+                        hbacsvcgroup_add, hbacsvcgroup_del = [], []
 
-                    user_add, user_del = gen_add_del_lists(
-                        user, res_find.get("memberuser_user"))
+                    if user:
+                        user_add, user_del = gen_add_del_lists(
+                            user, res_find.get("memberuser_user"))
+                    else:
+                        user_add, user_del = [], []
 
-                    group_add, group_del = gen_add_del_lists(
-                        group, res_find.get("memberuser_group"))
+                    if group:
+                        group_add, group_del = gen_add_del_lists(
+                            group, res_find.get("memberuser_group"))
+                    else:
+                        group_add, group_del = [], []
 
                     # Add hosts and hostgroups
                     if len(host_add) > 0 or len(hostgroup_add) > 0:

--- a/plugins/modules/ipasudorule.py
+++ b/plugins/modules/ipasudorule.py
@@ -371,6 +371,7 @@ def main():
 
     # Connect to IPA API
     with ansible_module.ipa_connect():
+
         commands = []
 
         for name in names:
@@ -693,19 +694,19 @@ def main():
                     if hostgroup is not None:
                         if "memberhost_hostgroup" in res_find:
                             hostgroup = gen_intersection_list(
-                                hostgroup, res_find['memberhost_hostgroup'])
+                                hostgroup, res_find["memberhost_hostgroup"])
                         else:
                             hostgroup = None
                     if user is not None:
                         if "memberuser_user" in res_find:
                             user = gen_intersection_list(
-                                user, res_find['memberuser_user'])
+                                user, res_find["memberuser_user"])
                         else:
                             user = None
                     if group is not None:
                         if "memberuser_group" in res_find:
                             group = gen_intersection_list(
-                                group, res_find['memberuser_group'])
+                                group, res_find["memberuser_group"])
                         else:
                             group = None
                     if allow_sudocmd is not None:
@@ -745,7 +746,7 @@ def main():
                     if runasuser is not None:
                         if "ipasudorunas_user" in res_find:
                             runasuser = gen_intersection_list(
-                                runasuser, res_find['ipasudorunas_user'])
+                                runasuser, res_find["ipasudorunas_user"])
                         else:
                             runasuser = None
                     if runasgroup is not None:

--- a/plugins/modules/ipasudorule.py
+++ b/plugins/modules/ipasudorule.py
@@ -293,18 +293,18 @@ def main():
                                            "runasgroupcategory")
     hostcategory = ansible_module.params_get("hostcategory")  # noqa
     nomembers = ansible_module.params_get("nomembers")  # noqa
-    host = ansible_module.params_get("host")
-    hostgroup = ansible_module.params_get("hostgroup")
-    user = ansible_module.params_get("user")
-    group = ansible_module.params_get("group")
+    host = ansible_module.params_get_lowercase("host")
+    hostgroup = ansible_module.params_get_lowercase("hostgroup")
+    user = ansible_module.params_get_lowercase("user")
+    group = ansible_module.params_get_lowercase("group")
     allow_sudocmd = ansible_module.params_get('allow_sudocmd')
     allow_sudocmdgroup = ansible_module.params_get('allow_sudocmdgroup')
     deny_sudocmd = ansible_module.params_get('deny_sudocmd')
     deny_sudocmdgroup = ansible_module.params_get('deny_sudocmdgroup')
     sudooption = ansible_module.params_get("sudooption")
     order = ansible_module.params_get("order")
-    runasuser = ansible_module.params_get("runasuser")
-    runasgroup = ansible_module.params_get("runasgroup")
+    runasuser = ansible_module.params_get_lowercase("runasuser")
+    runasgroup = ansible_module.params_get_lowercase("runasgroup")
     action = ansible_module.params_get("action")
 
     # state
@@ -371,7 +371,6 @@ def main():
 
     # Connect to IPA API
     with ansible_module.ipa_connect():
-
         commands = []
 
         for name in names:
@@ -425,17 +424,29 @@ def main():
                         res_find = {}
 
                     # Generate addition and removal lists
-                    host_add, host_del = gen_add_del_lists(
-                        host, res_find.get('memberhost_host', []))
+                    if host is not None:
+                        host_add, host_del = gen_add_del_lists(
+                            host , res_find.get('memberhost_host'))
+                    else:
+                        host_add, host_del = [], []
 
-                    hostgroup_add, hostgroup_del = gen_add_del_lists(
-                        hostgroup, res_find.get('memberhost_hostgroup', []))
+                    if hostgroup is not None:
+                        hostgroup_add, hostgroup_del = gen_add_del_lists(
+                            hostgroup, res_find.get('memberhost_hostgroup'))
+                    else:
+                        hostgroup_add, hostgroup_del = [], []
 
-                    user_add, user_del = gen_add_del_lists(
-                        user, res_find.get('memberuser_user', []))
+                    if user is not None:
+                        user_add, user_del = gen_add_del_lists(
+                            user, res_find.get('memberuser_user'))
+                    else:
+                        user_add, user_del = [], []
 
-                    group_add, group_del = gen_add_del_lists(
-                        group, res_find.get('memberuser_group', []))
+                    if group is not None:
+                        group_add, group_del = gen_add_del_lists(
+                            group, res_find.get('memberuser_group'))
+                    else:
+                        group_add, group_del = [], []
 
                     allow_cmd_add, allow_cmd_del = gen_add_del_lists(
                         allow_sudocmd,
@@ -456,11 +467,18 @@ def main():
                     sudooption_add, sudooption_del = gen_add_del_lists(
                         sudooption, res_find.get('ipasudoopt', []))
 
-                    runasuser_add, runasuser_del = gen_add_del_lists(
-                        runasuser, res_find.get('ipasudorunas_user', []))
+                    if runasuser is not None:
+                        runasuser_add, runasuser_del = gen_add_del_lists(
+                            runasuser, res_find.get('ipasudorunas_user'))
+                    else:
+                        runasuser_add, runasuser_del = [], []
 
-                    runasgroup_add, runasgroup_del = gen_add_del_lists(
-                        runasgroup, res_find.get('ipasudorunas_group', []))
+                    if runasgroup is not None:
+                        runasgroup_add, runasgroup_del = gen_add_del_lists(
+                            runasgroup, res_find.get('ipasudorunasgroup_group')
+                        )
+                    else:
+                        runasgroup_add, runasgroup_del = [], []
 
                     # Add hosts and hostgroups
                     if len(host_add) > 0 or len(hostgroup_add) > 0:
@@ -675,19 +693,19 @@ def main():
                     if hostgroup is not None:
                         if "memberhost_hostgroup" in res_find:
                             hostgroup = gen_intersection_list(
-                                hostgroup, res_find["memberhost_hostgroup"])
+                                hostgroup, res_find['memberhost_hostgroup'])
                         else:
                             hostgroup = None
                     if user is not None:
                         if "memberuser_user" in res_find:
                             user = gen_intersection_list(
-                                user, res_find["memberuser_user"])
+                                user, res_find['memberuser_user'])
                         else:
                             user = None
                     if group is not None:
                         if "memberuser_group" in res_find:
                             group = gen_intersection_list(
-                                group, res_find["memberuser_group"])
+                                group, res_find['memberuser_group'])
                         else:
                             group = None
                     if allow_sudocmd is not None:
@@ -727,7 +745,7 @@ def main():
                     if runasuser is not None:
                         if "ipasudorunas_user" in res_find:
                             runasuser = gen_intersection_list(
-                                runasuser, res_find["ipasudorunas_user"])
+                                runasuser, res_find['ipasudorunas_user'])
                         else:
                             runasuser = None
                     if runasgroup is not None:

--- a/tests/delegation/test_delegation_member_case_insensitive.yml
+++ b/tests/delegation/test_delegation_member_case_insensitive.yml
@@ -1,0 +1,121 @@
+---
+- name: Test delegation
+  hosts: "{{ ipa_test_host | default('ipaserver') }}"
+  become: no
+  gather_facts: no
+
+  tasks:
+  - block:
+      # CLEANUP TEST ITEMS
+
+      - name: Ensure test groups are absent
+        ipagroup:
+          ipaadmin_password: SomeADMINpassword
+          ipaapi_context: "{{ ipa_context | default(omit) }}"
+          name: managers,employees
+          state: absent
+
+      - name: Ensure delegation "basic manager attributes" is absent
+        ipadelegation:
+          ipaadmin_password: SomeADMINpassword
+          ipaapi_context: "{{ ipa_context | default(omit) }}"
+          name: "basic manager attributes"
+          state: absent
+
+      # CREATE TEST ITEMS
+
+      - name: Ensure test group managers is present
+        ipagroup:
+          ipaadmin_password: SomeADMINpassword
+          ipaapi_context: "{{ ipa_context | default(omit) }}"
+          name: managers
+
+      - name: Ensure test group employees is present
+        ipagroup:
+          ipaadmin_password: SomeADMINpassword
+          ipaapi_context: "{{ ipa_context | default(omit) }}"
+          name: employees
+
+      # TESTS
+
+      - name: Ensure delegation "basic manager attributes" is present, group/membergroup mixed case
+        ipadelegation:
+          ipaadmin_password: SomeADMINpassword
+          ipaapi_context: "{{ ipa_context | default(omit) }}"
+          name: "basic manager attributes"
+          permission: read
+          attribute:
+          - businesscategory
+          group: Managers
+          membergroup: Employees
+        register: result
+        failed_when: not result.changed or result.failed
+
+      - name: Ensure delegation "basic manager attributes" is present, group lowercase
+        ipadelegation:
+          ipaadmin_password: SomeADMINpassword
+          ipaapi_context: "{{ ipa_context | default(omit) }}"
+          name: "basic manager attributes"
+          permission: read
+          attribute:
+          - businesscategory
+          group: "{{ 'Managers' | lower }}"
+          membergroup: employees
+        register: result
+        failed_when: result.changed or result.failed
+
+      - name: Ensure delegation "basic manager attributes" is present, group uppercase
+        ipadelegation:
+          ipaadmin_password: SomeADMINpassword
+          ipaapi_context: "{{ ipa_context | default(omit) }}"
+          name: "basic manager attributes"
+          permission: read
+          attribute:
+          - businesscategory
+          group: "{{ 'Managers' | upper }}"
+          membergroup: employees
+        register: result
+        failed_when: result.changed or result.failed
+
+      - name: Ensure delegation "basic manager attributes" is present, membergroup lowercase
+        ipadelegation:
+          ipaadmin_password: SomeADMINpassword
+          ipaapi_context: "{{ ipa_context | default(omit) }}"
+          name: "basic manager attributes"
+          permission: read
+          attribute:
+          - businesscategory
+          group: managers
+          membergroup: "{{ 'Employees' | lower }}"
+        register: result
+        failed_when: result.changed or result.failed
+
+      - name: Ensure delegation "basic manager attributes" is present, membergroup uppercase
+        ipadelegation:
+          ipaadmin_password: SomeADMINpassword
+          ipaapi_context: "{{ ipa_context | default(omit) }}"
+          name: "basic manager attributes"
+          permission: read
+          attribute:
+          - businesscategory
+          group: Managers
+          membergroup: "{{ 'Employees' | upper }}"
+        register: result
+        failed_when: result.changed or result.failed
+
+    always:
+      # CLEANUP TEST ITEMS
+
+      - name: Ensure delegation "basic manager attributes" is absent
+        ipadelegation:
+          ipaadmin_password: SomeADMINpassword
+          ipaapi_context: "{{ ipa_context | default(omit) }}"
+          name: "basic manager attributes"
+          state: absent
+
+      - name: Ensure test groups are absent
+        ipagroup:
+          ipaadmin_password: SomeADMINpassword
+          ipaapi_context: "{{ ipa_context | default(omit) }}"
+          name: managers,employees
+          state: absent

--- a/tests/env_freeipa_facts.yml
+++ b/tests/env_freeipa_facts.yml
@@ -10,7 +10,7 @@
 - name: Retrieving FreeIPA version.
   shell:
     cmd: 'ipa --version | sed -n "s/VERSION: \([^,]*\).*API_VERSION: \([^,]*\).*/\1\\n\2/p"'
-  register: ipa_cmd_version
+  register: ipa_cmd_version # noqa: var-naming
 
 - name: Verify if host is an IPA server or client.
   shell:
@@ -21,7 +21,7 @@
       echo $RESULT
   vars:
     KRB5CCNAME: "__check_ipa_host_is_client_or_server__"
-  register: output
+  register: output # noqa: var-naming
 
 - name: Set FreeIPA facts.
   set_fact:

--- a/tests/env_freeipa_facts.yml
+++ b/tests/env_freeipa_facts.yml
@@ -29,3 +29,15 @@
     ipa_api_version: "{{ ipa_cmd_version.stdout_lines[1] }}"
     ipa_host_is_client: "{{ (output.stdout_lines[-1] == 'CLIENT') | bool }}"
     trust_test_is_supported: no
+
+- block:
+  - name: Get Domain from server name
+    set_fact:
+      ipaserver_domain: "{{ ansible_facts['fqdn'].split('.')[1:] | join ('.') }}"
+    when: "'fqdn' in ansible_facts"
+
+  - name: Set Domain to 'ipa.test' if FQDN could not be retrieved.
+    set_fact:
+      ipaserver_domain: "ipa.test"
+    when: "'fqdn' not in ansible_facts"
+  when: ipaserver_domain is not defined

--- a/tests/group/test_group_member_case_insensitive.yml
+++ b/tests/group/test_group_member_case_insensitive.yml
@@ -1,0 +1,273 @@
+---
+- name: Test group
+  hosts: "{{ ipa_test_host | default('ipaserver') }}"
+  become: no
+  gather_facts: no
+
+  vars:
+    user_list:
+      - User1
+      - uSer2
+      - usEr3
+    group_list:
+      - Group1
+      - gRoup2
+      - grOup3
+
+  tasks:
+  - include_tasks: ../env_freeipa_facts.yml
+
+  - block:
+      - name: Ensure test users are present
+        ipauser:
+          ipaadmin_password: SomeADMINpassword
+          ipaapi_context: "{{ ipa_context | default(omit) }}"
+          users:
+          - name: "{{ item }}"
+            first: First
+            last: Last
+        with_items: "{{ user_list }}"
+
+      - name: Ensure test groups are present
+        ipagroup:
+          ipaadmin_password: SomeADMINpassword
+          ipaapi_context: "{{ ipa_context | default(omit) }}"
+          name: "{{ item }}"
+        with_items: "{{ group_list }}"
+        register: result
+        failed_when: not result.changed or result.failed
+
+      - name: Ensure group "{{ group_list[0] }}" is present with "{{ group_list[1] }}" and "{{ group_list[2] }}"  as members, mixed case
+        ipagroup:
+          ipaadmin_password: SomeADMINpassword
+          ipaapi_context: "{{ ipa_context | default(omit) }}"
+          name: "{{ group_list[0] }}"
+          group:
+          - "{{ group_list[1] }}"
+          - "{{ group_list[2] }}"
+          action: member
+        register: result
+        failed_when: not result.changed or result.failed
+
+      - name: Ensure group "{{ group_list[0] }}" is present with "{{ group_list[1] | lower }}" and "{{ group_list[2] | lower }}"  as members, lowercase
+        ipagroup:
+          ipaadmin_password: SomeADMINpassword
+          ipaapi_context: "{{ ipa_context | default(omit) }}"
+          name: "{{ group_list[0] }}"
+          group:
+          - "{{ group_list[1] | lower }}"
+          - "{{ group_list[2] | lower }}"
+          action: member
+        register: result
+        failed_when: result.changed or result.failed
+
+      - name: Ensure group "{{ group_list[0] }}" is present with "{{ group_list[1] | upper }}" and "{{ group_list[2] | upper }}"  as members, uppercase
+        ipagroup:
+          ipaadmin_password: SomeADMINpassword
+          ipaapi_context: "{{ ipa_context | default(omit) }}"
+          name: "{{ group_list[0] }}"
+          group:
+          - "{{ group_list[1] | upper }}"
+          - "{{ group_list[2] | upper }}"
+          action: member
+        register: result
+        failed_when: result.changed or result.failed
+
+      - name: Ensure group "{{ group_list[0] }}" is present with no members.
+        ipagroup:
+          ipaadmin_password: SomeADMINpassword
+          ipaapi_context: "{{ ipa_context | default(omit) }}"
+          name: "{{ group_list[0] }}"
+          group: []
+        register: result
+        failed_when: not result.changed or result.failed
+
+      - name: Ensure groups "{{ group_list[1] }}" and "{{ group_list[2] }}"  are present in group "{{ group_list[0] }}", mixed case
+        ipagroup:
+          ipaadmin_password: SomeADMINpassword
+          ipaapi_context: "{{ ipa_context | default(omit) }}"
+          name: "{{ group_list[0] }}"
+          group:
+          - "{{ group_list[1] }}"
+          - "{{ group_list[2] }}"
+          action: member
+        register: result
+        failed_when: not result.changed or result.failed
+
+      - name: Ensure groups "{{ group_list[1] | lower }}" and "{{ group_list[2] | lower }}"  are present in group "{{ group_list[0] }}", lowercase
+        ipagroup:
+          ipaadmin_password: SomeADMINpassword
+          ipaapi_context: "{{ ipa_context | default(omit) }}"
+          name: "{{ group_list[0] }}"
+          group:
+          - "{{ group_list[1] | lower }}"
+          - "{{ group_list[2] | lower }}"
+          action: member
+        register: result
+        failed_when: result.changed or result.failed
+
+      - name: Ensure groups "{{ group_list[1] | upper }}" and "{{ group_list[2] | upper }}"  are present in group "{{ group_list[0] }}", uppercase
+        ipagroup:
+          ipaadmin_password: SomeADMINpassword
+          ipaapi_context: "{{ ipa_context | default(omit) }}"
+          name: "{{ group_list[0] }}"
+          group:
+          - "{{ group_list[1] | upper }}"
+          - "{{ group_list[2] | upper }}"
+          action: member
+        register: result
+        failed_when: result.changed or result.failed
+
+      - name: Ensure groups "{{ group_list[1] | upper }}" and "{{ group_list[2] | upper }}"  are absent in group "{{ group_list[0] }}", uppercase
+        ipagroup:
+          ipaadmin_password: SomeADMINpassword
+          ipaapi_context: "{{ ipa_context | default(omit) }}"
+          name: "{{ group_list[0] }}"
+          group:
+          - "{{ group_list[1] | upper }}"
+          - "{{ group_list[2] | upper }}"
+          state: absent
+          action: member
+        register: result
+        failed_when: not result.changed or result.failed
+
+      - name: Ensure groups "{{ group_list[1] | lower }}" and "{{ group_list[2] | lower }}"  are absent in group "{{ group_list[0] }}", lowercase
+        ipagroup:
+          ipaadmin_password: SomeADMINpassword
+          ipaapi_context: "{{ ipa_context | default(omit) }}"
+          name: "{{ group_list[0] }}"
+          group:
+          - "{{ group_list[1] | lower }}"
+          - "{{ group_list[2] | lower }}"
+          state: absent
+          action: member
+        register: result
+        failed_when: result.changed or result.failed
+
+      - name: Ensure groups "{{ group_list[1] }}" and "{{ group_list[2] }}"  are absent in group "{{ group_list[0] }}", mixed case
+        ipagroup:
+          ipaadmin_password: SomeADMINpassword
+          ipaapi_context: "{{ ipa_context | default(omit) }}"
+          name: "{{ group_list[0] }}"
+          group:
+          - "{{ group_list[1] }}"
+          - "{{ group_list[2] }}"
+          state: absent
+          action: member
+        register: result
+        failed_when: result.changed or result.failed
+
+      - name: Ensure users "{{ ', '.join(user_list) }}" are present in group "{{ group_list[0] }}", mixed case
+        ipagroup:
+          ipaadmin_password: SomeADMINpassword
+          ipaapi_context: "{{ ipa_context | default(omit) }}"
+          name: "{{ group_list[0] }}"
+          user: "{{ user_list }}"
+          action: member
+        register: result
+        failed_when: not result.changed or result.failed
+
+      - name: Ensure users "{{ ', '.join(user_list) | lower }}" are present in group "{{ group_list[0] }}", lowercase
+        ipagroup:
+          ipaadmin_password: SomeADMINpassword
+          ipaapi_context: "{{ ipa_context | default(omit) }}"
+          name: "{{ group_list[0] }}"
+          user: "{{ item | lower }}"
+          action: member
+        register: result
+        failed_when: result.changed or result.failed
+        with_items: "{{ user_list }}"
+
+      - name: Ensure users "{{ ', '.join(user_list) | lower }}" are present in group "{{ group_list[0] }}", uppercase
+        ipagroup:
+          ipaadmin_password: SomeADMINpassword
+          ipaapi_context: "{{ ipa_context | default(omit) }}"
+          name: "{{ group_list[0] }}"
+          user: "{{ item | upper }}"
+          action: member
+        register: result
+        failed_when: result.changed or result.failed
+        with_items: "{{ user_list }}"
+
+      - name: Ensure users "{{ ', '.join(user_list) | lower }}" are present in group "{{ group_list[0] }}", uppercase
+        ipagroup:
+          ipaadmin_password: SomeADMINpassword
+          ipaapi_context: "{{ ipa_context | default(omit) }}"
+          name: "{{ group_list[0] }}"
+          user: "{{ item | upper }}"
+          action: member
+          state: absent
+        register: result
+        failed_when: not result.changed or result.failed
+        with_items: "{{ user_list }}"
+
+      - name: Ensure users "{{ ', '.join(user_list) | lower }}" are present in group "{{ group_list[0] }}", lowercase
+        ipagroup:
+          ipaadmin_password: SomeADMINpassword
+          ipaapi_context: "{{ ipa_context | default(omit) }}"
+          name: "{{ group_list[0] }}"
+          user: "{{ item | lower }}"
+          action: member
+          state: absent
+        register: result
+        failed_when: result.changed or result.failed
+        with_items: "{{ user_list }}"
+
+      - name: Ensure users "{{ ', '.join(user_list) }}" are present in group "{{ group_list[0] }}", mixed case
+        ipagroup:
+          ipaadmin_password: SomeADMINpassword
+          ipaapi_context: "{{ ipa_context | default(omit) }}"
+          name: "{{ group_list[0] }}"
+          user: "{{ user_list }}"
+          action: member
+          state: absent
+        register: result
+        failed_when: result.changed or result.failed
+
+      - name: Tests requiring IPA version 4.8.4+
+        block:
+          - name: Ensure membermanager "{{ user_list[0] }}" is membermanager_user for "{{ group_list[0] }}", mixed case
+            ipagroup:
+              ipaadmin_password: SomeADMINpassword
+              name: "{{ group_list[0] }}"
+              membermanager_user: "{{ user_list[0] }}"
+            register: result
+            failed_when: not result.changed or result.failed
+
+          - name: Ensure membermanager "{{ user_list[0] | lower }}" is membermanager_user for "{{ group_list[0] }}", lowercase
+            ipagroup:
+              ipaadmin_password: SomeADMINpassword
+              name: "{{ group_list[0] }}"
+              membermanager_user: "{{ user_list[0] | lower }}"
+            register: result
+            failed_when: result.changed or result.failed
+
+          - name: Ensure membermanager "{{ user_list[0] | upper }}" is membermanager_user for "{{ group_list[0] }}", uppercase
+            ipagroup:
+              ipaadmin_password: SomeADMINpassword
+              name: "{{ group_list[0] }}"
+              membermanager_user: "{{ user_list[0] | upper }}"
+            register: result
+            failed_when: result.changed or result.failed
+
+        when: ipa_version is version('4.8.4', '>=')
+
+    always:
+
+      - name: Ensure test groups are absent
+        ipagroup:
+          ipaadmin_password: SomeADMINpassword
+          ipaapi_context: "{{ ipa_context | default(omit) }}"
+          name: "{{ group_list }}"
+          state: absent
+        register: result
+        failed_when: not result.changed or result.failed
+
+      - name: Ensure test users absent
+        ipauser:
+          ipaadmin_password: SomeADMINpassword
+          ipaapi_context: "{{ ipa_context | default(omit) }}"
+          name: "{{ user_list }}"
+          state: absent
+        register: result
+        failed_when: not result.changed or result.failed

--- a/tests/hbacrule/test_hbacrule_member_case_insensitive.yml
+++ b/tests/hbacrule/test_hbacrule_member_case_insensitive.yml
@@ -1,0 +1,355 @@
+---
+- name: Test group
+  hosts: "{{ ipa_test_host | default('ipaserver') }}"
+  become: no
+  gather_facts: no
+
+  vars:
+    user_list:
+      - User1
+      - uSer2
+      - usEr3
+    group_list:
+      - Group1
+      - gRoup2
+      - grOup3
+    host_list:
+      - HoSt01
+      - hOsT02
+    hostgroup_list:
+      - TestHostGroup
+    hbacsvc_list:
+      - Svc1
+      - sVC2
+    hbacsvcgroup_list:
+      - sVCgrOUp1
+
+  tasks:
+  - include_tasks: ../env_freeipa_facts.yml
+
+  - block:
+      # setup
+
+      - name: Ensure test hbacrule is absent
+        ipahbacrule:
+          ipaadmin_password: SomeADMINpassword
+          name: testrule
+          state: absent
+
+      - name: Ensure test users are present
+        ipauser:
+          ipaadmin_password: SomeADMINpassword
+          users:
+          - name: "{{ item }}"
+            first: First
+            last: Last
+        with_items: "{{ user_list }}"
+
+      - name: Ensure test groups are present
+        ipagroup:
+          ipaadmin_password: SomeADMINpassword
+          name: "{{ item }}"
+        with_items: "{{ group_list }}"
+
+      - name: Ensure test hosts are present
+        ipahost:
+          ipaadmin_password: SomeADMINpassword
+          name: "{{ item }}.{{ ipaserver_domain }}"
+          force: yes
+        with_items: "{{ host_list }}"
+
+      - name: Ensure test hostgroups are present
+        ipahostgroup:
+          ipaadmin_password: SomeADMINpassword
+          name: "{{ item }}"
+        with_items: "{{ hostgroup_list }}"
+
+      - name: Ensure test hbac services are present
+        ipahbacsvc:
+          ipaadmin_password: SomeADMINpassword
+          name: "{{ item }}"
+        with_items: "{{ hbacsvc_list }}"
+
+      - name: Ensure test hbac service groups are present
+        ipahbacsvcgroup:
+          ipaadmin_password: SomeADMINpassword
+          name: "{{ item }}"
+        with_items: "{{ hbacsvcgroup_list }}"
+
+      # Test with action: hbacrule
+
+      - name: Ensure hbacrule is present with members, mixed case
+        ipahbacrule:
+          ipaadmin_password: SomeADMINpassword
+          name: testrule
+          user:
+          - "{{ user_list[1] }}"
+          - "{{ user_list[2] }}"
+          group:
+          - "{{ group_list[1] }}"
+          - "{{ group_list[2] }}"
+          host:
+          - "{{ host_list[0] }}"
+          - "{{ host_list[1] }}"
+          hostgroup:
+          - "{{ hostgroup_list[0] }}"
+          hbacsvc:
+          - "{{ hbacsvc_list[0] }}"
+          - "{{ hbacsvc_list[1] }}"
+          hbacsvcgroup:
+          - "{{ hbacsvcgroup_list[0] }}"
+        register: result
+        failed_when: not result.changed or result.failed
+
+      - name: Ensure hbacrule is present with members, lowercase
+        ipahbacrule:
+          ipaadmin_password: SomeADMINpassword
+          name: testrule
+          user:
+          - "{{ user_list[1] | lower }}"
+          - "{{ user_list[2] | lower }}"
+          group:
+          - "{{ group_list[1] | lower }}"
+          - "{{ group_list[2] | lower }}"
+          host:
+          - "{{ host_list[0] | lower }}"
+          - "{{ host_list[1] | lower }}"
+          hostgroup:
+          - "{{ hostgroup_list[0] | lower }}"
+          hbacsvc:
+          - "{{ hbacsvc_list[0] | lower }}"
+          - "{{ hbacsvc_list[1] | lower }}"
+          hbacsvcgroup:
+          - "{{ hbacsvcgroup_list[0] | lower }}"
+        register: result
+        failed_when: result.changed or result.failed
+
+      - name: Ensure hbacrule is present with members, upercase
+        ipahbacrule:
+          ipaadmin_password: SomeADMINpassword
+          name: testrule
+          user:
+          - "{{ user_list[1] | upper }}"
+          - "{{ user_list[2] | upper }}"
+          group:
+          - "{{ group_list[1] | upper }}"
+          - "{{ group_list[2] | upper }}"
+          host:
+          - "{{ host_list[0] | upper }}"
+          - "{{ host_list[1] | upper }}"
+          hostgroup:
+          - "{{ hostgroup_list[0] | upper }}"
+          hbacsvc:
+          - "{{ hbacsvc_list[0] | upper }}"
+          - "{{ hbacsvc_list[1] | upper }}"
+          hbacsvcgroup:
+          - "{{ hbacsvcgroup_list[0] | upper  }}"
+        register: result
+        failed_when: result.changed or result.failed
+
+      - name: Ensure test hbacrule is absent
+        ipahbacrule:
+          ipaadmin_password: SomeADMINpassword
+          name: testrule
+          state: absent
+
+      # Test with action: members
+
+      - name: Ensure test hbacrule is present
+        ipahbacrule:
+          ipaadmin_password: SomeADMINpassword
+          name: testrule
+
+      - name: Ensure hbacrule members present, mixed case
+        ipahbacrule:
+          ipaadmin_password: SomeADMINpassword
+          name: testrule
+          user:
+          - "{{ user_list[1] }}"
+          - "{{ user_list[2] }}"
+          group:
+          - "{{ group_list[1] }}"
+          - "{{ group_list[2] }}"
+          host:
+          - "{{ host_list[0] }}"
+          - "{{ host_list[1] }}"
+          hostgroup:
+          - "{{ hostgroup_list[0] }}"
+          hbacsvc:
+          - "{{ hbacsvc_list[0] }}"
+          - "{{ hbacsvc_list[1] }}"
+          hbacsvcgroup:
+          - "{{ hbacsvcgroup_list[0] }}"
+          action: member
+        register: result
+        failed_when: not result.changed or result.failed
+
+      - name: Ensure hbacrule members present, lowercase
+        ipahbacrule:
+          ipaadmin_password: SomeADMINpassword
+          name: testrule
+          user:
+          - "{{ user_list[1] | lower }}"
+          - "{{ user_list[2] | lower }}"
+          group:
+          - "{{ group_list[1] | lower }}"
+          - "{{ group_list[2] | lower }}"
+          host:
+          - "{{ host_list[0] | lower }}"
+          - "{{ host_list[1] | lower }}"
+          hostgroup:
+          - "{{ hostgroup_list[0] | lower }}"
+          hbacsvc:
+          - "{{ hbacsvc_list[0] | lower }}"
+          - "{{ hbacsvc_list[1] | lower }}"
+          hbacsvcgroup:
+          - "{{ hbacsvcgroup_list[0] | lower }}"
+          action: member
+        register: result
+        failed_when: result.changed or result.failed
+
+      - name: Ensure hbacrule members present, upercase
+        ipahbacrule:
+          ipaadmin_password: SomeADMINpassword
+          name: testrule
+          user:
+          - "{{ user_list[1] | upper }}"
+          - "{{ user_list[2] | upper }}"
+          group:
+          - "{{ group_list[1] | upper }}"
+          - "{{ group_list[2] | upper }}"
+          host:
+          - "{{ host_list[0] | upper }}"
+          - "{{ host_list[1] | upper }}"
+          hostgroup:
+          - "{{ hostgroup_list[0] | upper }}"
+          hbacsvc:
+          - "{{ hbacsvc_list[0] | upper }}"
+          - "{{ hbacsvc_list[1] | upper }}"
+          hbacsvcgroup:
+          - "{{ hbacsvcgroup_list[0] | upper }}"
+          action: member
+        register: result
+        failed_when: result.changed or result.failed
+
+      # Test absent members
+
+      - name: Ensure hbacrule members are absent, upercase
+        ipahbacrule:
+          ipaadmin_password: SomeADMINpassword
+          name: testrule
+          user:
+          - "{{ user_list[1] | upper }}"
+          - "{{ user_list[2] | upper }}"
+          group:
+          - "{{ group_list[1] | upper }}"
+          - "{{ group_list[2] | upper }}"
+          host:
+          - "{{ host_list[0] | upper }}"
+          - "{{ host_list[1] | upper }}"
+          hostgroup:
+          - "{{ hostgroup_list[0] | upper }}"
+          hbacsvc:
+          - "{{ hbacsvc_list[0] | upper }}"
+          - "{{ hbacsvc_list[1] | upper }}"
+          hbacsvcgroup:
+          - "{{ hbacsvcgroup_list[0] | upper }}"
+          action: member
+          state: absent
+        register: result
+        failed_when: not result.changed or result.failed
+
+      - name: Ensure hbacrule members are absent, mixed case
+        ipahbacrule:
+          ipaadmin_password: SomeADMINpassword
+          name: testrule
+          user:
+          - "{{ user_list[1] }}"
+          - "{{ user_list[2] }}"
+          group:
+          - "{{ group_list[1] }}"
+          - "{{ group_list[2] }}"
+          host:
+          - "{{ host_list[0] }}"
+          - "{{ host_list[1] }}"
+          hostgroup:
+          - "{{ hostgroup_list[0] }}"
+          action: member
+          state: absent
+        register: result
+        failed_when: result.changed or result.failed
+
+      - name: Ensure hbacrule members are absent, lowercase
+        ipahbacrule:
+          ipaadmin_password: SomeADMINpassword
+          name: testrule
+          user:
+          - "{{ user_list[1] | lower }}"
+          - "{{ user_list[2] | lower }}"
+          group:
+          - "{{ group_list[1] | lower }}"
+          - "{{ group_list[2] | lower }}"
+          host:
+          - "{{ host_list[0] | lower }}"
+          - "{{ host_list[1] | lower }}"
+          hostgroup:
+          - "{{ hostgroup_list[0] | lower }}"
+          hbacsvc:
+          - "{{ hbacsvc_list[0] | lower }}"
+          - "{{ hbacsvc_list[1] | lower }}"
+          hbacsvcgroup:
+          - "{{ hbacsvcgroup_list[0] | lower }}"
+          action: member
+          state: absent
+        register: result
+        failed_when: result.changed or result.failed
+
+    always:
+      - name: Ensure test hbacrule is absent
+        ipahbacrule:
+          ipaadmin_password: SomeADMINpassword
+          name: testrule
+          state: absent
+
+      - name: Ensure test users are absent
+        ipauser:
+          ipaadmin_password: SomeADMINpassword
+          users:
+          - name: "{{ item }}"
+          state: absent
+        with_items: "{{ user_list }}"
+
+      - name: Ensure test groups are absent
+        ipagroup:
+          ipaadmin_password: SomeADMINpassword
+          name: "{{ item }}"
+          state: absent
+        with_items: "{{ group_list }}"
+
+      - name: Ensure test hosts are absent
+        ipahost:
+          ipaadmin_password: SomeADMINpassword
+          name: "{{ item }}.{{ ipaserver_domain }}"
+          state: absent
+        with_items: "{{ host_list }}"
+
+      - name: Ensure test hostgroups are absent
+        ipahostgroup:
+          ipaadmin_password: SomeADMINpassword
+          name: "{{ item }}"
+          state: absent
+        with_items: "{{ hostgroup_list }}"
+
+      - name: Ensure test hbac services are absent
+        ipahbacsvc:
+          ipaadmin_password: SomeADMINpassword
+          name: "{{ item }}"
+          state: absent
+        with_items: "{{ hbacsvc_list }}"
+
+      - name: Ensure test hbac service groups are absent
+        ipahbacsvcgroup:
+          ipaadmin_password: SomeADMINpassword
+          name: "{{ item }}"
+          state: absent
+        with_items: "{{ hbacsvcgroup_list }}"

--- a/tests/hbacsvcgroup/test_hbacsvcgroup_member_case_insensitive.yml
+++ b/tests/hbacsvcgroup/test_hbacsvcgroup_member_case_insensitive.yml
@@ -1,0 +1,132 @@
+---
+- name: Test group
+  hosts: "{{ ipa_test_host | default('ipaserver') }}"
+  become: no
+  gather_facts: no
+
+  vars:
+    hbacsvc_list:
+      - sVc1
+      - SvC2
+
+  tasks:
+  - include_tasks: ../env_freeipa_facts.yml
+
+  - block:
+      - name: Ensure test hbacsvcgroup is absent
+        ipahbacsvcgroup:
+          ipaadmin_password: SomeADMINpassword
+          name: testgroup
+          state: absent
+
+      - name: Ensure test HBAC services are present
+        ipahbacsvc:
+          ipaadmin_password: SomeADMINpassword
+          name: "{{ item }}"
+        with_items: "{{ hbacsvc_list }}"
+
+      - name: Ensure hbacsvcgroup is present with members, mixed case
+        ipahbacsvcgroup:
+          ipaadmin_password: SomeADMINpassword
+          name: testgroup
+          hbacsvc: "{{ hbacsvc_list }}"
+        register: result
+        failed_when: not result.changed or result.failed
+
+      - name: Ensure hbacsvcgroup is present with members, lowercase
+        ipahbacsvcgroup:
+          ipaadmin_password: SomeADMINpassword
+          name: testgroup
+          hbacsvc: "{{ hbacsvc_list | lower }}"
+        register: result
+        failed_when: result.changed or result.failed
+
+      - name: Ensure hbacsvcgroup is present with members, uppercase
+        ipahbacsvcgroup:
+          ipaadmin_password: SomeADMINpassword
+          name: testgroup
+          hbacsvc: "{{ hbacsvc_list | upper }}"
+        register: result
+        failed_when: result.changed or result.failed
+
+      - name: Ensure test hbacsvcgroup is absent
+        ipahbacsvcgroup:
+          ipaadmin_password: SomeADMINpassword
+          name: testgroup
+          state: absent
+
+      - name: Ensure test hbacsvcgroup is present
+        ipahbacsvcgroup:
+          ipaadmin_password: SomeADMINpassword
+          name: testgroup
+
+      - name: Ensure hbacsvcgroup has members, mixed case
+        ipahbacsvcgroup:
+          ipaadmin_password: SomeADMINpassword
+          name: testgroup
+          hbacsvc: "{{ hbacsvc_list }}"
+          action: member
+        register: result
+        failed_when: not result.changed or result.failed
+
+      - name: Ensure hbacsvcgroup has members, lowercase
+        ipahbacsvcgroup:
+          ipaadmin_password: SomeADMINpassword
+          name: testgroup
+          hbacsvc: "{{ hbacsvc_list | lower }}"
+          action: member
+        register: result
+        failed_when: result.changed or result.failed
+
+      - name: Ensure hbacsvcgroup has members, uppercase
+        ipahbacsvcgroup:
+          ipaadmin_password: SomeADMINpassword
+          name: testgroup
+          hbacsvc: "{{ hbacsvc_list | upper }}"
+          action: member
+        register: result
+        failed_when: result.changed or result.failed
+
+      - name: Ensure hbacsvcgroup has members absent, uppercase
+        ipahbacsvcgroup:
+          ipaadmin_password: SomeADMINpassword
+          name: testgroup
+          hbacsvc: "{{ hbacsvc_list | upper }}"
+          action: member
+          state: absent
+        register: result
+        failed_when: not result.changed or result.failed
+
+      - name: Ensure hbacsvcgroup has members absent, mixed case
+        ipahbacsvcgroup:
+          ipaadmin_password: SomeADMINpassword
+          name: testgroup
+          hbacsvc: "{{ hbacsvc_list }}"
+          action: member
+          state: absent
+        register: result
+        failed_when: result.changed or result.failed
+
+      - name: Ensure hbacsvcgroup has members absent, lowercase
+        ipahbacsvcgroup:
+          ipaadmin_password: SomeADMINpassword
+          name: testgroup
+          hbacsvc: "{{ hbacsvc_list | lower }}"
+          action: member
+          state: absent
+        register: result
+        failed_when: result.changed or result.failed
+
+    always:
+      - name: Ensure test hbac service group is absent
+        ipahbacsvcgroup:
+          ipaadmin_password: SomeADMINpassword
+          name: testgroup
+          state: absent
+
+      - name: Ensure test hbac services are absent
+        ipahbacsvc:
+          ipaadmin_password: SomeADMINpassword
+          ipaapi_context: "{{ ipa_context | default(omit) }}"
+          name: "{{ hbacsvc_list }}"
+          state: absent

--- a/tests/sudorule/test_sudorule_member_case_insensitive.yml
+++ b/tests/sudorule/test_sudorule_member_case_insensitive.yml
@@ -1,0 +1,290 @@
+---
+- name: Test sudorule members should be case insensitive.
+  hosts: "{{ ipa_test_host | default('ipaserver') }}"
+  become: no
+  gather_facts: no
+
+  vars:
+    groups_present:
+      - eleMENT1
+      - Element2
+      - eLeMenT3
+      - ElemENT4
+
+
+  tasks:
+  - block:
+    # SETUP
+    - name: Ensure domain name
+      set_fact:
+        ipa_domain: ipa.test
+      when: ipa_domain is not defined
+
+    - name: Ensure test groups exist.
+      ipagroup:
+        ipaadmin_password: SomeADMINpassword
+        name: "{{ item }}"
+      loop: "{{ groups_present }}"
+
+    - name: Ensure test hostgroups exist.
+      ipahostgroup:
+        ipaadmin_password: SomeADMINpassword
+        name: "{{ item }}"
+      loop: "{{ groups_present }}"
+
+    - name: Ensure test hosts exist.
+      ipahost:
+        ipaadmin_password: SomeADMINpassword
+        name: "{{ item }}.{{ ipa_domain }}"
+        force: yes
+      loop: "{{ groups_present }}"
+
+    - name: Ensure test users exist.
+      ipauser:
+        ipaadmin_password: SomeADMINpassword
+        name: "user{{ item }}"
+        first: "{{ item }}"
+        last: "{{ item }}"
+      loop: "{{ groups_present }}"
+
+    - name: Ensure sudorule do not exist
+      ipasudorule:
+        ipaadmin_password: SomeADMINpassword
+        name: "{{ item }}"
+        state: absent
+      loop: "{{ groups_present }}"
+
+    # TESTS
+    - name: Start tests.
+      debug:
+        msg: "Tests are starting."
+
+    - name: Ensure sudorule exist with runasusers members
+      ipasudorule:
+        ipaadmin_password: SomeADMINpassword
+        name: "{{ item }}"
+        cmdcategory: all
+        runasuser: "user{{ item }}"
+      loop: "{{ groups_present }}"
+      register: result
+      failed_when: result.failed or not result.changed
+
+    - name: Ensure sudorule exist with lowercase runasusers members
+      ipasudorule:
+        ipaadmin_password: SomeADMINpassword
+        name: "{{ item }}"
+        cmdcategory: all
+        runasuser: "user{{ item | lower }}"
+      loop: "{{ groups_present }}"
+      register: result
+      failed_when: result.failed or result.changed
+
+    - name: Ensure sudorule exist with uppercase runasusers members
+      ipasudorule:
+        ipaadmin_password: SomeADMINpassword
+        name: "{{ item }}"
+        cmdcategory: all
+        runasuser: "user{{ item | upper }}"
+      loop: "{{ groups_present }}"
+      register: result
+      failed_when: result.failed or result.changed
+
+    - name: Ensure sudorule exist with runasgroup members
+      ipasudorule:
+        ipaadmin_password: SomeADMINpassword
+        name: "{{ item }}"
+        cmdcategory: all
+        runasgroup: "{{ item }}"
+      loop: "{{ groups_present }}"
+      register: result
+      failed_when: result.failed or not result.changed
+
+    - name: Ensure sudorule exist with lowercase runasgroup members
+      ipasudorule:
+        ipaadmin_password: SomeADMINpassword
+        name: "{{ item }}"
+        cmdcategory: all
+        runasgroup: "{{ item | lower }}"
+      loop: "{{ groups_present }}"
+      register: result
+      failed_when: result.failed or result.changed
+
+    - name: Ensure sudorule exist with uppercase runasgroup members
+      ipasudorule:
+        ipaadmin_password: SomeADMINpassword
+        name: "{{ item }}"
+        cmdcategory: all
+        runasgroup: "{{ item | upper }}"
+      loop: "{{ groups_present }}"
+      register: result
+      failed_when: result.failed or result.changed
+
+    - name: Ensure sudorule do not exist
+      ipasudorule:
+        ipaadmin_password: SomeADMINpassword
+        name: "{{ item }}"
+        state: absent
+      loop: "{{ groups_present }}"
+
+    #####
+
+    - name: Ensure sudorule exist with members
+      ipasudorule:
+        ipaadmin_password: SomeADMINpassword
+        name: "{{ item }}"
+        cmdcategory: all
+        hostgroup: "{{ item }}"
+        host: "{{ item }}.{{ ipa_domain }}"
+        group: "{{ item }}"
+        user: "user{{ item }}"
+      loop: "{{ groups_present }}"
+      register: result
+      failed_when: result.failed or not result.changed
+
+    - name: Ensure sudorule exist with members, lowercase
+      ipasudorule:
+        ipaadmin_password: SomeADMINpassword
+        name: "{{ item }}"
+        cmdcategory: all
+        hostgroup: "{{ item  | lower }}"
+        host: "{{ item  | lower }}.{{ ipa_domain }}"
+        group: "{{ item  | lower }}"
+        user: "user{{ item  | lower }}"
+      loop: "{{ groups_present }}"
+      register: result
+      failed_when: result.failed or result.changed
+
+    - name: Ensure sudorule exist with members, uppercase
+      ipasudorule:
+        ipaadmin_password: SomeADMINpassword
+        name: "{{ item }}"
+        cmdcategory: all
+        hostgroup: "{{ item  | upper }}"
+        host: "{{ item  | upper }}.{{ ipa_domain }}"
+        group: "{{ item  | upper }}"
+        user: "user{{ item  | upper }}"
+      loop: "{{ groups_present }}"
+      register: result
+      failed_when: result.failed or result.changed
+
+    - name: Ensure sudorule member is absent
+      ipasudorule:
+        ipaadmin_password: SomeADMINpassword
+        name: "{{ item }}"
+        hostgroup: "{{ item }}"
+        host: "{{ item }}.{{ ipa_domain }}"
+        group: "{{ item }}"
+        user: "user{{ item }}"
+        action: member
+        state: absent
+      loop: "{{ groups_present }}"
+      register: result
+      failed_when: result.failed or not result.changed
+
+    - name: Ensure sudorule member is absent, lowercase
+      ipasudorule:
+        ipaadmin_password: SomeADMINpassword
+        name: "{{ item }}"
+        hostgroup: "{{ item  | lower }}"
+        host: "{{ item  | lower }}.{{ ipa_domain }}"
+        group: "{{ item  | lower }}"
+        user: "user{{ item  | lower }}"
+        action: member
+        state: absent
+      loop: "{{ groups_present }}"
+      register: result
+      failed_when: result.failed or result.changed
+
+    - name: Ensure sudorule member is absent, upercase
+      ipasudorule:
+        ipaadmin_password: SomeADMINpassword
+        name: "{{ item }}"
+        hostgroup: "{{ item  | upper }}"
+        host: "{{ item  | upper }}.{{ ipa_domain }}"
+        group: "{{ item  | upper }}"
+        user: "user{{ item  | upper }}"
+        action: member
+        state: absent
+      loop: "{{ groups_present }}"
+      register: result
+      failed_when: result.failed or result.changed
+
+    - name: Ensure sudorule member is present, upercase
+      ipasudorule:
+        ipaadmin_password: SomeADMINpassword
+        name: "{{ item }}"
+        hostgroup: "{{ item  | upper }}"
+        host: "{{ item  | upper }}.{{ ipa_domain }}"
+        group: "{{ item  | upper }}"
+        user: "user{{ item  | upper }}"
+        action: member
+      loop: "{{ groups_present }}"
+      register: result
+      failed_when: result.failed or not result.changed
+
+    - name: Ensure sudorule member is present, lowercase
+      ipasudorule:
+        ipaadmin_password: SomeADMINpassword
+        name: "{{ item }}"
+        hostgroup: "{{ item  | lower }}"
+        host: "{{ item  | lower }}.{{ ipa_domain }}"
+        group: "{{ item  | lower }}"
+        user: "user{{ item  | lower }}"
+        action: member
+      loop: "{{ groups_present }}"
+      register: result
+      failed_when: result.failed or result.changed
+
+    - name: Ensure sudorule member is present, mixed case
+      ipasudorule:
+        ipaadmin_password: SomeADMINpassword
+        name: "{{ item }}"
+        hostgroup: "{{ item }}"
+        host: "{{ item }}.{{ ipa_domain }}"
+        group: "{{ item }}"
+        user: "user{{ item }}"
+        action: member
+      loop: "{{ groups_present }}"
+      register: result
+      failed_when: result.failed or result.changed
+
+    - name: End tests.
+      debug:
+        msg: "All tests executed."
+
+    always:
+    # cleanup
+    - name: Ensure sudorule do not exist
+      ipasudorule:
+        ipaadmin_password: SomeADMINpassword
+        name: "{{ item }}"
+        state: absent
+      loop: "{{ groups_present }}"
+
+    - name: Ensure test groups do not exist.
+      ipagroup:
+        ipaadmin_password: SomeADMINpassword
+        name: "{{ item }}"
+        state: absent
+      loop: "{{ groups_present }}"
+
+    - name: Ensure test hostgroups do not exist.
+      ipahostgroup:
+        ipaadmin_password: SomeADMINpassword
+        name: "{{ item }}"
+        state: absent
+      loop: "{{ groups_present }}"
+
+    - name: Ensure test hosts do not exist.
+      ipahost:
+        ipaadmin_password: SomeADMINpassword
+        name: "{{ item }}.{{ ipa_domain }}"
+        state: absent
+      loop: "{{ groups_present }}"
+
+    - name: Ensure test users do not exist.
+      ipauser:
+        ipaadmin_password: SomeADMINpassword
+        name: "user{{ item }}"
+        state: absent
+      loop: "{{ groups_present }}"


### PR DESCRIPTION
When adding users, groups, hosts and hostgroups as members, most
often the data is stored in lowercase. If the user mixes uppercase and
lowercase characters the module will fail to compare and try to add the
provided member as a new one, even if it is the same as the existing
one.

These series of changes fix that issue fix providing ways to compare
using only lowercase characters.

Fix #589 