### PR TITLE
hbacrule: Fix member management idempotence issues.

### DIFF
--- a/tests/env_freeipa_facts.yml
+++ b/tests/env_freeipa_facts.yml
@@ -29,3 +29,15 @@
     ipa_api_version: "{{ ipa_cmd_version.stdout_lines[1] }}"
     ipa_host_is_client: "{{ (output.stdout_lines[-1] == 'CLIENT') | bool }}"
     trust_test_is_supported: no
+
+- block:
+  - name: Get Domain from server name
+    set_fact:
+      ipaserver_domain: "{{ ansible_facts['fqdn'].split('.')[1:] | join ('.') }}"
+    when: "'fqdn' in ansible_facts"
+
+  - name: Set Domain to 'ipa.test' if FQDN could not be retrieved.
+    set_fact:
+      ipaserver_domain: "ipa.test"
+    when: "'fqdn' not in ansible_facts"
+  when: ipaserver_domain is not defined

--- a/tests/hbacrule/test_hbacrule_member_case_insensitive.yml
+++ b/tests/hbacrule/test_hbacrule_member_case_insensitive.yml
@@ -1,0 +1,503 @@
+---
+- name: Test group
+  hosts: "{{ ipa_test_host | default('ipaserver') }}"
+  become: no
+  gather_facts: yes
+
+  vars:
+    user_list:
+      - User1
+      - uSer2
+      - usEr3
+    group_list:
+      - Group1
+      - gRoup2
+      - grOup3
+    host_list:
+      - HoSt01
+      - hOsT02
+    hostgroup_list:
+      - TestHostGroup
+    hbacsvc_list:
+      - Svc1
+      - sVC2
+    hbacsvcgroup_list:
+      - sVCgrOUp1
+
+  tasks:
+  - include_tasks: ../env_freeipa_facts.yml
+
+  - block:
+      # setup
+
+      - name: Ensure test hbacrule is absent
+        ipahbacrule:
+          ipaadmin_password: SomeADMINpassword
+          name: testrule
+          state: absent
+
+      - name: Ensure test users are present
+        ipauser:
+          ipaadmin_password: SomeADMINpassword
+          users:
+          - name: "{{ item }}"
+            first: First
+            last: Last
+        with_items: "{{ user_list }}"
+
+      - name: Ensure test groups are present
+        ipagroup:
+          ipaadmin_password: SomeADMINpassword
+          name: "{{ item }}"
+        with_items: "{{ group_list }}"
+
+      - name: Ensure test hosts are present
+        ipahost:
+          ipaadmin_password: SomeADMINpassword
+          name: "{{ item }}.{{ ipaserver_domain }}"
+          force: yes
+        with_items: "{{ host_list }}"
+
+      - name: Ensure test hostgroups are present
+        ipahostgroup:
+          ipaadmin_password: SomeADMINpassword
+          name: "{{ item }}"
+        with_items: "{{ hostgroup_list }}"
+
+      - name: Ensure test hbac services are present
+        ipahbacsvc:
+          ipaadmin_password: SomeADMINpassword
+          name: "{{ item }}"
+        with_items: "{{ hbacsvc_list }}"
+
+      - name: Ensure test hbac service groups are present
+        ipahbacsvcgroup:
+          ipaadmin_password: SomeADMINpassword
+          name: "{{ item }}"
+        with_items: "{{ hbacsvcgroup_list }}"
+
+      # Test with action: hbacrule
+
+      - name: Check if hbacrule present with members would trigger changes, mixed case
+        ipahbacrule:
+          ipaadmin_password: SomeADMINpassword
+          name: testrule
+          user:
+          - "{{ user_list[1] }}"
+          - "{{ user_list[2] }}"
+          group:
+          - "{{ group_list[1] }}"
+          - "{{ group_list[2] }}"
+          host:
+          - "{{ host_list[0] }}"
+          - "{{ host_list[1] }}"
+          hostgroup:
+          - "{{ hostgroup_list[0] }}"
+          hbacsvc:
+          - "{{ hbacsvc_list[0] }}"
+          - "{{ hbacsvc_list[1] }}"
+          hbacsvcgroup:
+          - "{{ hbacsvcgroup_list[0] }}"
+        check_mode: yes
+        register: result
+        failed_when: not result.changed or result.failed
+
+      - name: Ensure hbacrule is present with members, mixed case
+        ipahbacrule:
+          ipaadmin_password: SomeADMINpassword
+          name: testrule
+          user:
+          - "{{ user_list[1] }}"
+          - "{{ user_list[2] }}"
+          group:
+          - "{{ group_list[1] }}"
+          - "{{ group_list[2] }}"
+          host:
+          - "{{ host_list[0] }}"
+          - "{{ host_list[1] }}"
+          hostgroup:
+          - "{{ hostgroup_list[0] }}"
+          hbacsvc:
+          - "{{ hbacsvc_list[0] }}"
+          - "{{ hbacsvc_list[1] }}"
+          hbacsvcgroup:
+          - "{{ hbacsvcgroup_list[0] }}"
+        register: result
+        failed_when: not result.changed or result.failed
+
+      - name: Check if hbacrule present with members would not trigger changes, mixed case
+        ipahbacrule:
+          ipaadmin_password: SomeADMINpassword
+          name: testrule
+          user:
+          - "{{ user_list[1] }}"
+          - "{{ user_list[2] }}"
+          group:
+          - "{{ group_list[1] }}"
+          - "{{ group_list[2] }}"
+          host:
+          - "{{ host_list[0] }}"
+          - "{{ host_list[1] }}"
+          hostgroup:
+          - "{{ hostgroup_list[0] }}"
+          hbacsvc:
+          - "{{ hbacsvc_list[0] }}"
+          - "{{ hbacsvc_list[1] }}"
+          hbacsvcgroup:
+          - "{{ hbacsvcgroup_list[0] }}"
+        check_mode: yes
+        register: result
+        failed_when: result.changed or result.failed
+
+      - name: Ensure hbacrule is present with members, lowercase
+        ipahbacrule:
+          ipaadmin_password: SomeADMINpassword
+          name: testrule
+          user:
+          - "{{ user_list[1] | lower }}"
+          - "{{ user_list[2] | lower }}"
+          group:
+          - "{{ group_list[1] | lower }}"
+          - "{{ group_list[2] | lower }}"
+          host:
+          - "{{ host_list[0] | lower }}"
+          - "{{ host_list[1] | lower }}"
+          hostgroup:
+          - "{{ hostgroup_list[0] | lower }}"
+          hbacsvc:
+          - "{{ hbacsvc_list[0] | lower }}"
+          - "{{ hbacsvc_list[1] | lower }}"
+          hbacsvcgroup:
+          - "{{ hbacsvcgroup_list[0] | lower }}"
+        register: result
+        failed_when: result.changed or result.failed
+
+      - name: Ensure hbacrule is present with members, upercase
+        ipahbacrule:
+          ipaadmin_password: SomeADMINpassword
+          name: testrule
+          user:
+          - "{{ user_list[1] | upper }}"
+          - "{{ user_list[2] | upper }}"
+          group:
+          - "{{ group_list[1] | upper }}"
+          - "{{ group_list[2] | upper }}"
+          host:
+          - "{{ host_list[0] | upper }}"
+          - "{{ host_list[1] | upper }}"
+          hostgroup:
+          - "{{ hostgroup_list[0] | upper }}"
+          hbacsvc:
+          - "{{ hbacsvc_list[0] | upper }}"
+          - "{{ hbacsvc_list[1] | upper }}"
+          hbacsvcgroup:
+          - "{{ hbacsvcgroup_list[0] | upper  }}"
+        register: result
+        failed_when: result.changed or result.failed
+
+      - name: Ensure test hbacrule is absent
+        ipahbacrule:
+          ipaadmin_password: SomeADMINpassword
+          name: testrule
+          state: absent
+
+      # Test with action: members
+
+      - name: Ensure test hbacrule is present
+        ipahbacrule:
+          ipaadmin_password: SomeADMINpassword
+          name: testrule
+
+      - name: Check if hbacrule members present would trigger changes, mixed case
+        ipahbacrule:
+          ipaadmin_password: SomeADMINpassword
+          name: testrule
+          user:
+          - "{{ user_list[1] }}"
+          - "{{ user_list[2] }}"
+          group:
+          - "{{ group_list[1] }}"
+          - "{{ group_list[2] }}"
+          host:
+          - "{{ host_list[0] }}"
+          - "{{ host_list[1] }}"
+          hostgroup:
+          - "{{ hostgroup_list[0] }}"
+          hbacsvc:
+          - "{{ hbacsvc_list[0] }}"
+          - "{{ hbacsvc_list[1] }}"
+          hbacsvcgroup:
+          - "{{ hbacsvcgroup_list[0] }}"
+        check_mode: yes
+        register: result
+        failed_when: not result.changed or result.failed
+
+      - name: Ensure hbacrule members present, mixed case
+        ipahbacrule:
+          ipaadmin_password: SomeADMINpassword
+          name: testrule
+          user:
+          - "{{ user_list[1] }}"
+          - "{{ user_list[2] }}"
+          group:
+          - "{{ group_list[1] }}"
+          - "{{ group_list[2] }}"
+          host:
+          - "{{ host_list[0] }}"
+          - "{{ host_list[1] }}"
+          hostgroup:
+          - "{{ hostgroup_list[0] }}"
+          hbacsvc:
+          - "{{ hbacsvc_list[0] }}"
+          - "{{ hbacsvc_list[1] }}"
+          hbacsvcgroup:
+          - "{{ hbacsvcgroup_list[0] }}"
+          action: member
+        register: result
+        failed_when: not result.changed or result.failed
+
+      - name: Check if hbacrule members present would not trigger changes, mixed case
+        ipahbacrule:
+          ipaadmin_password: SomeADMINpassword
+          name: testrule
+          user:
+          - "{{ user_list[1] }}"
+          - "{{ user_list[2] }}"
+          group:
+          - "{{ group_list[1] }}"
+          - "{{ group_list[2] }}"
+          host:
+          - "{{ host_list[0] }}"
+          - "{{ host_list[1] }}"
+          hostgroup:
+          - "{{ hostgroup_list[0] }}"
+          hbacsvc:
+          - "{{ hbacsvc_list[0] }}"
+          - "{{ hbacsvc_list[1] }}"
+          hbacsvcgroup:
+          - "{{ hbacsvcgroup_list[0] }}"
+        check_mode: yes
+        register: result
+        failed_when: result.changed or result.failed
+
+      - name: Ensure hbacrule members present, lowercase
+        ipahbacrule:
+          ipaadmin_password: SomeADMINpassword
+          name: testrule
+          user:
+          - "{{ user_list[1] | lower }}"
+          - "{{ user_list[2] | lower }}"
+          group:
+          - "{{ group_list[1] | lower }}"
+          - "{{ group_list[2] | lower }}"
+          host:
+          - "{{ host_list[0] | lower }}"
+          - "{{ host_list[1] | lower }}"
+          hostgroup:
+          - "{{ hostgroup_list[0] | lower }}"
+          hbacsvc:
+          - "{{ hbacsvc_list[0] | lower }}"
+          - "{{ hbacsvc_list[1] | lower }}"
+          hbacsvcgroup:
+          - "{{ hbacsvcgroup_list[0] | lower }}"
+          action: member
+        register: result
+        failed_when: result.changed or result.failed
+
+      - name: Ensure hbacrule members present, upercase
+        ipahbacrule:
+          ipaadmin_password: SomeADMINpassword
+          name: testrule
+          user:
+          - "{{ user_list[1] | upper }}"
+          - "{{ user_list[2] | upper }}"
+          group:
+          - "{{ group_list[1] | upper }}"
+          - "{{ group_list[2] | upper }}"
+          host:
+          - "{{ host_list[0] | upper }}"
+          - "{{ host_list[1] | upper }}"
+          hostgroup:
+          - "{{ hostgroup_list[0] | upper }}"
+          hbacsvc:
+          - "{{ hbacsvc_list[0] | upper }}"
+          - "{{ hbacsvc_list[1] | upper }}"
+          hbacsvcgroup:
+          - "{{ hbacsvcgroup_list[0] | upper }}"
+          action: member
+        register: result
+        failed_when: result.changed or result.failed
+
+      # Test absent members
+
+      - name: Check if hbacrule members absent would trigger change, upercase
+        ipahbacrule:
+          ipaadmin_password: SomeADMINpassword
+          name: testrule
+          user:
+          - "{{ user_list[1] | upper }}"
+          - "{{ user_list[2] | upper }}"
+          group:
+          - "{{ group_list[1] | upper }}"
+          - "{{ group_list[2] | upper }}"
+          host:
+          - "{{ host_list[0] | upper }}"
+          - "{{ host_list[1] | upper }}"
+          hostgroup:
+          - "{{ hostgroup_list[0] | upper }}"
+          hbacsvc:
+          - "{{ hbacsvc_list[0] | upper }}"
+          - "{{ hbacsvc_list[1] | upper }}"
+          hbacsvcgroup:
+          - "{{ hbacsvcgroup_list[0] | upper }}"
+          action: member
+          state: absent
+        check_mode: yes
+        register: result
+        failed_when: not result.changed or result.failed
+
+      - name: Ensure hbacrule members are absent, upercase
+        ipahbacrule:
+          ipaadmin_password: SomeADMINpassword
+          name: testrule
+          user:
+          - "{{ user_list[1] | upper }}"
+          - "{{ user_list[2] | upper }}"
+          group:
+          - "{{ group_list[1] | upper }}"
+          - "{{ group_list[2] | upper }}"
+          host:
+          - "{{ host_list[0] | upper }}"
+          - "{{ host_list[1] | upper }}"
+          hostgroup:
+          - "{{ hostgroup_list[0] | upper }}"
+          hbacsvc:
+          - "{{ hbacsvc_list[0] | upper }}"
+          - "{{ hbacsvc_list[1] | upper }}"
+          hbacsvcgroup:
+          - "{{ hbacsvcgroup_list[0] | upper }}"
+          action: member
+          state: absent
+        register: result
+        failed_when: not result.changed or result.failed
+
+      - name: Check if hbacrule members absent would not trigger change, upercase
+        ipahbacrule:
+          ipaadmin_password: SomeADMINpassword
+          name: testrule
+          user:
+          - "{{ user_list[1] | upper }}"
+          - "{{ user_list[2] | upper }}"
+          group:
+          - "{{ group_list[1] | upper }}"
+          - "{{ group_list[2] | upper }}"
+          host:
+          - "{{ host_list[0] | upper }}"
+          - "{{ host_list[1] | upper }}"
+          hostgroup:
+          - "{{ hostgroup_list[0] | upper }}"
+          hbacsvc:
+          - "{{ hbacsvc_list[0] | upper }}"
+          - "{{ hbacsvc_list[1] | upper }}"
+          hbacsvcgroup:
+          - "{{ hbacsvcgroup_list[0] | upper }}"
+          action: member
+          state: absent
+        check_mode: yes
+        register: result
+        failed_when: result.changed or result.failed
+
+      - name: Ensure hbacrule members are absent, mixed case
+        ipahbacrule:
+          ipaadmin_password: SomeADMINpassword
+          name: testrule
+          user:
+          - "{{ user_list[1] }}"
+          - "{{ user_list[2] }}"
+          group:
+          - "{{ group_list[1] }}"
+          - "{{ group_list[2] }}"
+          host:
+          - "{{ host_list[0] }}"
+          - "{{ host_list[1] }}"
+          hostgroup:
+          - "{{ hostgroup_list[0] }}"
+          action: member
+          state: absent
+        register: result
+        failed_when: result.changed or result.failed
+
+      - name: Ensure hbacrule members are absent, lowercase
+        ipahbacrule:
+          ipaadmin_password: SomeADMINpassword
+          name: testrule
+          user:
+          - "{{ user_list[1] | lower }}"
+          - "{{ user_list[2] | lower }}"
+          group:
+          - "{{ group_list[1] | lower }}"
+          - "{{ group_list[2] | lower }}"
+          host:
+          - "{{ host_list[0] | lower }}"
+          - "{{ host_list[1] | lower }}"
+          hostgroup:
+          - "{{ hostgroup_list[0] | lower }}"
+          hbacsvc:
+          - "{{ hbacsvc_list[0] | lower }}"
+          - "{{ hbacsvc_list[1] | lower }}"
+          hbacsvcgroup:
+          - "{{ hbacsvcgroup_list[0] | lower }}"
+          action: member
+          state: absent
+        register: result
+        failed_when: result.changed or result.failed
+
+    always:
+      - name: Ensure test hbacrule is absent
+        ipahbacrule:
+          ipaadmin_password: SomeADMINpassword
+          name: testrule
+          state: absent
+
+      - name: Ensure test users are absent
+        ipauser:
+          ipaadmin_password: SomeADMINpassword
+          users:
+          - name: "{{ item }}"
+          state: absent
+        with_items: "{{ user_list }}"
+
+      - name: Ensure test groups are absent
+        ipagroup:
+          ipaadmin_password: SomeADMINpassword
+          name: "{{ item }}"
+          state: absent
+        with_items: "{{ group_list }}"
+
+      - name: Ensure test hosts are absent
+        ipahost:
+          ipaadmin_password: SomeADMINpassword
+          name: "{{ item }}.{{ ipaserver_domain }}"
+          state: absent
+        with_items: "{{ host_list }}"
+
+      - name: Ensure test hostgroups are absent
+        ipahostgroup:
+          ipaadmin_password: SomeADMINpassword
+          name: "{{ item }}"
+          state: absent
+        with_items: "{{ hostgroup_list }}"
+
+      - name: Ensure test hbac services are absent
+        ipahbacsvc:
+          ipaadmin_password: SomeADMINpassword
+          name: "{{ item }}"
+          state: absent
+        with_items: "{{ hbacsvc_list }}"
+
+      - name: Ensure test hbac service groups are absent
+        ipahbacsvcgroup:
+          ipaadmin_password: SomeADMINpassword
+          name: "{{ item }}"
+          state: absent
+        with_items: "{{ hbacsvcgroup_list }}"


### PR DESCRIPTION
Members of hbacrule must be compared in a case insensitive manner.
This patch fixes comparation of member parameters against existing
members by converting parameters to lowercase.

Also, there were some cases where a change with an empty set of members
was issued to IPA API, leading to a result of 'changed: yes' when
'changed: no' was expected. The fix involved a refactoring of the
member management code.

As the tests use the `ipaserver_domain` variable, a task to define it for
every test playbook, avaiable in `env_freeipa_facts.yml`.