### PR TITLE
Automember fixes

### DIFF
--- a/README-automember.md
+++ b/README-automember.md
@@ -230,6 +230,34 @@ Example playbook to ensure default hostgroup for all unmatched group entries is 
         state: absent
 ```
 
+Example playbook to ensure all orphan automember group rules are removed:
+
+```yaml
+- name: Playbook to ensure all orphan automember group rules are removed
+  hosts: ipaserver
+  become: yes
+  gather_facts: no
+  tasks:
+    - ipaautomember:
+        ipaadmin_password: SomeADMINpassword
+        automember_type: group
+        state: orphans_removed
+```
+
+Example playbook to ensure all orphan automember hostgroup rules are removed:
+
+```yaml
+- name: Playbook to ensure all orphan automember hostgroup rules are removed
+  hosts: ipaserver
+  become: yes
+  gather_facts: no
+  tasks:
+    - ipaautomember:
+        ipaadmin_password: SomeADMINpassword
+        automember_type: hostgroup
+        state: orphans_removed
+```
+
 
 Variables
 ---------
@@ -253,7 +281,7 @@ Variable | Description | Required
 `no_wait` | Don't wait for rebuilding membership. | no
 `default_group` | Default (fallback) group for all unmatched entries. Use the empty string "" for ensuring the default group is not set. | no
 `action` | Work on automember or member level. It can be one of `member` or `automember` and defaults to `automember`. | no
-`state` | The state to ensure. It can be one of `present`, `absent`, 'rebuilt'. default: `present`. | no
+`state` | The state to ensure. It can be one of `present`, `absent`, 'rebuilt'. 'orphans_removed' default: `present`. | no
 
 
 Authors

--- a/README-automember.md
+++ b/README-automember.md
@@ -104,11 +104,72 @@ Example playbook to add an inclusive condition to an existing rule
         ipaadmin_password: SomeADMINpassword
         name: "My domain hosts"
         description: "my automember condition"
-        automember_tye: hostgroup
+        automember_type: hostgroup
         action: member
         inclusive:
           - key: fqdn
             expression: ".*.mydomain.com"
+```
+
+Example playbook to ensure group membership for all users has been rebuilt
+
+```yaml
+- name: Playbook to ensure group membership for all users has been rebuilt
+  hosts: ipaserver
+  become: yes
+  gather_facts: no
+  tasks:
+    - ipaautomember:
+        ipaadmin_password: SomeADMINpassword
+        automember_type: group
+        state: rebuilt
+```
+
+Example playbook to ensure group membership for given users has been rebuilt
+
+
+```yaml
+- name: Playbook to ensure group membership for given users has been rebuilt
+  hosts: ipaserver
+  become: yes
+  gather_facts: no
+  tasks:
+    - ipaautomember:
+        ipaadmin_password: SomeADMINpassword
+        users:
+        - user1
+        - user2
+        state: rebuilt
+```
+
+Example playbook to ensure hostgroup membership for all hosts has been rebuilt
+
+```yaml
+- name: Playbook to ensure hostgroup membership for all hosts has been rebuilt
+  hosts: ipaserver
+  become: yes
+  gather_facts: no
+  tasks:
+    - ipaautomember:
+        ipaadmin_password: SomeADMINpassword
+        automember_type: hostgroup
+        state: rebuilt
+```
+
+Example playbook to ensure hostgroup membership for given hosts has been rebuilt
+
+```yaml
+- name: Playbook to ensure hostgroup membership for given hosts has been rebuilt
+  hosts: ipaserver
+  become: yes
+  gather_facts: no
+  tasks:
+    - ipaautomember:
+        ipaadmin_password: SomeADMINpassword
+        hosts:
+        - host1.mydomain.com
+        - host2.mydomain.com
+        state: rebuilt
 ```
 
 
@@ -129,11 +190,15 @@ Variable | Description | Required
 `automember_type` | Grouping to which the rule applies. It can be one of `group`, `hostgroup`. | yes
 `inclusive` | List of dictionaries in the format of `{'key': attribute, 'expression': inclusive_regex}` | no
 `exclusive` | List of dictionaries in the format of `{'key': attribute, 'expression': exclusive_regex}` | no
+`users` | Users to rebuild membership for. | no
+`hosts` | Hosts to rebuild membership for. | no
+`no_wait` | Don't wait for rebuilding membership. | no
 `action` | Work on automember or member level. It can be one of `member` or `automember` and defaults to `automember`. | no
-`state` | The state to ensure. It can be one of `present`, `absent`, default: `present`. | no
+`state` | The state to ensure. It can be one of `present`, `absent`, 'rebuilt'. default: `present`. | no
 
 
 Authors
 =======
 
 Mark Hahl
+Thomas Woerner

--- a/README-automember.md
+++ b/README-automember.md
@@ -172,6 +172,64 @@ Example playbook to ensure hostgroup membership for given hosts has been rebuilt
         state: rebuilt
 ```
 
+Example playbook to ensure default group fallback_group for all unmatched group entries is set
+
+```yaml
+- name: Playbook to ensure default group fallback_group for all unmatched group entries is set
+  hosts: ipaserver
+  become: yes
+  gather_facts: no
+  tasks:
+    - ipaautomember:
+        ipaadmin_password: SomeADMINpassword
+        automember_type: group
+        default_group: fallback_group
+```
+
+Example playbook to ensure default group for all unmatched group entries is not set
+
+```yaml
+- name: Playbook to ensure default group for all unmatched group entries is not set
+  hosts: ipaserver
+  become: yes
+  gather_facts: no
+  tasks:
+    - ipaautomember:
+        ipaadmin_password: SomeADMINpassword
+        default_group: ""
+        automember_type: group
+        state: absent
+```
+
+Example playbook to ensure default hostgroup fallback_hostgroup for all unmatched group entries
+
+```yaml
+- name: Playbook to ensure default hostgroup fallback_hostgroup for all unmatched group entries
+  hosts: ipaserver
+  become: yes
+  gather_facts: no
+  tasks:
+    - ipaautomember:
+        ipaadmin_password: SomeADMINpassword
+        automember_type: hostgroup
+        default_group: fallback_hostgroup
+```
+
+Example playbook to ensure default hostgroup for all unmatched group entries is not set
+
+```yaml
+- name: Playbook to ensure default hostgroup for all unmatched group entries is not set
+  hosts: ipaserver
+  become: yes
+  gather_facts: no
+  tasks:
+    - ipaautomember:
+        ipaadmin_password: SomeADMINpassword
+        automember_type: hostgroup
+        default_group: ""
+        state: absent
+```
+
 
 Variables
 ---------
@@ -193,6 +251,7 @@ Variable | Description | Required
 `users` | Users to rebuild membership for. | no
 `hosts` | Hosts to rebuild membership for. | no
 `no_wait` | Don't wait for rebuilding membership. | no
+`default_group` | Default (fallback) group for all unmatched entries. Use the empty string "" for ensuring the default group is not set. | no
 `action` | Work on automember or member level. It can be one of `member` or `automember` and defaults to `automember`. | no
 `state` | The state to ensure. It can be one of `present`, `absent`, 'rebuilt'. default: `present`. | no
 

--- a/playbooks/automember/automember-default-group-not-set.yml
+++ b/playbooks/automember/automember-default-group-not-set.yml
@@ -1,0 +1,10 @@
+---
+- name: Automember default group not set
+  hosts: ipaserver
+  become: true
+  tasks:
+  - name: Ensure automember default group is not set
+    ipaautomember:
+      ipaadmin_password: SomeADMINpassword
+      automember_type: group
+      default_group: ""

--- a/playbooks/automember/automember-default-group-set.yml
+++ b/playbooks/automember/automember-default-group-set.yml
@@ -1,0 +1,10 @@
+---
+- name: Automember default group set
+  hosts: ipaserver
+  become: true
+  tasks:
+  - name: Ensure automember default group is set
+    ipaautomember:
+      ipaadmin_password: SomeADMINpassword
+      automember_type: group
+      default_group: fallback_group

--- a/playbooks/automember/automember-default-hostgroup-not-set.yml
+++ b/playbooks/automember/automember-default-hostgroup-not-set.yml
@@ -1,0 +1,10 @@
+---
+- name: Automember default hostgroup not set
+  hosts: ipaserver
+  become: true
+  tasks:
+  - name: Ensure automember default hostgroup is not set
+    ipaautomember:
+      ipaadmin_password: SomeADMINpassword
+      automember_type: hostgroup
+      default_group: ""

--- a/playbooks/automember/automember-default-hostgroup-set.yml
+++ b/playbooks/automember/automember-default-hostgroup-set.yml
@@ -1,0 +1,10 @@
+---
+- name: Automember default hostgroup set
+  hosts: ipaserver
+  become: true
+  tasks:
+  - name: Ensure automember default hostgroup is set
+    ipaautomember:
+      ipaadmin_password: SomeADMINpassword
+      automember_type: hostgroup
+      default_group: fallback_hostgroup

--- a/playbooks/automember/automember-group-membership-all-users-rebuilt.yml
+++ b/playbooks/automember/automember-group-membership-all-users-rebuilt.yml
@@ -1,0 +1,10 @@
+---
+- name: Automember group membership for all users rebuilt example
+  hosts: ipaserver
+  become: true
+  tasks:
+  - name: Ensure group automember rule admins is present
+    ipaautomember:
+      ipaadmin_password: SomeADMINpassword
+      automember_type: group
+      state: rebuilt

--- a/playbooks/automember/automember-group-membership-users-rebuilt.yml
+++ b/playbooks/automember/automember-group-membership-users-rebuilt.yml
@@ -1,0 +1,12 @@
+---
+- name: Automember group membership for given users rebuilt example
+  hosts: ipaserver
+  become: true
+  tasks:
+  - name: Ensure group membership for given users has been rebuilt
+    ipaautomember:
+      ipaadmin_password: SomeADMINpassword
+      users:
+      - user1
+      - user2
+      state: rebuilt

--- a/playbooks/automember/automember-group-orphans-removed.yml
+++ b/playbooks/automember/automember-group-orphans-removed.yml
@@ -1,0 +1,10 @@
+---
+- name: Automember orphan group rules are removed example
+  hosts: ipaserver
+  become: true
+  tasks:
+  - name: Ensure orphan group rules are removed
+    ipaautomember:
+      ipaadmin_password: SomeADMINpassword
+      automember_type: group
+      state: orphans_removed

--- a/playbooks/automember/automember-hostgroup-membership-all-hosts-rebuilt.yml
+++ b/playbooks/automember/automember-hostgroup-membership-all-hosts-rebuilt.yml
@@ -1,0 +1,10 @@
+---
+- name: Automember hostgroup membership for all hosts rebuilt example
+  hosts: ipaserver
+  become: true
+  tasks:
+  - name: Ensure hostgroup membership for all hosts has been rebuilt
+    ipaautomember:
+      ipaadmin_password: SomeADMINpassword
+      automember_type: hostgroup
+      state: rebuilt

--- a/playbooks/automember/automember-hostgroup-membership-hosts-rebuilt.yml
+++ b/playbooks/automember/automember-hostgroup-membership-hosts-rebuilt.yml
@@ -1,0 +1,12 @@
+---
+- name: Automember hostgroup membership for given hosts rebuilt example
+  hosts: ipaserver
+  become: true
+  tasks:
+  - name: Ensure hostgroup membership for given hosts has been rebuilt
+    ipaautomember:
+      ipaadmin_password: SomeADMINpassword
+      hosts:
+      - host1.mydomain.com
+      - host2.mydomain.com
+      state: rebuilt

--- a/playbooks/automember/automember-hostgroup-orphans-removed.yml
+++ b/playbooks/automember/automember-hostgroup-orphans-removed.yml
@@ -1,0 +1,10 @@
+---
+- name: Automember orphan hostgroup rules are removed example
+  hosts: ipaserver
+  become: true
+  tasks:
+  - name: Ensure orphan hostgroup rules are removed
+    ipaautomember:
+      ipaadmin_password: SomeADMINpassword
+      automember_type: hostgroup
+      state: orphans_removed

--- a/plugins/module_utils/ansible_freeipa_module.py
+++ b/plugins/module_utils/ansible_freeipa_module.py
@@ -419,6 +419,9 @@ else:
     def api_get_realm():
         return api.env.realm
 
+    def api_get_basedn():
+        return api.env.basedn
+
     def gen_add_del_lists(user_list, res_list):
         """
         Generate the lists for the addition and removal of members.
@@ -881,6 +884,11 @@ else:
         def ipa_get_realm():
             """Retrieve IPA API realm."""
             return api_get_realm()
+
+        @staticmethod
+        def ipa_get_basedn():
+            """Retrieve IPA API basedn."""
+            return api_get_basedn()
 
         @staticmethod
         def ipa_command_exists(command):

--- a/tests/automember/test_automember_client_context.yml
+++ b/tests/automember/test_automember_client_context.yml
@@ -13,7 +13,6 @@
     ipaautomember:
       ipaadmin_password: SomeADMINpassword
       ipaapi_context: server
-      name: ThisShouldNotWork
       automember_type: group
       state: rebuilt
     register: result

--- a/tests/automember/test_automember_client_context.yml
+++ b/tests/automember/test_automember_client_context.yml
@@ -14,7 +14,8 @@
       ipaadmin_password: SomeADMINpassword
       ipaapi_context: server
       name: ThisShouldNotWork
-      state: rebuild
+      automember_type: group
+      state: rebuilt
     register: result
     failed_when: not (result.failed and result.msg is regex("No module named '*ipaserver'*"))
     when: ipa_host_is_client

--- a/tests/automember/test_automember_default_group.yml
+++ b/tests/automember/test_automember_default_group.yml
@@ -1,0 +1,166 @@
+---
+- name: Test automember default groups
+  hosts: "{{ ipa_test_host | default('ipaserver') }}"
+  become: true
+
+  tasks:
+
+  # SET FACTS
+
+  # CLEANUP TEST ITEMS
+
+  - name: Ensure group testgroup is absent
+    ipagroup:
+      ipaadmin_password: SomeADMINpassword
+      ipaapi_context: "{{ ipa_context | default(omit) }}"
+      name: testgroup
+      state: absent
+
+  - name: Ensure hostgroup testhostgroup is absent
+    ipahostgroup:
+      ipaadmin_password: SomeADMINpassword
+      ipaapi_context: "{{ ipa_context | default(omit) }}"
+      name: testhostgroup
+      state: absent
+
+  - name: Ensure automember default group is unset
+    ipaautomember:
+      ipaadmin_password: SomeADMINpassword
+      ipaapi_context: "{{ ipa_context | default(omit) }}"
+      default_group: ""
+      automember_type: group
+
+  - name: Ensure automember default hostgroup is unset
+    ipaautomember:
+      ipaadmin_password: SomeADMINpassword
+      ipaapi_context: "{{ ipa_context | default(omit) }}"
+      default_group: ""
+      automember_type: hostgroup
+
+  # CREATE TEST ITEMS
+
+  - name: Ensure group testgroup is present
+    ipagroup:
+      ipaadmin_password: SomeADMINpassword
+      ipaapi_context: "{{ ipa_context | default(omit) }}"
+      name: testgroup
+      state: present
+    register: result
+    failed_when: not result.changed or result.failed
+
+  - name: Ensure hostgroup testhostgroup is present
+    ipahostgroup:
+      ipaadmin_password: SomeADMINpassword
+      ipaapi_context: "{{ ipa_context | default(omit) }}"
+      name: testhostgroup
+      state: present
+    register: result
+    failed_when: not result.changed or result.failed
+
+  # TESTS
+
+  # GROUP TEST
+
+  - name: Ensure automember default group is set to testgroup
+    ipaautomember:
+      ipaadmin_password: SomeADMINpassword
+      ipaapi_context: "{{ ipa_context | default(omit) }}"
+      default_group: testgroup
+      automember_type: group
+    register: result
+    failed_when: not result.changed or result.failed
+
+  - name: Ensure automember default group is set to testgroup, again
+    ipaautomember:
+      ipaadmin_password: SomeADMINpassword
+      ipaapi_context: "{{ ipa_context | default(omit) }}"
+      default_group: testgroup
+      automember_type: group
+    register: result
+    failed_when: result.changed or result.failed
+
+  - name: Ensure automember default group is unset
+    ipaautomember:
+      ipaadmin_password: SomeADMINpassword
+      ipaapi_context: "{{ ipa_context | default(omit) }}"
+      default_group: ""
+      automember_type: group
+    register: result
+    failed_when: not result.changed or result.failed
+
+  - name: Ensure automember default group is unset, again
+    ipaautomember:
+      ipaadmin_password: SomeADMINpassword
+      ipaapi_context: "{{ ipa_context | default(omit) }}"
+      default_group: ""
+      automember_type: group
+    register: result
+    failed_when: result.changed or result.failed
+
+  # HOSTGROUP TEST
+
+  - name: Ensure automember default hostgroup is set to testhostgroup
+    ipaautomember:
+      ipaadmin_password: SomeADMINpassword
+      ipaapi_context: "{{ ipa_context | default(omit) }}"
+      default_group: testhostgroup
+      automember_type: hostgroup
+    register: result
+    failed_when: not result.changed or result.failed
+
+  - name: Ensure automember default hostgroup is set to testhostgroup, again
+    ipaautomember:
+      ipaadmin_password: SomeADMINpassword
+      ipaapi_context: "{{ ipa_context | default(omit) }}"
+      default_group: testhostgroup
+      automember_type: hostgroup
+    register: result
+    failed_when: result.changed or result.failed
+
+  - name: Ensure automember default hostgroup is unset
+    ipaautomember:
+      ipaadmin_password: SomeADMINpassword
+      ipaapi_context: "{{ ipa_context | default(omit) }}"
+      default_group: ""
+      automember_type: hostgroup
+    register: result
+    failed_when: not result.changed or result.failed
+
+  - name: Ensure automember default hostgroup is unset, again
+    ipaautomember:
+      ipaadmin_password: SomeADMINpassword
+      ipaapi_context: "{{ ipa_context | default(omit) }}"
+      default_group: ""
+      automember_type: hostgroup
+    register: result
+    failed_when: result.changed or result.failed
+
+  # CLEANUP TEST ITEMS
+
+  - name: Ensure group testgroup is absent
+    ipagroup:
+      ipaadmin_password: SomeADMINpassword
+      ipaapi_context: "{{ ipa_context | default(omit) }}"
+      name: testgroup
+      state: absent
+
+  - name: Ensure hostgroup testhostgroup is absent
+    ipahostgroup:
+      ipaadmin_password: SomeADMINpassword
+      ipaapi_context: "{{ ipa_context | default(omit) }}"
+      name: testhostgroup
+      state: absent
+
+  - name: Ensure automember default group is unset
+    ipaautomember:
+      ipaadmin_password: SomeADMINpassword
+      ipaapi_context: "{{ ipa_context | default(omit) }}"
+      default_group: ""
+      automember_type: group
+
+  - name: Ensure automember default hostgroup is unset
+    ipaautomember:
+      ipaadmin_password: SomeADMINpassword
+      ipaapi_context: "{{ ipa_context | default(omit) }}"
+      default_group: ""
+      automember_type: hostgroup

--- a/tests/automember/test_automember_orphans_removed.yml
+++ b/tests/automember/test_automember_orphans_removed.yml
@@ -1,0 +1,250 @@
+---
+- name: Test automember orphans_removed
+  hosts: "{{ ipa_test_host | default('ipaserver') }}"
+  become: true
+
+  tasks:
+
+  # SET FACTS
+
+  - name: Get Domain from server name
+    set_fact:
+      ipaserver_domain: "{{ ansible_facts['fqdn'].split('.')[1:] |
+                            join ('.') }}"
+    when: ipaserver_domain is not defined
+
+  # CLEANUP TEST ITEMS
+
+  - name: Ensure user testuser is absent
+    ipauser:
+      ipaadmin_password: SomeADMINpassword
+      ipaapi_context: "{{ ipa_context | default(omit) }}"
+      name: testuser
+      state: absent
+
+  - name: Ensure group testgroup is absent
+    ipagroup:
+      ipaadmin_password: SomeADMINpassword
+      ipaapi_context: "{{ ipa_context | default(omit) }}"
+      name: testgroup
+      state: absent
+
+  - name: Ensure host testhost is absent
+    ipahost:
+      ipaadmin_password: SomeADMINpassword
+      ipaapi_context: "{{ ipa_context | default(omit) }}"
+      name: "{{ 'testhost.' + ipaserver_domain }}"
+      state: absent
+
+  - name: Ensure hostgroup testhostgroup is absent
+    ipahostgroup:
+      ipaadmin_password: SomeADMINpassword
+      ipaapi_context: "{{ ipa_context | default(omit) }}"
+      name: testhostgroup
+      state: absent
+
+  - name: Ensure automember group testgroup is absent
+    ipaautomember:
+      ipaadmin_password: SomeADMINpassword
+      ipaapi_context: "{{ ipa_context | default(omit) }}"
+      name: testgroup
+      automember_type: group
+      state: absent
+
+  - name: Ensure automember hostgroup testhostgroup is absent
+    ipaautomember:
+      ipaadmin_password: SomeADMINpassword
+      ipaapi_context: "{{ ipa_context | default(omit) }}"
+      name: testhostgroup
+      automember_type: hostgroup
+      state: absent
+
+  # CREATE TEST ITEMS
+
+  - name: Ensure user testuser is present
+    ipauser:
+      ipaadmin_password: SomeADMINpassword
+      ipaapi_context: "{{ ipa_context | default(omit) }}"
+      name: testuser
+      first: Test
+      last: User
+    register: result
+    failed_when: not result.changed or result.failed
+
+  - name: Ensure host testhost is present
+    ipahost:
+      ipaadmin_password: SomeADMINpassword
+      ipaapi_context: "{{ ipa_context | default(omit) }}"
+      name: "{{ 'testhost.' + ipaserver_domain }}"
+      force: yes
+      reverse: no
+    register: result
+    failed_when: not result.changed or result.failed
+
+  - name: Ensure group testgroup is present
+    ipagroup:
+      ipaadmin_password: SomeADMINpassword
+      ipaapi_context: "{{ ipa_context | default(omit) }}"
+      name: testgroup
+      state: present
+    register: result
+    failed_when: not result.changed or result.failed
+
+  - name: Ensure hostgroup testhostgroup is present
+    ipahostgroup:
+      ipaadmin_password: SomeADMINpassword
+      ipaapi_context: "{{ ipa_context | default(omit) }}"
+      name: testhostgroup
+      state: present
+    register: result
+    failed_when: not result.changed or result.failed
+
+  # TESTS
+
+  # GROUP TEST
+
+  - name: Ensure automember group testgroup exists
+    ipaautomember:
+      ipaadmin_password: SomeADMINpassword
+      ipaapi_context: "{{ ipa_context | default(omit) }}"
+      name: testgroup
+      automember_type: group
+    register: result
+    failed_when: not result.changed or result.failed
+
+  - name: Ensure automember group condition exits for users
+    ipaautomember:
+      ipaadmin_password: SomeADMINpassword
+      ipaapi_context: "{{ ipa_context | default(omit) }}"
+      name: testgroup
+      automember_type: group
+      action: member
+      inclusive:
+        - key: uid
+          expression: uid
+    register: result
+    failed_when: not result.changed or result.failed
+
+  - name: Ensure group testgroup is absent
+    ipagroup:
+      ipaadmin_password: SomeADMINpassword
+      ipaapi_context: "{{ ipa_context | default(omit) }}"
+      name: testgroup
+      state: absent
+    register: result
+    failed_when: not result.changed or result.failed
+
+  - name: Ensure group orphans have been removed
+    ipaautomember:
+      ipaadmin_password: SomeADMINpassword
+      ipaapi_context: "{{ ipa_context | default(omit) }}"
+      automember_type: group
+      state: orphans_removed
+    register: result
+    failed_when: not result.changed or result.failed
+
+  - name: Ensure group orphans have been removed again
+    ipaautomember:
+      ipaadmin_password: SomeADMINpassword
+      ipaapi_context: "{{ ipa_context | default(omit) }}"
+      automember_type: group
+      state: orphans_removed
+    register: result
+    failed_when: result.changed or result.failed
+
+  # HOSTGROUP TEST
+
+  - name: Ensure automember hostgroup testhostgroup exists
+    ipaautomember:
+      ipaadmin_password: SomeADMINpassword
+      ipaapi_context: "{{ ipa_context | default(omit) }}"
+      name: testhostgroup
+      automember_type: hostgroup
+    register: result
+    failed_when: not result.changed or result.failed
+
+  - name: Ensure automember hostgroup condition exits for hosts
+    ipaautomember:
+      ipaadmin_password: SomeADMINpassword
+      ipaapi_context: "{{ ipa_context | default(omit) }}"
+      name: testhostgroup
+      automember_type: hostgroup
+      action: member
+      inclusive:
+        - key: fqdn
+          expression: "{{ '.*.' + ipaserver_domain }}"
+    register: result
+    failed_when: not result.changed or result.failed
+
+  - name: Ensure hostgroup testhostgroup is absent
+    ipahostgroup:
+      ipaadmin_password: SomeADMINpassword
+      ipaapi_context: "{{ ipa_context | default(omit) }}"
+      name: testhostgroup
+      state: absent
+    register: result
+    failed_when: not result.changed or result.failed
+
+  - name: Ensure hostgroup orphans have been removed
+    ipaautomember:
+      ipaadmin_password: SomeADMINpassword
+      ipaapi_context: "{{ ipa_context | default(omit) }}"
+      automember_type: hostgroup
+      state: orphans_removed
+    register: result
+    failed_when: not result.changed or result.failed
+
+  - name: Ensure hostgroup orphans have been removed again
+    ipaautomember:
+      ipaadmin_password: SomeADMINpassword
+      ipaapi_context: "{{ ipa_context | default(omit) }}"
+      automember_type: hostgroup
+      state: orphans_removed
+    register: result
+    failed_when: result.changed or result.failed
+
+  # CLEANUP TEST ITEMS
+
+  - name: Ensure user testuser is absent
+    ipauser:
+      ipaadmin_password: SomeADMINpassword
+      ipaapi_context: "{{ ipa_context | default(omit) }}"
+      name: testuser
+      state: absent
+
+  - name: Ensure group testgroup is absent
+    ipagroup:
+      ipaadmin_password: SomeADMINpassword
+      ipaapi_context: "{{ ipa_context | default(omit) }}"
+      name: testgroup
+      state: absent
+
+  - name: Ensure host testhost is absent
+    ipahost:
+      ipaadmin_password: SomeADMINpassword
+      ipaapi_context: "{{ ipa_context | default(omit) }}"
+      name: "{{ 'testhost.' + ipaserver_domain }}"
+      state: absent
+
+  - name: Ensure hostgroup testhostgroup is absent
+    ipahostgroup:
+      ipaadmin_password: SomeADMINpassword
+      ipaapi_context: "{{ ipa_context | default(omit) }}"
+      name: testhostgroup
+      state: absent
+
+  - name: Ensure automember group testgroup is absent
+    ipaautomember:
+      ipaadmin_password: SomeADMINpassword
+      ipaapi_context: "{{ ipa_context | default(omit) }}"
+      name: testgroup
+      automember_type: group
+      state: absent
+
+  - name: Ensure automember hostgroup testhostgroup is absent
+    ipaautomember:
+      ipaadmin_password: SomeADMINpassword
+      ipaapi_context: "{{ ipa_context | default(omit) }}"
+      name: testhostgroup
+      automember_type: hostgroup
+      state: absent

--- a/tests/automember/test_automember_rebuilt.yml
+++ b/tests/automember/test_automember_rebuilt.yml
@@ -1,0 +1,155 @@
+---
+- name: Test automember rebuilt
+  hosts: "{{ ipa_test_host | default('ipaserver') }}"
+  become: true
+
+  tasks:
+
+  # SET FACTS
+
+  - name: Get Domain from server name
+    set_fact:
+      ipaserver_domain: "{{ ansible_facts['fqdn'].split('.')[1:] |
+                            join ('.') }}"
+    when: ipaserver_domain is not defined
+
+  # CLEANUP TEST ITEMS
+
+  - name: Ensure user testuser is absent
+    ipauser:
+      ipaadmin_password: SomeADMINpassword
+      ipaapi_context: "{{ ipa_context | default(omit) }}"
+      name: testuser
+      state: absent
+
+  - name: Ensure host testhost is absent
+    ipahost:
+      ipaadmin_password: SomeADMINpassword
+      ipaapi_context: "{{ ipa_context | default(omit) }}"
+      name: "{{ 'testhost.' + ipaserver_domain }}"
+      state: absent
+
+  # CREATE TEST ITEMS
+
+  - name: Ensure user testuser is present
+    ipauser:
+      ipaadmin_password: SomeADMINpassword
+      ipaapi_context: "{{ ipa_context | default(omit) }}"
+      name: testuser
+      first: Test
+      last: User
+    register: result
+    failed_when: not result.changed or result.failed
+
+  - name: Ensure host testhost is present
+    ipahost:
+      ipaadmin_password: SomeADMINpassword
+      ipaapi_context: "{{ ipa_context | default(omit) }}"
+      name: "{{ 'testhost.' + ipaserver_domain }}"
+      force: yes
+      reverse: no
+    register: result
+    failed_when: not result.changed or result.failed
+
+  # TESTS
+
+  - name: Ensure group membership has been rebuilt
+    ipaautomember:
+      ipaadmin_password: SomeADMINpassword
+      ipaapi_context: "{{ ipa_context | default(omit) }}"
+      automember_type: group
+      state: rebuilt
+    register: result
+    failed_when: not result.changed or result.failed
+
+  - name: Ensure group membership has been rebuilt no_wait
+    ipaautomember:
+      ipaadmin_password: SomeADMINpassword
+      ipaapi_context: "{{ ipa_context | default(omit) }}"
+      automember_type: group
+      no_wait: yes
+      state: rebuilt
+    register: result
+    failed_when: not result.changed or result.failed
+
+  - name: Ensure group membership for given users has been rebuilt
+    ipaautomember:
+      ipaadmin_password: SomeADMINpassword
+      ipaapi_context: "{{ ipa_context | default(omit) }}"
+      users:
+      - testuser
+      state: rebuilt
+    register: result
+    failed_when: not result.changed or result.failed
+
+  - name: Ensure hostgroup membership for given hosts has been rebuilt
+    ipaautomember:
+      ipaadmin_password: SomeADMINpassword
+      ipaapi_context: "{{ ipa_context | default(omit) }}"
+      hosts:
+      - "{{ 'testhost.' + ipaserver_domain }}"
+      state: rebuilt
+    register: result
+    failed_when: not result.changed or result.failed
+
+  - name: Ensure group membership for given users has been rebuilt with type group
+    ipaautomember:
+      ipaadmin_password: SomeADMINpassword
+      ipaapi_context: "{{ ipa_context | default(omit) }}"
+      automember_type: group
+      users:
+      - testuser
+      state: rebuilt
+    register: result
+    failed_when: not result.changed or result.failed
+
+  - name: Ensure hostgroup membership for given hosts has been rebuilt with type hostgroup
+    ipaautomember:
+      ipaadmin_password: SomeADMINpassword
+      ipaapi_context: "{{ ipa_context | default(omit) }}"
+      automember_type: hostgroup
+      hosts:
+      - "{{ 'testhost.' + ipaserver_domain }}"
+      state: rebuilt
+    register: result
+    failed_when: not result.changed or result.failed
+
+  - name: Ensure group membership rebuild fails with hosts
+    ipaautomember:
+      ipaadmin_password: SomeADMINpassword
+      ipaapi_context: "{{ ipa_context | default(omit) }}"
+      automember_type: group
+      hosts:
+      - "{{ 'testhost.' + ipaserver_domain }}"
+      state: rebuilt
+    register: result
+    failed_when: not result.failed or
+                 "hosts can not be set when type is 'group'" not in result.msg
+
+  - name: Ensure hostgroup membership rebuild fails with users
+    ipaautomember:
+      ipaadmin_password: SomeADMINpassword
+      ipaapi_context: "{{ ipa_context | default(omit) }}"
+      automember_type: hostgroup
+      users:
+      - testuser
+      state: rebuilt
+    register: result
+    failed_when: not result.failed or
+                 "users can not be set when type is 'hostgroup'" not in result.msg
+
+  # CLEANUP TEST ITEMS
+
+  - name: Ensure user testuser is absent
+    ipauser:
+      ipaadmin_password: SomeADMINpassword
+      ipaapi_context: "{{ ipa_context | default(omit) }}"
+      name: testuser
+      state: absent
+
+  - name: Ensure host testhost is absent
+    ipahost:
+      ipaadmin_password: SomeADMINpassword
+      ipaapi_context: "{{ ipa_context | default(omit) }}"
+      name: "{{ 'testhost.' + ipaserver_domain }}"
+      state: absent


### PR DESCRIPTION
- ansible_freeipa_module: New api_get_basedn, IPAAnsibleModule.ipa_get_basedn
    
    These functions have been added to get the basedb from api.env for use
    with DN for example.
    
    api_get_basedn is returning api.env.basedn
    IPAAnsibleModule.ipa_get_basedn is a wrapper for api_get_basedn

-  automember: Add automember state: rebuilt
    
    There was state: rebuild before, but the code was incomplete and was not
    able to run properly.
    
    New parameters:
    - users: Limit the rebuild to the given users only
    - hosts: Limit the rebuild to the given hosts only
    - no_wait: Don't wait for rebuilding membership
    
    New parameters and examples have been added to README-automember.md
    
    tests/automember/test_automember_client_context.yml has been using
    state: rebuild and lacked the automember_type parameter.
    
    grouping was used in functions and has been replaced by automember_type.
    
    Some typos in examples have been fixed also.
    
    New playbooks:
    - playbooks/automember/automember-group-membership-all-users-rebuilt.yml
    - playbooks/automember/automember-group-membership-users-rebuilt.yml
    - playbooks/automember/automember-hostgroup-membership-all-hosts-rebuilt.yml
    - playbooks/automember/automember-hostgroup-membership-hosts-rebuilt.yml
    
    New tests:
    - tests/automember/test_automember_rebuilt.yml

- automember: Add automember default group handling
    
    The fallback group and hostgroup for unmached entries can be set and
    unset using default_group. If default_group is empty, then the default
    group will be unset.
    
    DN and ipa_get_based provided by ansible_freeipa_module are used in the
    code.
    
    New parameters:
    - default_group: Default (fallback) group for all unmatched entries.
    
    New parameters and examples have been added to README-automember.md
    
    New playbooks:
    - playbooks/automember/automember-default-group-not-set.yml
    - playbooks/automember/automember-default-group-set.yml
    - playbooks/automember/automember-default-hostgroup-not-set.yml
    - playbooks/automember/automember-default-hostgroup-set.yml
    
    New tests:
    - tests/automember/test_automember_default_group.yml

- automember: Add support for action: orphans_removed
    
    The removal of group or hostgroup orphans has been added to the automember
    module.
    
    It can be ensured that orphans have been removed using action: orphans_removed
    The automember_type needs to be set for this.
    
    New examples have been added to README-automember.md
    
    New playbooks:
    - playbooks/automember/automember-group-orphans-removed.yml
    - playbooks/automember/automember-hostgroup-orphans-removed.yml
    
    New tests:
    - tests/automember/test_automember_orphans_removed.yml