### PR TITLE
iparole: Fix idempotence issues

### DIFF
--- a/plugins/module_utils/ansible_freeipa_module.py
+++ b/plugins/module_utils/ansible_freeipa_module.py
@@ -875,10 +875,11 @@ else:
             """
             return api_command_no_name(self, command, args)
 
-        @staticmethod
-        def ipa_get_domain():
+        def ipa_get_domain(self):
             """Retrieve IPA API domain."""
-            return api_get_domain()
+            if not hasattr(self, "__ipa_api_domain"):
+                setattr(self, "__ipa_api_domain", api_get_domain())
+            return getattr(self, "__ipa_api_domain")
 
         @staticmethod
         def ipa_get_realm():

--- a/plugins/modules/iparole.py
+++ b/plugins/modules/iparole.py
@@ -193,7 +193,9 @@ def ensure_absent_state(module, name, action, res_find):
         _members = module.params_get_lowercase("privilege")
         if _members is not None:
             del_list = gen_intersection_list(
-                _members, get_lowercase(res_find, "memberof_privilege"))
+                _members,
+                result_get_value_lowercase(res_find, "memberof_privilege")
+            )
             if del_list:
                 commands.append([name, "role_remove_privilege",
                                  {"privilege": del_list}])
@@ -203,7 +205,9 @@ def ensure_absent_state(module, name, action, res_find):
             _members = module.params_get_lowercase(key)
             if _members:
                 del_list = gen_intersection_list(
-                    _members, get_lowercase(res_find, "member_%s" % key))
+                    _members,
+                    result_get_value_lowercase(res_find, "member_%s" % key)
+                )
                 if del_list:
                     member_args[key] = del_list
 
@@ -217,7 +221,7 @@ def ensure_absent_state(module, name, action, res_find):
 
         _services = get_service_param(module, "service")
         if _services:
-            _existing = get_lowercase(res_find, "member_service")
+            _existing = result_get_value_lowercase(res_find, "member_service")
             items = gen_intersection_list(_services.keys(), _existing)
             if items:
                 member_args["service"] = [_services[key] for key in items]
@@ -251,11 +255,15 @@ def get_service_param(module, key):
     return _services
 
 
-def get_lowercase(res_find, key, default=None):
+def result_get_value_lowercase(res_find, key, default=None):
     """
     Retrieve a member of a dictionary converted to lowercase.
 
-    If 'key' is not found in the dictionary, return 'default'.
+    If field data is a string it is returned in lowercase. If
+    field data is a list or tuple, it is assumed that all values
+    are strings and the result is a list of strings in lowercase.
+
+    If 'key' is not found in the dictionary, returns 'default'.
     """
     existing = res_find.get(key)
     if existing is not None:
@@ -289,7 +297,9 @@ def ensure_role_with_members_is_present(module, name, res_find, action):
     _members = module.params_get_lowercase("privilege")
     if _members:
         add_list, del_list = gen_add_del_lists(
-            _members, get_lowercase(res_find, "memberof_privilege"))
+            _members,
+            result_get_value_lowercase(res_find, "memberof_privilege")
+        )
 
         if add_list:
             commands.append([name, "role_add_privilege",
@@ -305,7 +315,9 @@ def ensure_role_with_members_is_present(module, name, res_find, action):
         _members = module.params_get_lowercase(key)
         if _members is not None:
             add_list, del_list = gen_add_del_lists(
-                _members, get_lowercase(res_find, "member_%s" % key))
+                _members,
+                result_get_value_lowercase(res_find, "member_%s" % key)
+            )
             if add_list:
                 add_members[key] = add_list
             if del_list:

--- a/plugins/modules/iparole.py
+++ b/plugins/modules/iparole.py
@@ -298,34 +298,6 @@ def ensure_role_with_members_is_present(module, name, res_find, action):
     return commands
 
 
-def ensure_members_are_present(module, name, res_find):
-    """Define commands to ensure members are present for action `member`."""
-    commands = []
-
-    members = member_difference(
-        module, 'privilege', 'memberof_privilege', res_find)
-    if members:
-        commands.append([name, "role_add_privilege",
-                         {"privilege": members}])
-
-    member_args = {}
-    for key in ['user', 'group', 'host', 'hostgroup']:
-        items = member_difference(
-            module, key, 'member_%s' % key, res_find)
-        if items:
-            member_args[key] = items
-
-    _services = filter_service(module, res_find,
-                               lambda res, svc: not res.startswith(svc))
-    if _services:
-        member_args['service'] = _services
-
-    if member_args:
-        commands.append([name, "role_add_member", member_args])
-
-    return commands
-
-
 # pylint: disable=unused-argument
 def result_handler(module, result, command, name, args, errors):
     """Process the result of a command, looking for errors."""

--- a/tests/role/test_role_member_case_insensitive.yml
+++ b/tests/role/test_role_member_case_insensitive.yml
@@ -1,0 +1,450 @@
+---
+- name: Test role members
+  hosts: "{{ ipa_test_host | default('ipaserver') }}"
+  become: no
+  gather_facts: no
+
+  vars:
+    user_list:
+      - User1
+      - uSer2
+      - usEr3
+    group_list:
+      - Group1
+      - gRoup2
+      - grOup3
+    host_list:
+      - HoSt01
+      - hOsT02
+    hostgroup_list:
+      - TestHostGroup
+    service_list:
+      - MySVC/host01
+
+  tasks:
+  - include_tasks: ../env_freeipa_facts.yml
+
+  - block:
+      # setup
+
+      - name: Ensure test role is absent
+        iparole:
+          ipaadmin_password: SomeADMINpassword
+          name: testrule
+          state: absent
+
+      - name: Ensure test users are present
+        ipauser:
+          ipaadmin_password: SomeADMINpassword
+          users:
+          - name: "{{ item }}"
+            first: First
+            last: Last
+        with_items: "{{ user_list }}"
+
+      - name: Ensure test groups are present
+        ipagroup:
+          ipaadmin_password: SomeADMINpassword
+          name: "{{ item }}"
+        with_items: "{{ group_list }}"
+
+      - name: Ensure test hosts are present
+        ipahost:
+          ipaadmin_password: SomeADMINpassword
+          name: "{{ item }}.{{ ipaserver_domain }}"
+          ip_address: 192.168.122.101
+          force: yes
+        with_items: "{{ host_list }}"
+
+      - name: Ensure test hostgroups are present
+        ipahostgroup:
+          ipaadmin_password: SomeADMINpassword
+          name: "{{ item }}"
+        with_items: "{{ hostgroup_list }}"
+
+      - name: Ensure test services are present
+        ipaservice:
+          ipaadmin_password: SomeADMINpassword
+          name: "{{ item }}.{{ ipaserver_domain }}"
+        with_items: "{{ service_list }}"
+
+      # Test with action: hbacrule
+
+      - name: Check role present with members would trigger a change, mixed case
+        iparole:
+          ipaadmin_password: SomeADMINpassword
+          name: testrole
+          user:
+          - "{{ user_list[1] }}"
+          - "{{ user_list[2] }}"
+          group:
+          - "{{ group_list[1] }}"
+          - "{{ group_list[2] }}"
+          host:
+          - "{{ host_list[0] }}"
+          - "{{ host_list[1] }}"
+          hostgroup:
+          - "{{ hostgroup_list[0] }}"
+          service:
+          - "{{ service_list[0] }}.{{ ipaserver_domain }}"
+        check_mode: yes
+        register: result
+        failed_when: not result.changed or result.failed
+
+      - name: Ensure role is present with members, mixed case
+        iparole:
+          ipaadmin_password: SomeADMINpassword
+          name: testrole
+          user:
+          - "{{ user_list[1] }}"
+          - "{{ user_list[2] }}"
+          group:
+          - "{{ group_list[1] }}"
+          - "{{ group_list[2] }}"
+          host:
+          - "{{ host_list[0] }}"
+          - "{{ host_list[1] }}"
+          hostgroup:
+          - "{{ hostgroup_list[0] }}"
+          service:
+          - "{{ service_list[0] }}.{{ ipaserver_domain }}"
+        register: result
+        failed_when: not result.changed or result.failed
+
+      - name: Check role present with members would not trigger a change, mixed case
+        iparole:
+          ipaadmin_password: SomeADMINpassword
+          name: testrole
+          user:
+          - "{{ user_list[1] }}"
+          - "{{ user_list[2] }}"
+          group:
+          - "{{ group_list[1] }}"
+          - "{{ group_list[2] }}"
+          host:
+          - "{{ host_list[0] }}"
+          - "{{ host_list[1] }}"
+          hostgroup:
+          - "{{ hostgroup_list[0] }}"
+          service:
+          - "{{ service_list[0] }}.{{ ipaserver_domain }}"
+        check_mode: yes
+        register: result
+        failed_when: result.changed or result.failed
+
+      - name: Ensure role is present with members, lowercase
+        iparole:
+          ipaadmin_password: SomeADMINpassword
+          name: testrole
+          user:
+          - "{{ user_list[1] | lower }}"
+          - "{{ user_list[2] | lower }}"
+          group:
+          - "{{ group_list[1] | lower }}"
+          - "{{ group_list[2] | lower }}"
+          host:
+          - "{{ host_list[0] | lower }}"
+          - "{{ host_list[1] | lower }}"
+          hostgroup:
+          - "{{ hostgroup_list[0] | lower }}"
+          service:
+          - "{{ (service_list[0] + '.' + ipaserver_domain) | lower }}"
+        register: result
+        failed_when: result.changed or result.failed
+
+      - name: Ensure role is present with members, upercase
+        iparole:
+          ipaadmin_password: SomeADMINpassword
+          name: testrole
+          user:
+          - "{{ user_list[1] | upper }}"
+          - "{{ user_list[2] | upper }}"
+          group:
+          - "{{ group_list[1] | upper }}"
+          - "{{ group_list[2] | upper }}"
+          host:
+          - "{{ host_list[0] | upper }}"
+          - "{{ host_list[1] | upper }}"
+          hostgroup:
+          - "{{ hostgroup_list[0] | upper }}"
+          service:
+          - "{{ (service_list[0] + '.' + ipaserver_domain) | upper }}"
+        register: result
+        failed_when: result.changed or result.failed
+
+      - name: Ensure test role is absent
+        iparole:
+          ipaadmin_password: SomeADMINpassword
+          name: testrole
+          state: absent
+
+      # Test with action: members
+
+      - name: Ensure test role is present
+        iparole:
+          ipaadmin_password: SomeADMINpassword
+          name: testrole
+
+      - name: Check role members present would trigger a change, mixed case
+        iparole:
+          ipaadmin_password: SomeADMINpassword
+          name: testrole
+          user:
+          - "{{ user_list[1] }}"
+          - "{{ user_list[2] }}"
+          group:
+          - "{{ group_list[1] }}"
+          - "{{ group_list[2] }}"
+          host:
+          - "{{ host_list[0] }}"
+          - "{{ host_list[1] }}"
+          hostgroup:
+          - "{{ hostgroup_list[0] }}"
+          service:
+          - "{{ service_list[0] }}.{{ ipaserver_domain }}"
+          action: member
+        check_mode: yes
+        register: result
+        failed_when: not result.changed or result.failed
+
+      - name: Ensure role is present with members, mixed case
+        iparole:
+          ipaadmin_password: SomeADMINpassword
+          name: testrole
+          user:
+          - "{{ user_list[1] }}"
+          - "{{ user_list[2] }}"
+          group:
+          - "{{ group_list[1] }}"
+          - "{{ group_list[2] }}"
+          host:
+          - "{{ host_list[0] }}"
+          - "{{ host_list[1] }}"
+          hostgroup:
+          - "{{ hostgroup_list[0] }}"
+          service:
+          - "{{ service_list[0] }}.{{ ipaserver_domain }}"
+          action: member
+        register: result
+        failed_when: not result.changed or result.failed
+
+      - name: Check role members present would  not trigger a change, mixed case
+        iparole:
+          ipaadmin_password: SomeADMINpassword
+          name: testrole
+          user:
+          - "{{ user_list[1] }}"
+          - "{{ user_list[2] }}"
+          group:
+          - "{{ group_list[1] }}"
+          - "{{ group_list[2] }}"
+          host:
+          - "{{ host_list[0] }}"
+          - "{{ host_list[1] }}"
+          hostgroup:
+          - "{{ hostgroup_list[0] }}"
+          service:
+          - "{{ service_list[0] }}.{{ ipaserver_domain }}"
+          action: member
+        check_mode: yes
+        register: result
+        failed_when: result.changed or result.failed
+
+      - name: Ensure role is present with members, lowercase
+        iparole:
+          ipaadmin_password: SomeADMINpassword
+          name: testrole
+          user:
+          - "{{ user_list[1] | lower }}"
+          - "{{ user_list[2] | lower }}"
+          group:
+          - "{{ group_list[1] | lower }}"
+          - "{{ group_list[2] | lower }}"
+          host:
+          - "{{ host_list[0] | lower }}"
+          - "{{ host_list[1] | lower }}"
+          hostgroup:
+          - "{{ hostgroup_list[0] | lower }}"
+          service:
+          - "{{ (service_list[0] + '.' + ipaserver_domain) | lower }}"
+          action: member
+        register: result
+        failed_when: result.changed or result.failed
+
+      - name: Ensure role is present with members, upercase
+        iparole:
+          ipaadmin_password: SomeADMINpassword
+          name: testrole
+          user:
+          - "{{ user_list[1] | upper }}"
+          - "{{ user_list[2] | upper }}"
+          group:
+          - "{{ group_list[1] | upper }}"
+          - "{{ group_list[2] | upper }}"
+          host:
+          - "{{ host_list[0] | upper }}"
+          - "{{ host_list[1] | upper }}"
+          hostgroup:
+          - "{{ hostgroup_list[0] | upper }}"
+          service:
+          - "{{ (service_list[0] + '.' + ipaserver_domain) | upper }}"
+          action: member
+        register: result
+        failed_when: result.changed or result.failed
+
+      # # Test absent members
+      - name: Check role members absent would trigger a change, upercase
+        iparole:
+          ipaadmin_password: SomeADMINpassword
+          name: testrole
+          user:
+          - "{{ user_list[1] | upper }}"
+          - "{{ user_list[2] | upper }}"
+          group:
+          - "{{ group_list[1] | upper }}"
+          - "{{ group_list[2] | upper }}"
+          host:
+          - "{{ host_list[0] | upper }}"
+          - "{{ host_list[1] | upper }}"
+          hostgroup:
+          - "{{ hostgroup_list[0] | upper }}"
+          service:
+          - "{{ (service_list[0] + '.' + ipaserver_domain) | upper }}"
+          action: member
+          state: absent
+        check_mode: yes
+        register: result
+        failed_when: not result.changed or result.failed
+
+      - name: Ensure role members are absent, upercase
+        iparole:
+          ipaadmin_password: SomeADMINpassword
+          name: testrole
+          user:
+          - "{{ user_list[1] | upper }}"
+          - "{{ user_list[2] | upper }}"
+          group:
+          - "{{ group_list[1] | upper }}"
+          - "{{ group_list[2] | upper }}"
+          host:
+          - "{{ host_list[0] | upper }}"
+          - "{{ host_list[1] | upper }}"
+          hostgroup:
+          - "{{ hostgroup_list[0] | upper }}"
+          service:
+          - "{{ (service_list[0] + '.' + ipaserver_domain) | upper }}"
+          action: member
+          state: absent
+        register: result
+        failed_when: not result.changed or result.failed
+
+      - name: Check role members absent would not trigger a change, upercase
+        iparole:
+          ipaadmin_password: SomeADMINpassword
+          name: testrole
+          user:
+          - "{{ user_list[1] | upper }}"
+          - "{{ user_list[2] | upper }}"
+          group:
+          - "{{ group_list[1] | upper }}"
+          - "{{ group_list[2] | upper }}"
+          host:
+          - "{{ host_list[0] | upper }}"
+          - "{{ host_list[1] | upper }}"
+          hostgroup:
+          - "{{ hostgroup_list[0] | upper }}"
+          service:
+          - "{{ (service_list[0] + '.' + ipaserver_domain) | upper }}"
+          action: member
+          state: absent
+        check_mode: yes
+        register: result
+        failed_when: result.changed or result.failed
+
+      - name: Ensure role members are absent, mixed case
+        iparole:
+          ipaadmin_password: SomeADMINpassword
+          name: testrole
+          user:
+          - "{{ user_list[1] }}"
+          - "{{ user_list[2] }}"
+          group:
+          - "{{ group_list[1] }}"
+          - "{{ group_list[2] }}"
+          host:
+          - "{{ host_list[0] }}"
+          - "{{ host_list[1] }}"
+          hostgroup:
+          - "{{ hostgroup_list[0] }}"
+          service:
+          - "{{ service_list[0] }}.{{ ipaserver_domain }}"
+          action: member
+          state: absent
+        register: result
+        failed_when: result.changed or result.failed
+
+      - name: Ensure role members are absent, lowercase
+        iparole:
+          ipaadmin_password: SomeADMINpassword
+          name: testrole
+          user:
+          - "{{ user_list[1] | lower }}"
+          - "{{ user_list[2] | lower }}"
+          group:
+          - "{{ group_list[1] | lower }}"
+          - "{{ group_list[2] | lower }}"
+          host:
+          - "{{ host_list[0] | lower }}"
+          - "{{ host_list[1] | lower }}"
+          hostgroup:
+          - "{{ hostgroup_list[0] | lower }}"
+          service:
+          - "{{ (service_list[0] + '.' + ipaserver_domain) | lower }}"
+          action: member
+          state: absent
+        register: result
+        failed_when: result.changed or result.failed
+
+    always:
+      - name: Ensure test role is absent
+        iparole:
+          ipaadmin_password: SomeADMINpassword
+          name: testrole
+          state: absent
+
+      - name: Ensure test users are absent
+        ipauser:
+          ipaadmin_password: SomeADMINpassword
+          users:
+          - name: "{{ item }}"
+          state: absent
+        with_items: "{{ user_list }}"
+
+      - name: Ensure test groups are absent
+        ipagroup:
+          ipaadmin_password: SomeADMINpassword
+          name: "{{ item }}"
+          state: absent
+        with_items: "{{ group_list }}"
+
+      - name: Ensure test hosts are absent
+        ipahost:
+          ipaadmin_password: SomeADMINpassword
+          name: "{{ item }}.{{ ipaserver_domain }}"
+          state: absent
+        with_items: "{{ host_list }}"
+
+      - name: Ensure test hostgroups are absent
+        ipahostgroup:
+          ipaadmin_password: SomeADMINpassword
+          name: "{{ item }}"
+          state: absent
+        with_items: "{{ hostgroup_list }}"
+
+      - name: Ensure test services are absent
+        ipaservice:
+          ipaadmin_password: SomeADMINpassword
+          name: "{{ item }}.{{ ipaserver_domain }}"
+          continue: yes
+          state: absent
+        with_items: "{{ service_list }}"

--- a/tests/sanity/ignore-2.12.txt
+++ b/tests/sanity/ignore-2.12.txt
@@ -18,6 +18,8 @@ plugins/modules/ipadnsrecord.py pylint:use-maxsplit-arg
 plugins/modules/ipareplica_enable_ipa.py pylint:ansible-format-automatic-specification
 plugins/modules/ipareplica_prepare.py pylint:ansible-format-automatic-specification
 plugins/modules/ipareplica_test.py pylint:ansible-format-automatic-specification
+plugins/modules/iparole.py compile-2.6!skip
+plugins/modules/iparole.py import-2.6!skip
 plugins/modules/ipaserver_setup_ca.py compile-2.6!skip
 plugins/modules/ipaserver_setup_ca.py import-2.6!skip
 plugins/modules/ipaserver_test.py pylint:ansible-format-automatic-specification


### PR DESCRIPTION
Members of iparole should be compared in a case insensitive manner,
hosts should always be FQDN, and services should be compared with
the realm.

This PR fixes these issues, by forcing the members comparisons to be
performed always using lowercase characters.

Also, there is some code cleanup, removing unused code, and changing
custom code to the `ansisble_freeipa_module_utils` counterparts.

See the individual commits for more details.

This PR should not be merged before #716 