### PR TITLE
upstream ci: Build images for CentOS 9 Stream.

### DIFF
--- a/molecule/centos-9-build/Dockerfile
+++ b/molecule/centos-9-build/Dockerfile
@@ -1,0 +1,30 @@
+FROM quay.io/centos/centos:stream9
+ENV container=docker
+
+RUN rm -fv /var/cache/dnf/metadata_lock.pid; \
+dnf makecache; \
+dnf --assumeyes install \
+    /usr/bin/python3 \
+    /usr/bin/python3-config \
+    /usr/bin/dnf-3 \
+    sudo \
+    bash \
+    systemd \
+    procps-ng \
+    iproute && \
+dnf clean all; \
+(cd /lib/systemd/system/sysinit.target.wants/; for i in *; do [ $i == systemd-tmpfiles-setup.service ] || rm -f $i; done); \
+rm -f /lib/systemd/system/multi-user.target.wants/*;\
+rm -f /etc/systemd/system/*.wants/*;\
+rm -f /lib/systemd/system/local-fs.target.wants/*; \
+rm -f /lib/systemd/system/sockets.target.wants/*udev*; \
+rm -f /lib/systemd/system/sockets.target.wants/*initctl*; \
+rm -f /lib/systemd/system/basic.target.wants/*;\
+rm -f /lib/systemd/system/anaconda.target.wants/*; \
+rm -rf /var/cache/dnf/;
+
+STOPSIGNAL RTMIN+3
+
+VOLUME ["/sys/fs/cgroup"]
+
+CMD ["/usr/sbin/init"]

--- a/molecule/centos-9-build/molecule.yml
+++ b/molecule/centos-9-build/molecule.yml
@@ -1,0 +1,18 @@
+---
+driver:
+  name: docker
+platforms:
+  - name: centos-9-build
+    image: "quay.io/centos/centos:stream9"
+    dockerfile: Dockerfile
+    hostname: ipaserver.test.local
+    dns_servers:
+      - 8.8.8.8
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    command: /usr/sbin/init
+    privileged: true
+provisioner:
+  name: ansible
+  playbooks:
+    prepare: ../resources/playbooks/prepare-build.yml

--- a/tests/azure/build-containers.yml
+++ b/tests/azure/build-containers.yml
@@ -29,6 +29,12 @@ jobs:
 
 - template: templates/build_container.yml
   parameters:
+    job_name_suffix: Centos9
+    container_name: centos-9
+    build_scenario_name: centos-9-build
+
+- template: templates/build_container.yml
+  parameters:
     job_name_suffix: FedoraLatest
     container_name: fedora-latest
     build_scenario_name: fedora-latest-build


### PR DESCRIPTION
This patch add support for building testing images for CentOS 9 Stream.