### PR TITLE
Enable pylint for ansible-freeipa roles.

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -75,7 +75,7 @@ jobs:
       - name: Run pylint
         run: |
             pip install pylint==2.10.2
-            pylint plugins --disable=import-error
+            pylint plugins roles --disable=import-error
 
   shellcheck:
     name: Shellcheck

--- a/roles/ipabackup/library/ipabackup_get_backup_dir.py
+++ b/roles/ipabackup/library/ipabackup_get_backup_dir.py
@@ -61,7 +61,7 @@ from ipaplatform.paths import paths
 
 def main():
     module = AnsibleModule(
-        argument_spec=dict(),
+        argument_spec={},
         supports_check_mode=True,
     )
 

--- a/roles/ipaclient/action_plugins/ipaclient_get_otp.py
+++ b/roles/ipaclient/action_plugins/ipaclient_get_otp.py
@@ -45,12 +45,14 @@ def run_cmd(args, stdin=None):
     if stdin:
         p_in = subprocess.PIPE
 
-    p = subprocess.Popen(args, stdin=p_in, stdout=p_out, stderr=p_err,
-                         close_fds=True)
-    __temp, stderr = p.communicate(stdin)
+    # pylint: disable=invalid-name
+    with subprocess.Popen(
+        args, stdin=p_in, stdout=p_out, stderr=p_err, close_fds=True
+    ) as p:
+        __temp, stderr = p.communicate(stdin)
 
-    if p.returncode != 0:
-        raise RuntimeError(stderr)
+        if p.returncode != 0:
+            raise RuntimeError(stderr)
 
 
 def kinit_password(principal, password, ccache_name, config):
@@ -128,8 +130,9 @@ KRB5CONF_TEMPLATE = """
 """
 
 
-class ActionModule(ActionBase):
+class ActionModule(ActionBase):  # pylint: disable=too-few-public-methods
 
+    # pylint: disable=too-many-return-statements
     def run(self, tmp=None, task_vars=None):
         """
         Handle credential cache transfer.
@@ -149,8 +152,9 @@ class ActionModule(ActionBase):
         Then the IPA commands can use this credential cache file.
         """
         if task_vars is None:
-            task_vars = dict()
+            task_vars = {}
 
+        # pylint: disable=super-with-arguments
         result = super(ActionModule, self).run(tmp, task_vars)
         principal = self._task.args.get('principal', None)
         keytab = self._task.args.get('keytab', None)
@@ -168,7 +172,7 @@ class ActionModule(ActionBase):
             return result
 
         data = self._execute_module(module_name='ipaclient_get_facts',
-                                    module_args=dict(), task_vars=task_vars)
+                                    module_args={}, task_vars=task_vars)
 
         try:
             domain = data['ansible_facts']['ipa']['domain']
@@ -195,7 +199,7 @@ class ActionModule(ActionBase):
             ipa_realm=realm,
             ipa_lifetime=lifetime))
 
-        with open(krb5conf_name, 'w') as f:
+        with open(krb5conf_name, 'w') as f:  # pylint: disable=invalid-name
             f.write(content)
 
         if password:

--- a/roles/ipaclient/library/ipaclient_api.py
+++ b/roles/ipaclient/library/ipaclient_api.py
@@ -133,7 +133,9 @@ def main():
 
         # Add CA certs to a temporary NSS database
         try:
+            # pylint: disable=deprecated-method
             argspec = inspect.getargspec(tmp_db.create_db)
+            # pylint: enable=deprecated-method
             if "password_filename" not in argspec.args:
                 tmp_db.create_db()
             else:
@@ -181,7 +183,7 @@ def main():
                 module.warn(
                     "Some capabilities including the ipa command capability "
                     "may not be available")
-            except errors.PublicError as e2:
+            except errors.PublicError as e2:  # pylint: disable=invalid-name
                 module.fail_json(
                     msg="Cannot connect to the IPA server RPC interface: "
                     "%s" % e2)

--- a/roles/ipaclient/library/ipaclient_get_facts.py
+++ b/roles/ipaclient/library/ipaclient_get_facts.py
@@ -56,10 +56,12 @@ def is_ntpd_configured():
     ntpd_conf_section = re.compile(r'^\s*\[ntpd\]\s*$')
 
     try:
+        # pylint: disable=invalid-name
         with open(SERVER_SYSRESTORE_STATE) as f:
             for line in f.readlines():
                 if ntpd_conf_section.match(line):
                     return True
+        # pylint: enable=invalid-name
         return False
     except IOError:
         return False
@@ -71,7 +73,7 @@ def is_dns_configured():
     bind_conf_section = re.compile(r'^\s*dyndb\s+"ipa"\s+"[^"]+"\s+{$')
 
     try:
-        with open(NAMED_CONF) as f:
+        with open(NAMED_CONF) as f:  # pylint: disable=invalid-name
             for line in f.readlines():
                 if bind_conf_section.match(line):
                     return True
@@ -103,7 +105,7 @@ def is_client_configured():
     # and /var/lib/ipa-client/sysrestore/sysrestore.state exists
 
     fstore = sysrestore.FileStore(paths.IPA_CLIENT_SYSRESTORE)
-    return (os.path.isfile(paths.IPA_DEFAULT_CONF) and fstore.has_files())
+    return os.path.isfile(paths.IPA_DEFAULT_CONF) and fstore.has_files()
 
 
 def is_server_configured():
@@ -129,7 +131,9 @@ def get_ipa_conf():
 
 def get_ipa_version():
     try:
+        # pylint: disable=import-outside-toplevel
         from ipapython import version
+        # pylint: enable=import-outside-toplevel
     except ImportError:
         return None
     else:
@@ -156,7 +160,7 @@ def get_ipa_version():
 
 def main():
     module = AnsibleModule(
-        argument_spec=dict(),
+        argument_spec={},
         supports_check_mode=True
     )
 

--- a/roles/ipaclient/library/ipaclient_get_otp.py
+++ b/roles/ipaclient/library/ipaclient_get_otp.py
@@ -146,7 +146,7 @@ def get_host_diff(ipa_host, module_host):
     :return: a dict representing the host attributes to apply
     """
     non_updateable_keys = ['ip_address']
-    data = dict()
+    data = {}
     for key in non_updateable_keys:
         if key in module_host:
             del module_host[key]
@@ -173,7 +173,7 @@ def get_module_host(module):
     :param module: the ansible module
     :returns: a dict representing the host attributes
     """
-    data = dict()
+    data = {}
     certificates = module.params.get('certificates')
     if certificates:
         data['usercertificate'] = certificates
@@ -189,7 +189,7 @@ def get_module_host(module):
     return data
 
 
-def ensure_host_present(module, api, ipahost):
+def ensure_host_present(module, _api, ipahost):
     """
     Ensure host exists in IPA and has the same attributes.
 
@@ -216,13 +216,13 @@ def ensure_host_present(module, api, ipahost):
         # already has Keytab: true, then we need first to run
         # ipa host-disable in order to remove OTP and keytab
         if module.params.get('random') and ipahost['has_keytab'] is True:
-            api.Command.host_disable(fqdn)
+            _api.Command.host_disable(fqdn)
 
-        result = api.Command.host_mod(fqdn, **diffs)
+        result = _api.Command.host_mod(fqdn, **diffs)
         # Save random password as it is not displayed by host-show
         if module.params.get('random'):
             randompassword = result['result']['randompassword']
-        result = api.Command.host_show(fqdn)
+        result = _api.Command.host_show(fqdn)
         if module.params.get('random'):
             result['result']['randompassword'] = randompassword
         module.exit_json(changed=True, host=result['result'])
@@ -236,17 +236,17 @@ def ensure_host_present(module, api, ipahost):
         module_host = get_module_host(module)
         # force creation of host even if there is no DNS record
         module_host["force"] = True
-        result = api.Command.host_add(fqdn, **module_host)
+        result = _api.Command.host_add(fqdn, **module_host)
         # Save random password as it is not displayed by host-show
         if module.params.get('random'):
             randompassword = result['result']['randompassword']
-        result = api.Command.host_show(fqdn)
+        result = _api.Command.host_show(fqdn)
         if module.params.get('random'):
             result['result']['randompassword'] = randompassword
         module.exit_json(changed=True, host=result['result'])
 
 
-def ensure_host_absent(module, api, host):
+def ensure_host_absent(module, _api, host):
     """
     Ensure host does not exist in IPA.
 
@@ -265,7 +265,7 @@ def ensure_host_absent(module, api, host):
 
     fqdn = unicode(module.params.get('fqdn'))
     try:
-        api.Command.host_del(fqdn)
+        _api.Command.host_del(fqdn)
     except Exception as e:
         module.fail_json(msg="Failed to remove host: %s" % e)
 

--- a/roles/ipaclient/library/ipaclient_setup_nis.py
+++ b/roles/ipaclient/library/ipaclient_setup_nis.py
@@ -82,7 +82,9 @@ def main():
 
     statestore = sysrestore.StateFile(paths.IPA_CLIENT_SYSRESTORE)
 
+    # pylint: disable=deprecated-method
     argspec = inspect.getargspec(configure_nisdomain)
+    # pylint: enable=deprecated-method
     if "statestore" not in argspec.args:
         # NUM_VERSION < 40500:
         configure_nisdomain(options=options, domain=domain)

--- a/roles/ipaclient/library/ipaclient_setup_ntp.py
+++ b/roles/ipaclient/library/ipaclient_setup_ntp.py
@@ -113,7 +113,9 @@ def main():
     if sync_time is not None:
         if options.conf_ntp:
             # Attempt to configure and sync time with NTP server (chrony).
+            # pylint: disable=deprecated-method
             argspec = inspect.getargspec(sync_time)
+            # pylint: enable=deprecated-method
             if "options" not in argspec.args:
                 synced_ntp = sync_time(options.ntp_servers, options.ntp_pool,
                                        fstore, statestore)
@@ -149,8 +151,8 @@ def main():
             if options.ntp_servers:
                 ntp_servers = options.ntp_servers
 
-            for s in ntp_servers:
-                synced_ntp = timeconf.synconce_ntp(s, options.debug)
+            for _ntp_server in ntp_servers:
+                synced_ntp = timeconf.synconce_ntp(_ntp_server, options.debug)
                 if synced_ntp:
                     break
 

--- a/roles/ipareplica/library/ipareplica_custodia_import_dm_password.py
+++ b/roles/ipareplica/library/ipareplica_custodia_import_dm_password.py
@@ -199,7 +199,9 @@ def main():
 
         ansible_log.debug("-- CUSTODIA IMPORT DM PASSWORD --")
 
+        # pylint: disable=deprecated-method
         argspec = inspect.getargspec(custodia.import_dm_password)
+        # pylint: enable=deprecated-method
         if "master_host_name" in argspec.args:
             custodia.import_dm_password(config.master_host_name)
         else:

--- a/roles/ipareplica/library/ipareplica_setup_certmonger.py
+++ b/roles/ipareplica/library/ipareplica_setup_certmonger.py
@@ -56,8 +56,7 @@ from ansible.module_utils.ansible_ipa_replica import (
 
 def main():
     ansible_module = AnsibleModule(
-        argument_spec=dict(
-        ),
+        argument_spec={},
         supports_check_mode=True,
     )
 

--- a/roles/ipareplica/library/ipareplica_setup_ds.py
+++ b/roles/ipareplica/library/ipareplica_setup_ds.py
@@ -316,7 +316,9 @@ def main():
         ansible_log.debug("-- CONFIGURE DIRSRV --")
         # Configure dirsrv
         with redirect_stdout(ansible_log):
+            # pylint: disable=deprecated-method
             argspec = inspect.getargspec(install_replica_ds)
+            # pylint: enable=deprecated-method
             if "promote" in argspec.args:
                 ds = install_replica_ds(config, options, ca_enabled,
                                         remote_api,
@@ -336,9 +338,13 @@ def main():
                                             ca_file=cafile,
                                             pkcs12_info=dirsrv_pkcs12_info)
 
+        # pylint: disable=deprecated-method
         ansible_log.debug("-- INSTALL DNS RECORDS --")
+        # pylint: enable=deprecated-method
         # Always try to install DNS records
+        # pylint: disable=deprecated-method
         argspec = inspect.getargspec(install_dns_records)
+        # pylint: enable=deprecated-method
         if "fstore" not in argspec.args:
             install_dns_records(config, options, remote_api)
         else:

--- a/roles/ipareplica/library/ipareplica_setup_http.py
+++ b/roles/ipareplica/library/ipareplica_setup_http.py
@@ -202,7 +202,9 @@ def main():
         create_ipa_conf(fstore, config, ca_enabled,
                         master=config.master_host_name)
 
+        # pylint: disable=deprecated-method
         argspec = inspect.getargspec(install_http)
+        # pylint: enable=deprecated-method
         if "promote" in argspec.args:
             install_http(
                 config,

--- a/roles/ipareplica/library/ipareplica_setup_krb.py
+++ b/roles/ipareplica/library/ipareplica_setup_krb.py
@@ -161,7 +161,9 @@ def main():
     ansible_log.debug("-- INSTALL_KRB --")
 
     with redirect_stdout(ansible_log):
+        # pylint: disable=deprecated-method
         argspec = inspect.getargspec(install_krb)
+        # pylint: enable=deprecated-method
         if "promote" in argspec.args:
             install_krb(
                 config,

--- a/roles/ipareplica/library/ipareplica_test.py
+++ b/roles/ipareplica/library/ipareplica_test.py
@@ -286,7 +286,9 @@ def main():
     # asks for HTTP certificate in newer ipa versions. In these versions
     # create_ipa_conf has the additional master argument.
     change_master_for_certmonger = False
+    # pylint: disable=deprecated-method
     argspec = inspect.getargspec(create_ipa_conf)
+    # pylint: enable=deprecated-method
     if "master" in argspec.args:
         change_master_for_certmonger = True
 
@@ -418,7 +420,9 @@ def main():
     # check selinux status, http and DS ports, NTP conflicting services
     try:
         with redirect_stdout(ansible_log):
+            # pylint: disable=deprecated-method
             argspec = inspect.getargspec(common_check)
+            # pylint: enable=deprecated-method
             if "skip_mem_check" in argspec.args:
                 common_check(options.no_ntp, options.skip_mem_check,
                              options.setup_ca)

--- a/roles/ipareplica/module_utils/ansible_ipa_replica.py
+++ b/roles/ipareplica/module_utils/ansible_ipa_replica.py
@@ -138,15 +138,15 @@ else:
 
         try:
             from ipaclient.install import timeconf
-            time_service = "chronyd"
-            ntpinstance = None
+            time_service = "chronyd"  # pylint: disable=invalid-name
+            ntpinstance = None  # pylint: disable=invalid-name
         except ImportError:
             try:
                 from ipaclient.install import ntpconf as timeconf
             except ImportError:
                 from ipaclient import ntpconf as timeconf
             from ipaserver.install import ntpinstance
-            time_service = "ntpd"
+            time_service = "ntpd"  # pylint: disable=invalid-name
 
     else:
         # IPA version < 4.6
@@ -162,10 +162,10 @@ else:
             filemode='a', console_format='%(message)s')
 
     @contextlib_contextmanager
-    def redirect_stdout(f):
-        sys.stdout = f
+    def redirect_stdout(stream):
+        sys.stdout = stream
         try:
-            yield f
+            yield stream
         finally:
             sys.stdout = sys.__stdout__
 
@@ -202,7 +202,8 @@ else:
             self.module.debug(msg)
             # self.module.warn(msg)
 
-    class installer_obj(object):
+    # pylint: disable=too-many-instance-attributes, useless-object-inheritance
+    class installer_obj(object):  # pylint: disable=invalid-name
         def __init__(self):
             # CompatServerReplicaInstall
             self.ca_cert_files = None
@@ -244,10 +245,10 @@ else:
         #             (attr, repr(value)))
         #     return value
 
-        def __getattr__(self, attr):
-            logger.info("  --> ADDING missing installer.%s", attr)
-            setattr(self, attr, None)
-            return getattr(self, attr)
+        def __getattr__(self, attrname):
+            logger.info("  --> ADDING missing installer.%s", attrname)
+            setattr(self, attrname, None)
+            return getattr(self, attrname)
 
         # def __setattr__(self, attr, value):
         #    logger.debug("  --> Setting installer.%s to %s" %
@@ -258,6 +259,9 @@ else:
             for name in self.__dict__:
                 yield self, name
 
+    # pylint: enable=too-many-instance-attributes, useless-object-inheritance
+
+    # pylint: disable=attribute-defined-outside-init
     installer = installer_obj()
     options = installer
 
@@ -274,6 +278,7 @@ else:
     # ServerReplicaInstall
     options.subject_base = None
     options.ca_subject = None
+    # pylint: enable=attribute-defined-outside-init
 
     def gen_env_boostrap_finalize_core(etc_ipa, default_config):
         env = Env()
@@ -295,9 +300,12 @@ else:
         # pylint: enable=no-member
         api.finalize()
 
-    def gen_ReplicaConfig():
+    def gen_ReplicaConfig():  # pylint: disable=invalid-name
+        # pylint: disable=too-many-instance-attributes
         class ExtendedReplicaConfig(ReplicaConfig):
+            # pylint: disable=useless-super-delegation
             def __init__(self, top_dir=None):
+                # pylint: disable=super-with-arguments
                 super(ExtendedReplicaConfig, self).__init__(top_dir)
 
             # def __getattribute__(self, attr):
@@ -306,12 +314,13 @@ else:
             #    if attr not in ["__dict__", "knobs"]:
             #        logger.debug("  <== Accessing config.%s (%s)" %
             #                     (attr, repr(value)))
-            #    return value
+            #    return value\
+            # pylint: enable=useless-super-delegation
 
-            def __getattr__(self, attr):
-                logger.info("  ==> ADDING missing config.%s", attr)
-                setattr(self, attr, None)
-                return getattr(self, attr)
+            def __getattr__(self, attrname):
+                logger.info("  ==> ADDING missing config.%s", attrname)
+                setattr(self, attrname, None)
+                return getattr(self, attrname)
 
             # def __setattr__(self, attr, value):
             #   logger.debug("  ==> Setting config.%s to %s" %
@@ -322,7 +331,9 @@ else:
             def knobs(self):
                 for name in self.__dict__:
                     yield self, name
+        # pylint: enable=too-many-instance-attributes
 
+        # pylint: disable=attribute-defined-outside-init
         # config = ReplicaConfig()
         config = ExtendedReplicaConfig()
         config.realm_name = api.env.realm
@@ -338,10 +349,12 @@ else:
         config.basedn = api.env.basedn
         # config.subject_base = options.subject_base
 
+        # pylint: enable=attribute-defined-outside-init
+
         return config
 
     def replica_ds_init_info(ansible_log,
-                             config, options, ca_is_configured, remote_api,
+                             config, options_, ca_is_configured, remote_api,
                              ds_ca_subject, ca_file,
                              promote=False, pkcs12_info=None):
 
@@ -364,7 +377,7 @@ else:
         ca_subject = ds_ca_subject
 
         ds = dsinstance.DsInstance(
-            config_ldif=options.dirsrv_config_file)
+            config_ldif=options_.dirsrv_config_file)
         ds.set_output(ansible_log)
 
         # Source: ipaserver/install/dsinstance.py

--- a/roles/ipaserver/library/ipaserver_prepare.py
+++ b/roles/ipaserver/library/ipaserver_prepare.py
@@ -312,6 +312,7 @@ def main():
 
         # Create the management framework config file and finalize api
         target_fname = paths.IPA_DEFAULT_CONF
+        # pylint: disable=invalid-name, consider-using-with
         fd = open(target_fname, "w")
         fd.write("[global]\n")
         fd.write("host=%s\n" % options.host_name)
@@ -331,6 +332,7 @@ def main():
             fd.write("ra_plugin=none\n")
         fd.write("mode=production\n")
         fd.close()
+        # pylint: enable=invalid-name, consider-using-with
 
         # Must be readable for everyone
         os.chmod(target_fname, 0o644)

--- a/roles/ipaserver/library/ipaserver_setup_ntp.py
+++ b/roles/ipaserver/library/ipaserver_setup_ntp.py
@@ -93,7 +93,9 @@ def main():
         # the ipa-server-install --uninstall
         ansible_module.log("Synchronizing time")
 
+        # pylint: disable=deprecated-method
         argspec = inspect.getargspec(sync_time)
+        # pylint: enable=deprecated-method
         if "options" not in argspec.args:
             synced_ntp = sync_time(options.ntp_servers, options.ntp_pool,
                                    fstore, sstore)

--- a/roles/ipaserver/library/ipaserver_test.py
+++ b/roles/ipaserver/library/ipaserver_test.py
@@ -742,7 +742,7 @@ def main():
         validate_admin_password(options.admin_password)
 
     # pkinit is not supported on DL0, don't allow related options
-
+    # pylint: disable=pointless-string-statement
     """
     # replica install: if not options.replica_file is None:
     if (not options._replica_install and \
@@ -755,6 +755,7 @@ def main():
                 "don't use any pkinit-related options.")
         options.no_pkinit = True
     """
+    # pylint: enable=pointless-string-statement
 
     if options.setup_dns:
         if len(options.forwarders) < 1 and not options.no_forwarders and \
@@ -942,7 +943,9 @@ def main():
     else:
         realm_name = options.realm_name.upper()
 
+    # pylint: disable=deprecated-method
     argspec = inspect.getargspec(validate_domain_name)
+    # pylint: enable=deprecated-method
     if "entity" in argspec.args:
         # NUM_VERSION >= 40690:
         try:

--- a/roles/ipaserver/module_utils/ansible_ipa_server.py
+++ b/roles/ipaserver/module_utils/ansible_ipa_server.py
@@ -105,23 +105,23 @@ else:
         try:
             from ipaclient.install import timeconf
             from ipaclient.install.client import sync_time
-            time_service = "chronyd"
-            ntpinstance = None
+            time_service = "chronyd"  # pylint: disable=invalid-name
+            ntpinstance = None  # pylint: disable=invalid-name
         except ImportError:
             try:
                 from ipaclient.install import ntpconf as timeconf
             except ImportError:
                 from ipaclient import ntpconf as timeconf
             from ipaserver.install import ntpinstance
-            time_service = "ntpd"
-            sync_time = None
+            time_service = "ntpd"  # pylint: disable=invalid-name
+            sync_time = None  # pylint: disable=invalid-name
         from ipaserver.install import (
             adtrust, bindinstance, ca, dns, dsinstance,
             httpinstance, installutils, kra, krbinstance,
             otpdinstance, custodiainstance, replication, service,
             sysupgrade)
-        adtrust_imported = True
-        kra_imported = True
+        adtrust_imported = True  # pylint: disable=invalid-name
+        kra_imported = True  # pylint: disable=invalid-name
         from ipaserver.install.installutils import (
             BadHostError, get_fqdn, get_server_ip_address,
             load_pkcs12, read_password, verify_fqdn,
@@ -158,9 +158,9 @@ else:
 
         try:
             from ipaserver.install import adtrustinstance
-            _server_trust_ad_installed = True
+            _server_trust_ad_installed = True  # pylint: disable=invalid-name
         except ImportError:
-            _server_trust_ad_installed = False
+            _server_trust_ad_installed = False  # pylint: disable=invalid-name
 
         try:
             from ipaclient.install.client import check_ldap_conf
@@ -192,10 +192,10 @@ else:
             filemode='a', console_format='%(message)s')
 
     @contextlib_contextmanager
-    def redirect_stdout(f):
-        sys.stdout = f
+    def redirect_stdout(stream):
+        sys.stdout = stream
         try:
-            yield f
+            yield stream
         finally:
             sys.stdout = sys.__stdout__
 
@@ -232,7 +232,9 @@ else:
             self.module.debug(msg)
             # self.module.warn(msg)
 
-    class options_obj(object):
+    # pylint: disable=too-few-public-methods, useless-object-inheritance
+    # pylint: disable=too-many-instance-attributes
+    class options_obj(object):  # pylint: disable=invalid-name
         def __init__(self):
             self._replica_install = False
             self.dnssec_master = False  # future unknown
@@ -255,8 +257,13 @@ else:
             for name in self.__dict__:
                 yield self, name
 
+    # pylint: enable=too-few-public-methods, useless-object-inheritance
+
+    # pylint: enable=too-many-instance-attributes
     options = options_obj()
     installer = options
+
+    # pylint: disable=attribute-defined-outside-init
 
     # ServerMasterInstall
     options.add_sids = True
@@ -299,6 +306,9 @@ else:
     options.ignore_topology_disconnect = False
     options.ignore_last_of_role = False
 
+    # pylint: enable=attribute-defined-outside-init
+
+    # pylint: disable=invalid-name
     def api_Backend_ldap2(host_name, setup_ca, connect=False):
         # we are sure we have the configuration file ready.
         cfg = dict(context='installer', confdir=paths.ETC_IPA, in_server=True,
@@ -312,10 +322,12 @@ else:
         if connect:
             api.Backend.ldap2.connect()
 
+    # pylint: enable=invalid-name
+
     def ds_init_info(ansible_log, fstore, domainlevel, dirsrv_config_file,
                      realm_name, host_name, domain_name, dm_password,
                      idstart, idmax, subject_base, ca_subject,
-                     no_hbac_allow, dirsrv_pkcs12_info, no_pkinit):
+                     _no_hbac_allow, dirsrv_pkcs12_info, no_pkinit):
 
         if not options.external_cert_files:
             ds = dsinstance.DsInstance(fstore=fstore, domainlevel=domainlevel,

--- a/setup.cfg
+++ b/setup.cfg
@@ -57,14 +57,20 @@ disable =
     fixme
 
 [pylint.BASIC]
-good-names = ex, i, j, k, Run, _, e, x, dn, cn, ip, os, unicode, __metaclass__
+good-names =
+    ex, i, j, k, Run, _, e, x, dn, cn, ip, os, unicode, __metaclass__, ds
 
 [pylint.IMPORTS]
 ignored-modules =
-    ansible.module_utils.ansible_freeipa_module,
+    ansible.errors, ansible.plugins.action,
+    ansible.module_utils, ansible.module_utils.ansible_freeipa_module,
     ipalib, ipalib.config, ipalib.constants, ipalib.krb_utils, ipalib.errors,
     ipapython.ipautil, ipapython.dn, ipapython.version, ipapython.dnsutil,
-    ipaplatform.paths
+    ipapython.ipa_log_manager, ipapython,
+    ipaplatform, ipaplatform.paths, ipaplatform.tasks, ipapython.admintool,
+    ipaserver.install.installutils, ipaserver.install.server.install,
+    ipaserver.install,
+    ipaclient.install.ipachangeconf, ipaclient.install.client
 
 [pylint.REFACTORING]
 max-nested-blocks = 9

--- a/utils/lint_check.sh
+++ b/utils/lint_check.sh
@@ -13,7 +13,7 @@ flake8 plugins utils roles setup.py
 echo -e "${INFO}Running 'pydocstyle'...${RST}"
 pydocstyle plugins utils roles setup.py
 echo -e "${INFO}Running 'pylint'...${RST}"
-pylint plugins setup.py
+pylint plugins roles setup.py
 
 ANSIBLE_LIBRARY="${ANSIBLE_LIBRARY:-plugins/modules}"
 ANSIBLE_MODULE_UTILS="${ANSIBLE_MODULE_UTILS:-plugins/module_utils}"


### PR DESCRIPTION
Pylint was not being applied to ansible-freeipa roles
in upstream CI or in utility scripts. This patch enables
pylint for roles in both scenarios.