### PR TITLE
correct comment in example playbook

### DIFF
--- a/README-pwpolicy.md
+++ b/README-pwpolicy.md
@@ -81,7 +81,7 @@ Example playbook to ensure maxlife is set to 49 in global policy:
   become: true
 
   tasks:
-  # Ensure absence of pwpolicies for group ops
+  # Ensure maxlife is set to 49 in global policy
   - ipapwpolicy:
       ipaadmin_password: SomeADMINpassword
       maxlife: 49


### PR DESCRIPTION
Insert "ensure maxlife is set to 49 in global policy" instead of the wrong comment from cut&paste.