### PR TITLE
build-galaxy-release: Cleanup of ipabackup_get_backup_dir.py link

### DIFF
--- a/utils/build-galaxy-release.sh
+++ b/utils/build-galaxy-release.sh
@@ -86,5 +86,6 @@ rm plugins/modules/ipaserver_*
 rm plugins/modules/ipareplica_*
 rm plugins/modules/ipaclient_*
 rm plugins/action/ipaclient_*
+rm plugins/action/ipabackup_*
 rmdir plugins/action
 git reset --hard


### PR DESCRIPTION
The link for plugins/modules/ipabackup_get_backup_dir.py from
roles/ipabackup/library/ipabackup_get_backup_dir.py was left over
after the script finished.