### PR TITLE
automember: Fix behavior of unused parameters.

### DIFF
--- a/plugins/modules/ipaautomember.py
+++ b/plugins/modules/ipaautomember.py
@@ -307,15 +307,21 @@ def main():
                         commands.append([name, 'automember_add', args])
                         res_find = {}
 
-                    inclusive_add, inclusive_del = gen_add_del_lists(
-                        transform_conditions(inclusive or []),
-                        res_find.get("automemberinclusiveregex", [])
-                    )
+                    if inclusive is not None:
+                        inclusive_add, inclusive_del = gen_add_del_lists(
+                            transform_conditions(inclusive),
+                            res_find.get("automemberinclusiveregex", [])
+                        )
+                    else:
+                        inclusive_add, inclusive_del = [], []
 
-                    exclusive_add, exclusive_del = gen_add_del_lists(
-                        transform_conditions(exclusive or []),
-                        res_find.get("automemberexclusiveregex", [])
-                    )
+                    if exclusive is not None:
+                        exclusive_add, exclusive_del = gen_add_del_lists(
+                            transform_conditions(exclusive),
+                            res_find.get("automemberexclusiveregex", [])
+                        )
+                    else:
+                        exclusive_add, exclusive_del = [], []
 
                 elif action == "member":
                     if res_find is None:

--- a/tests/automember/test_automember.yml
+++ b/tests/automember/test_automember.yml
@@ -367,6 +367,83 @@
     failed_when: result.changed or not result.failed or
                  "Invalid automember condition key 'cns'" not in result.msg
 
+  # Tests for issue https://bugzilla.redhat.com/show_bug.cgi?id=1976922
+  - name: Ensure group testgroup is absent
+    ipaautomember:
+      ipaadmin_password: SomeADMINpassword
+      ipaapi_context: "{{ ipa_context | default(omit) }}"
+      name: testgroup
+      state: absent
+      automember_type: group
+    register: result
+    failed_when: not result.changed or result.failed
+
+  - name: Ensure group testgroup is present
+    ipaautomember:
+      ipaadmin_password: SomeADMINpassword
+      ipaapi_context: "{{ ipa_context | default(omit) }}"
+      name: testgroup
+      description: Automember rule.
+      automember_type: group
+      inclusive:
+      - key: cn
+        expression: "@1"
+      exclusive:
+      - key: cn
+        expression: s
+    register: result
+    failed_when: not result.changed or result.failed
+
+  - name: Ensure group testgroup is present with updated description
+    ipaautomember:
+      ipaadmin_password: SomeADMINpassword
+      ipaapi_context: "{{ ipa_context | default(omit) }}"
+      name: testgroup
+      description: New automember rule.
+      automember_type: group
+    register: result
+    failed_when: not result.changed or result.failed
+
+  - name: Ensure group testgroup is present with updated description, again
+    ipaautomember:
+      ipaadmin_password: SomeADMINpassword
+      ipaapi_context: "{{ ipa_context | default(omit) }}"
+      name: testgroup
+      description: New automember rule.
+      automember_type: group
+    register: result
+    failed_when: result.changed or result.failed
+
+  - name: Verify inclusive and exclusive rules have not changed
+    ipaautomember:
+      ipaadmin_password: SomeADMINpassword
+      ipaapi_context: "{{ ipa_context | default(omit) }}"
+      name: testgroup
+      automember_type: group
+      inclusive:
+      - key: cn
+        expression: "@1"
+      exclusive:
+      - key: cn
+        expression: s
+    register: result
+    failed_when: result.changed or result.failed
+
+  - name: Verify no other rules existed.
+    ipaautomember:
+      ipaadmin_password: SomeADMINpassword
+      ipaapi_context: "{{ ipa_context | default(omit) }}"
+      name: testgroup
+      automember_type: group
+      inclusive: []
+      exclusive: []
+      action: member
+      state: absent
+    register: result
+    failed_when: result.changed or result.failed
+
+  # End of ests for issue https://bugzilla.redhat.com/show_bug.cgi?id=1976922
+
   # CLEANUP TEST ITEMS
 
   - name: Ensure group testgroup is absent


### PR DESCRIPTION
If a task with 'action: automember' tried to modify an automember rule
and did not provide either 'inclusive' or 'exclusive' parameters, the
regex for the missing arguments would be removed.

This patch fixes this behavior to only modify those parameters that
were set on the task, and leave the missing parameters in the state
they were before the task.

Reference: https://bugzilla.redhat.com/show_bug.cgi?id=1976922