### PR TITLE
sudorule: Create FQDN from single hostnames

### DIFF
--- a/plugins/modules/ipasudorule.py
+++ b/plugins/modules/ipasudorule.py
@@ -188,7 +188,7 @@ RETURN = """
 
 from ansible.module_utils.ansible_freeipa_module import \
     IPAAnsibleModule, compare_args_ipa, gen_add_del_lists, gen_add_list, \
-    gen_intersection_list
+    gen_intersection_list, api_get_domain, ensure_fqdn
 
 
 def find_sudorule(module, name):
@@ -374,6 +374,13 @@ def main():
 
     # Connect to IPA API
     with ansible_module.ipa_connect():
+        default_domain = api_get_domain()
+
+        # Ensure host is not short hostname.
+        if host:
+            host = list(
+                {ensure_fqdn(value.lower(), default_domain) for value in host}
+            )
 
         commands = []
 

--- a/tests/sudorule/test_sudorule_single_hostnames.yml
+++ b/tests/sudorule/test_sudorule_single_hostnames.yml
@@ -1,0 +1,151 @@
+---
+- name: Test sudorule with single hostnames.
+  hosts: "{{ ipa_test_host | default('ipaserver') }}"
+  become: no
+  gather_facts: no
+
+  tasks:
+  - block:
+    # setup test environment
+    - name: Get Domain from the server name
+      set_fact:
+        ipaserver_domain: "{{ ansible_facts['fqdn'].split('.')[1:] | join ('.') }}"
+      when: ipaserver_domain is not defined
+
+    - name: Ensure test sudo rule is absent
+      ipasudorule:
+        ipaadmin_password: SomeADMINpassword
+        name: sudorule_for_hosts
+        state: absent
+
+    - name: Ensure test host exist
+      ipahost:
+        ipaadmin_password: SomeADMINpassword
+        hosts:
+          - name: "host01.{{ ipaserver_domain }}"
+            force: yes
+          - name: "host02.{{ ipaserver_domain }}"
+            force: yes
+
+    # start tests
+    - name: Ensure sudorule exist with host member using FQDN.
+      ipasudorule:
+        ipaadmin_password: SomeADMINpassword
+        name: sudorule_for_hosts
+        host: "host01.{{ ipaserver_domain }}"
+      register: result
+      failed_when: result.failed or not result.changed
+
+    - name: Ensure sudorule host member using short hostname.
+      ipasudorule:
+        ipaadmin_password: SomeADMINpassword
+        name: sudorule_for_hosts
+        host: host01
+      register: result
+      failed_when: result.failed or result.changed
+
+    - name: Ensure sudorule exist with another host using short name.
+      ipasudorule:
+        ipaadmin_password: SomeADMINpassword
+        name: sudorule_for_hosts
+        host: host02
+      register: result
+      failed_when: result.failed or not result.changed
+
+    - name: Ensure sudorule exist with another host member using FQDN.
+      ipasudorule:
+        ipaadmin_password: SomeADMINpassword
+        name: sudorule_for_hosts
+        host: "host02.{{ ipaserver_domain }}"
+      register: result
+      failed_when: result.failed or result.changed
+
+    - name: Ensure sudorule exist with another host member using FQDN.
+      ipasudorule:
+        ipaadmin_password: SomeADMINpassword
+        name: sudorule_for_hosts
+        host: "host02.{{ ipaserver_domain }}"
+      register: result
+      failed_when: result.failed or result.changed
+
+    # cleanup for member tests.
+    - name: Ensure test sudo rule is absent
+      ipasudorule:
+        ipaadmin_password: SomeADMINpassword
+        name: sudorule_for_hosts
+        state: absent
+
+    - name: Ensure test sudo rule is absent
+      ipasudorule:
+        ipaadmin_password: SomeADMINpassword
+        name: sudorule_for_hosts
+        state: absent
+
+    # member tests
+    - name: Ensure test sudo rule is present
+      ipasudorule:
+        ipaadmin_password: SomeADMINpassword
+        name: sudorule_for_hosts
+
+    - name: Ensure sudorule host member using FQDN.
+      ipasudorule:
+        ipaadmin_password: SomeADMINpassword
+        name: sudorule_for_hosts
+        host: "host01.{{ ipaserver_domain }}"
+        action: member
+      register: result
+      failed_when: result.failed or not result.changed
+
+    - name: Ensure sudorule host member using short hostname.
+      ipasudorule:
+        ipaadmin_password: SomeADMINpassword
+        name: sudorule_for_hosts
+        host: host01
+        action: member
+      register: result
+      failed_when: result.failed or result.changed
+
+    - name: Ensure test sudo rule is absent
+      ipasudorule:
+        ipaadmin_password: SomeADMINpassword
+        name: sudorule_for_hosts
+        state: absent
+
+    - name: Ensure test sudo rule is present
+      ipasudorule:
+        ipaadmin_password: SomeADMINpassword
+        name: sudorule_for_hosts
+
+    - name: Ensure sudorule host member using FQDN.
+      ipasudorule:
+        ipaadmin_password: SomeADMINpassword
+        name: sudorule_for_hosts
+        host: "host01.{{ ipaserver_domain }}"
+        action: member
+      register: result
+      failed_when: result.failed or not result.changed
+
+    - name: Ensure sudorule host member using short hostname.
+      ipasudorule:
+        ipaadmin_password: SomeADMINpassword
+        name: sudorule_for_hosts
+        host: host01
+        action: member
+      register: result
+      failed_when: result.failed or result.changed
+
+    always:
+    # cleanup
+    - name: Ensure test sudo rule is absent
+      ipasudorule:
+        ipaadmin_password: SomeADMINpassword
+        name: sudorule_for_hosts
+        state: absent
+
+    - name: Ensure test host is absent
+      ipahost:
+        ipaadmin_password: SomeADMINpassword
+        name:
+          - "host01.{{ ipaserver_domain }}"
+          - "host02.{{ ipaserver_domain }}"
+        state: absent


### PR DESCRIPTION
Single hostnames can be used for sudorule_add_host and will match fqdn
in IPA internally. Simple host names have to be extended to be FQDN to
be able to compare them for sudorule_host_add and sudorule_host_remove.

Fixes #672