### PR TITLE
upstream CI: Enable nightly tests using ansible-core 2.12.

### DIFF
--- a/tests/azure/nightly.yml
+++ b/tests/azure/nightly.yml
@@ -34,6 +34,15 @@ stages:
       scenario: fedora-latest
       ansible_version: "-core >=2.11,<2.12"
 
+- stage: FedoraLatest_Ansible_Core_2_12
+  dependsOn: []
+  jobs:
+  - template: templates/group_tests.yml
+    parameters:
+      build_number: $(Build.BuildNumber)
+      scenario: fedora-latest
+      ansible_version: "-core >=2.12,<2.13"
+
 - stage: FedoraLatest_Ansible_latest
   dependsOn: []
   jobs:
@@ -63,6 +72,15 @@ stages:
       scenario: centos-8
       ansible_version: "-core >=2.11,<2.12"
 
+- stage: CentOS8_Ansible_Core_2_12
+  dependsOn: []
+  jobs:
+  - template: templates/group_tests.yml
+    parameters:
+      build_number: $(Build.BuildNumber)
+      scenario: centos-8
+      ansible_version: "-core >=2.12,<2.13"
+
 - stage: CentOS8_Ansible_latest
   dependsOn: []
   jobs:
@@ -91,6 +109,15 @@ stages:
       build_number: $(Build.BuildNumber)
       scenario: centos-7
       ansible_version: "-core >=2.11,<2.12"
+
+- stage: CentOS7_Ansible_Core_2_12
+  dependsOn: []
+  jobs:
+  - template: templates/group_tests.yml
+    parameters:
+      build_number: $(Build.BuildNumber)
+      scenario: centos-7
+      ansible_version: "-core >=2.12,<2.13"
 
 - stage: CentOS7_Ansible_latest
   dependsOn: []

--- a/tests/azure/templates/playbook_tests.yml
+++ b/tests/azure/templates/playbook_tests.yml
@@ -14,7 +14,7 @@ parameters:
     default: ""
   - name: python_version
     type: string
-    default: 3.6
+    default: 3.x
   - name: build_number
     type: string
 

--- a/tests/azure/templates/pytest_tests.yml
+++ b/tests/azure/templates/pytest_tests.yml
@@ -9,7 +9,7 @@ parameters:
     default: ""
   - name: python_version
     type: string
-    default: 3.6
+    default: 3.x
 
 jobs:
 - job: Test_PyTests


### PR DESCRIPTION
This patch modifies the Python version used to be the latest available,
and add stages to execute the tests using ansible-core 2.12. As we
use Ubuntu 20.04, Python version 3.8 is avaiable.

Previously, ansible-core 2.12 was not available as it cannot be
installed with Python 3.6, which was the version used.