### PR TITLE
upstream CI:  Add support for CentOS 9 stream.

### DIFF
--- a/molecule/centos-9/molecule.yml
+++ b/molecule/centos-9/molecule.yml
@@ -1,0 +1,18 @@
+---
+driver:
+  name: docker
+platforms:
+  - name: centos-9
+    image: quay.io/ansible-freeipa/upstream-tests:centos-9
+    pre_build_image: true
+    hostname: ipaserver.test.local
+    dns_servers:
+      - 127.0.0.1
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    command: /usr/sbin/init
+    privileged: true
+provisioner:
+  name: ansible
+  playbooks:
+    prepare: ../resources/playbooks/prepare.yml

--- a/tests/azure/azure-pipelines.yml
+++ b/tests/azure/azure-pipelines.yml
@@ -18,6 +18,17 @@ stages:
       scenario: fedora-latest
       ansible_version: ">=2.9,<2.10"
 
+# CentOS 9
+
+- stage: CentOS9_Ansible_2_9
+  dependsOn: []
+  jobs:
+  - template: templates/group_tests.yml
+    parameters:
+      build_number: $(Build.BuildNumber)
+      scenario: centos-9
+      ansible_version: ">=2.9,<2.10"
+
 # CentOS 8
 
 - stage: CentOS8_Ansible_2_9

--- a/tests/azure/nightly.yml
+++ b/tests/azure/nightly.yml
@@ -43,6 +43,35 @@ stages:
       scenario: fedora-latest
       ansible_version: ""
 
+# CentoOS 9
+
+- stage: CentOS9_Ansible_2_9
+  dependsOn: []
+  jobs:
+  - template: templates/group_tests.yml
+    parameters:
+      build_number: $(Build.BuildNumber)
+      scenario: centos-9
+      ansible_version: ">=2.9,<2.10"
+
+- stage: CentOS9_Ansible_Core_2_11
+  dependsOn: []
+  jobs:
+  - template: templates/group_tests.yml
+    parameters:
+      build_number: $(Build.BuildNumber)
+      scenario: centos-9
+      ansible_version: "-core >=2.11,<2.12"
+
+- stage: CentOS9_Ansible_latest
+  dependsOn: []
+  jobs:
+  - template: templates/group_tests.yml
+    parameters:
+      build_number: $(Build.BuildNumber)
+      scenario: centos-9
+      ansible_version: ""
+
 # CentOS 8
 
 - stage: CentOS8_Ansible_2_9


### PR DESCRIPTION
This patch add support for running ansible-freeipa tests with the
CentOS 9 stream images, both on new pull requests and nightly tests.

This must not be merged before #698.