### PR TITLE
Fix role issues in Debian based distros.

### DIFF
--- a/roles/ipabackup/vars/Ubuntu-18.04.yml
+++ b/roles/ipabackup/vars/Ubuntu-18.04.yml
@@ -1,0 +1,9 @@
+# vars/Ubuntu.yml
+ipaserver_packages: [ "freeipa-server" ]
+ipaserver_packages_dns: [ "freeipa-server-dns" ]
+ipaserver_packages_adtrust: [ "freeipa-server-trust-ad" ]
+ipaserver_packages_firewalld: [ "firewalld" ]
+# Ubuntu Bionic Beaver must use python2 as Python interpreter due
+# to the way python-ipalib package is defined.
+# Package python2.7 must be installed before executing this role.
+ansible_python_interpreter: '/usr/bin/python2.7'

--- a/roles/ipaclient/vars/Debian-10.yml
+++ b/roles/ipaclient/vars/Debian-10.yml
@@ -1,0 +1,7 @@
+---
+# vars/Debian.yml
+ipaclient_packages: [ "freeipa-client" ]
+# Debian Buster must use python2 as Python interpreter due
+# to the way freeipa-client package is defined.
+# You must install package python2.7 before executing this role.
+ansible_python_interpreter: '/usr/bin/python2'

--- a/roles/ipaclient/vars/Ubuntu-18.04.yml
+++ b/roles/ipaclient/vars/Ubuntu-18.04.yml
@@ -1,0 +1,6 @@
+# vars/Ubuntu-18.04.yml
+ipaclient_packages: [ "freeipa-client" ]
+# Ubuntu Bionic Beaver must use python2 as Python interpreter due
+# to the way python-ipalib package is defined.
+# Package python2.7 must be installed before executing this role.
+ansible_python_interpreter: '/usr/bin/python2.7'

--- a/roles/ipareplica/vars/Ubuntu-18.04.yml
+++ b/roles/ipareplica/vars/Ubuntu-18.04.yml
@@ -1,0 +1,9 @@
+# vars/Ubuntu.yml
+ipareplica_packages: [ "freeipa-server" ]
+ipareplica_packages_dns: [ "freeipa-server-dns" ]
+ipareplica_packages_adtrust: [ "freeipa-server-trust-ad" ]
+ipareplica_packages_firewalld: [ "firewalld" ]
+# Ubuntu Bionic Beaver must use python2 as Python interpreter due
+# to the way python-ipalib package is defined.
+# Package python2.7 must be installed before executing this role.
+ansible_python_interpreter: '/usr/bin/python2.7'

--- a/roles/ipaserver/vars/Ubuntu-18.04.yml
+++ b/roles/ipaserver/vars/Ubuntu-18.04.yml
@@ -1,0 +1,9 @@
+# vars/Ubuntu.yml
+ipaserver_packages: [ "freeipa-server" ]
+ipaserver_packages_dns: [ "freeipa-server-dns" ]
+ipaserver_packages_adtrust: [ "freeipa-server-trust-ad" ]
+ipaserver_packages_firewalld: [ "firewalld" ]
+# Ubuntu Bionic Beaver must use python2 as Python interpreter due
+# to the way python-ipalib package is defined.
+# Package python2.7 must be installed before executing this role.
+ansible_python_interpreter: '/usr/bin/python2.7'


### PR DESCRIPTION
In Debian 10 (Buster) and Ubuntu 18.04, ansible-freeipa roles
fail to execute due to the packages requiring Python 2.7, and
Ansible identifying that they may execute using Python 3.x.

This PR force `ansible_python_interpreter` to Python 2.7, allowing
roles to be executed on these distros.

The changes are based on previous contributions.

Fix #607