### PR TITLE
upstrem CI: Fix Ansible version in pytest playbooks.

### DIFF
--- a/tests/azure/templates/group_tests.yml
+++ b/tests/azure/templates/group_tests.yml
@@ -38,3 +38,4 @@ jobs:
   parameters:
     build_number: ${{ parameters.build_number }}
     scenario: ${{ parameters.scenario }}
+    ansible_version: ${{ parameters.ansible_version }}


### PR DESCRIPTION
When using group_tests, the pytest playbook was not receiving the
Ansible version to use, executing always with the latest available
version.

This patch fixes the behavior by passing the Ansible version to use
for tests to pytest_tests playbook.