### PR TITLE
Login shell is called defaultshell and not defaultlogin

### DIFF
--- a/README-config.md
+++ b/README-config.md
@@ -56,12 +56,12 @@ Example playbook to read config options:
       register: result
     - name: display default login shell
       debug:
-        msg: '{{ result.config.defaultlogin }}'
+        msg: '{{ result.config.defaultshell }}'
 
     - name: ensure defaultloginshell and maxusernamelength are set as required
       ipaconfig:
         ipaadmin_password: password
-        defaultlogin: /bin/bash
+        defaultshell: /bin/bash
         maxusername: 64
 ```
 


### PR DESCRIPTION
The example didn't work for me with the following error (on freeipa 4.9.8):

TASK [display default login shell] **************************************************************************************************
fatal: [freeipa1.example.org]: FAILED! => {"msg": "
The task includes an option with an undefined variable. The error was: 'dict object' has no attribute 'defaultlogin'

Using the correct variable defaultshell works for me.