### PR TITLE
Readme fixes

### DIFF
--- a/README-automember.md
+++ b/README-automember.md
@@ -115,9 +115,6 @@ Example playbook to add an inclusive condition to an existing rule
 Variables
 ---------
 
-ipaautomember
--------
-
 Variable | Description | Required
 -------- | ----------- | --------
 `ipaadmin_principal` | The admin principal is a string and defaults to `admin` | no

--- a/README-automountlocation.md
+++ b/README-automountlocation.md
@@ -97,9 +97,6 @@ Example playbook to ensure absence of an automount location:
 Variables
 =========
 
-ipaautomountlocation
--------
-
 Variable | Description | Required
 -------- | ----------- | --------
 `ipaadmin_principal` | The admin principal is a string and defaults to `admin` | no

--- a/README-config.md
+++ b/README-config.md
@@ -82,9 +82,6 @@ Example playbook to read config options:
 Variables
 =========
 
-ipauser
--------
-
 **General Variables:**
 
 Variable | Description | Required

--- a/README-delegation.md
+++ b/README-delegation.md
@@ -135,9 +135,6 @@ Example playbook to make sure delegation "basic manager attributes" is absent:
 Variables
 ---------
 
-ipadelegation
--------
-
 Variable | Description | Required
 -------- | ----------- | --------
 `ipaadmin_principal` | The admin principal is a string and defaults to `admin` | no

--- a/README-dnsconfig.md
+++ b/README-dnsconfig.md
@@ -119,9 +119,6 @@ Example playbook to disallow synchronization of forward (A, AAAA) and reverse (P
 Variables
 =========
 
-ipadnsconfig
-------------
-
 Variable | Description | Required
 -------- | ----------- | --------
 `ipaadmin_principal` | The admin principal is a string and defaults to `admin` | no

--- a/README-dnsforwardzone.md
+++ b/README-dnsforwardzone.md
@@ -100,9 +100,6 @@ Example playbook to ensure presence of a forwardzone to ipa DNS:
 Variables
 =========
 
-ipagroup
--------
-
 Variable | Description | Required
 -------- | ----------- | --------
 `ipaadmin_principal` | The admin principal is a string and defaults to `admin` | no

--- a/README-dnsrecord.md
+++ b/README-dnsrecord.md
@@ -242,9 +242,6 @@ Example playbook to ensure multiple DNS records are absent:
 Variables
 =========
 
-ipadnsrecord
-------------
-
 Variable | Description | Required
 -------- | ----------- | --------
 `ipaadmin_principal` | The admin principal is a string and defaults to `admin` | no

--- a/README-dnszone.md
+++ b/README-dnszone.md
@@ -195,9 +195,6 @@ Example playbook to create a zone for reverse DNS lookup, from an IP address, gi
 Variables
 =========
 
-ipadnszone
-----------
-
 Variable | Description | Required
 -------- | ----------- | --------
 `ipaadmin_principal` | The admin principal is a string and defaults to `admin` | no
@@ -232,9 +229,6 @@ Variable | Description | Required
 
 Return Values
 =============
-
-ipadnszone
-----------
 
 Variable | Description | Returned When
 -------- | ----------- | -------------

--- a/README-group.md
+++ b/README-group.md
@@ -147,9 +147,6 @@ Example playbook to remove groups:
 Variables
 =========
 
-ipagroup
--------
-
 Variable | Description | Required
 -------- | ----------- | --------
 `ipaadmin_principal` | The admin principal is a string and defaults to `admin` | no

--- a/README-hbacrule.md
+++ b/README-hbacrule.md
@@ -129,9 +129,6 @@ Example playbook to make sure HBAC Rule login is absent:
 Variables
 =========
 
-ipahbacrule
----------------
-
 Variable | Description | Required
 -------- | ----------- | --------
 `ipaadmin_principal` | The admin principal is a string and defaults to `admin` | no

--- a/README-hbacsvc.md
+++ b/README-hbacsvc.md
@@ -91,9 +91,6 @@ Example playbook to make sure HBAC Services for http and tftp are absent
 Variables
 =========
 
-ipahbacsvc
-----------
-
 Variable | Description | Required
 -------- | ----------- | --------
 `ipaadmin_principal` | The admin principal is a string and defaults to `admin` | no

--- a/README-hbacsvcgroup.md
+++ b/README-hbacsvcgroup.md
@@ -129,9 +129,6 @@ Example playbook to make sure HBAC Service Group login is absent:
 Variables
 =========
 
-ipahbacsvcgroup
----------------
-
 Variable | Description | Required
 -------- | ----------- | --------
 `ipaadmin_principal` | The admin principal is a string and defaults to `admin` | no

--- a/README-host.md
+++ b/README-host.md
@@ -313,9 +313,6 @@ Example playbook to ensure a host is absent:
 Variables
 =========
 
-ipahost
--------
-
 Variable | Description | Required
 -------- | ----------- | --------
 `ipaadmin_principal` | The admin principal is a string and defaults to `admin` | no
@@ -369,9 +366,6 @@ Variable | Description | Required
 
 Return Values
 =============
-
-ipahost
--------
 
 There are only return values if one or more random passwords have been generated.
 

--- a/README-hostgroup.md
+++ b/README-hostgroup.md
@@ -143,9 +143,6 @@ Example playbook to make sure host-group databases is absent:
 Variables
 =========
 
-ipahostgroup
--------
-
 Variable | Description | Required
 -------- | ----------- | --------
 `ipaadmin_principal` | The admin principal is a string and defaults to `admin` | no

--- a/README-location.md
+++ b/README-location.md
@@ -74,9 +74,6 @@ Example playbook to make sure location "my_location1" is absent:
 Variables
 ---------
 
-ipalocation
--------
-
 Variable | Description | Required
 -------- | ----------- | --------
 `ipaadmin_principal` | The admin principal is a string and defaults to `admin` | no

--- a/README-permission.md
+++ b/README-permission.md
@@ -154,9 +154,6 @@ Example playbook to make sure permission "MyPermission" is renamed to "MyNewPerm
 Variables
 ---------
 
-ipapermission
--------
-
 Variable | Description | Required
 -------- | ----------- | --------
 `ipaadmin_principal` | The admin principal is a string and defaults to `admin` | no

--- a/README-privilege.md
+++ b/README-privilege.md
@@ -126,9 +126,6 @@ Example playbook to make sure privilege "DNS Special Privilege" is absent:
 Variables
 ---------
 
-ipaprivilege
-------------
-
 Variable | Description | Required
 -------- | ----------- | --------
 `ipaadmin_principal` | The admin principal is a string and defaults to `admin`. | no

--- a/README-pwpolicy.md
+++ b/README-pwpolicy.md
@@ -91,9 +91,6 @@ Example playbook to ensure maxlife is set to 49 in global policy:
 Variables
 =========
 
-ipapwpolicy
--------
-
 Variable | Description | Required
 -------- | ----------- | --------
 `ipaadmin_principal` | The admin principal is a string and defaults to `admin` | no

--- a/README-role.md
+++ b/README-role.md
@@ -238,9 +238,6 @@ Example playbook to ensure that different members are not associated with a role
 Variables
 ---------
 
-iparole
--------
-
 Variable | Description | Required
 -------- | ----------- | --------
 `ipaadmin_principal` | The admin principal is a string and defaults to `admin` | no

--- a/README-selfservice.md
+++ b/README-selfservice.md
@@ -131,9 +131,6 @@ Example playbook to make sure selfservice "Users can manage their own name detai
 Variables
 ---------
 
-ipaselfservice
--------
-
 Variable | Description | Required
 -------- | ----------- | --------
 `ipaadmin_principal` | The admin principal is a string and defaults to `admin` | no

--- a/README-server.md
+++ b/README-server.md
@@ -242,9 +242,6 @@ This task will always report a change.
 Variables
 ---------
 
-ipaserver
--------
-
 Variable | Description | Required
 -------- | ----------- | --------
 `ipaadmin_principal` | The admin principal is a string and defaults to `admin` | no

--- a/README-service.md
+++ b/README-service.md
@@ -285,8 +285,6 @@ Example playbook to allow users, groups, hosts or hostgroups to retrieve a keyta
 Variables
 ---------
 
-ipaservice
-
 Variable | Description | Required
 -------- | ----------- | --------
 `ipaadmin_principal` | The admin principal is a string and defaults to `admin` | no

--- a/README-sudocmd.md
+++ b/README-sudocmd.md
@@ -76,9 +76,6 @@ Example playbook to make sure sudocmd is absent:
 Variables
 =========
 
-ipasudocmd
--------
-
 Variable | Description | Required
 -------- | ----------- | --------
 `ipaadmin_principal` | The admin principal is a string and defaults to `admin` | no

--- a/README-sudocmdgroup.md
+++ b/README-sudocmdgroup.md
@@ -116,9 +116,6 @@ Example playbook to make sure sudocmdgroup is absent:
 Variables
 =========
 
-ipasudocmdgroup
--------
-
 Variable | Description | Required
 -------- | ----------- | --------
 `ipaadmin_principal` | The admin principal is a string and defaults to `admin` | no

--- a/README-sudorule.md
+++ b/README-sudorule.md
@@ -113,9 +113,6 @@ Example playbook to make sure Sudo Rule is absent:
 Variables
 =========
 
-ipasudorule
----------------
-
 Variable | Description | Required
 -------- | ----------- | --------
 `ipaadmin_principal` | The admin principal is a string and defaults to `admin` | no

--- a/README-trust.md
+++ b/README-trust.md
@@ -94,9 +94,6 @@ This will only delete the ipa-side of the trust and it does NOT delete the id-ra
 Variables
 =========
 
-ipatrust
--------
-
 Variable | Description | Required
 -------- | ----------- | --------
 `ipaadmin_principal` | The admin principal is a string and defaults to `admin` | no

--- a/README-user.md
+++ b/README-user.md
@@ -356,9 +356,6 @@ Example playbook to ensure users are absent:
 Variables
 =========
 
-ipauser
--------
-
 **General Variables:**
 
 Variable | Description | Required
@@ -431,9 +428,6 @@ Variable | Description | Required
 
 Return Values
 =============
-
-ipauser
--------
 
 There are only return values if one or more random passwords have been generated.
 

--- a/README-vault.md
+++ b/README-vault.md
@@ -210,9 +210,6 @@ Example playbook to make sure vault is absent:
 Variables
 =========
 
-ipavault
--------
-
 Variable | Description | Required
 -------- | ----------- | --------
 `ipaadmin_principal` | The admin principal is a string and defaults to `admin` | no
@@ -249,9 +246,6 @@ Variable | Description | Required
 
 Return Values
 =============
-
-ipavault
---------
 
 There is only a return value if `state` is `retrieved`.
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Features
 * Repair mode for clients
 * Backup and restore, also to and from controller
 * Modules for automembership rule management
+* Modules for automount location management
 * Modules for config management
 * Modules for delegation management
 * Modules for dns config management
@@ -424,6 +425,7 @@ Modules in plugin/modules
 =========================
 
 * [ipaautomember](README-automember.md)
+* [ipaautomountlocation](README-automountlocation.md)
 * [ipaconfig](README-config.md)
 * [ipadelegation](README-delegation.md)
 * [ipadnsconfig](README-dnsconfig.md)
@@ -436,12 +438,12 @@ Modules in plugin/modules
 * [ipahbacsvcgroup](README-hbacsvc.md)
 * [ipahost](README-host.md)
 * [ipahostgroup](README-hostgroup.md)
-* [ipalocation](README-ipalocation.md)
-* [ipapermission](README-ipapermission.md)
-* [ipaprivilege](README-ipaprivilege.md)
+* [ipalocation](README-location.md)
+* [ipapermission](README-permission.md)
+* [ipaprivilege](README-privilege.md)
 * [ipapwpolicy](README-pwpolicy.md)
 * [iparole](README-role.md)
-* [ipaselfservice](README-ipaselfservice.md)
+* [ipaselfservice](README-selfservice.md)
 * [ipaserver](README-server.md)
 * [ipaservice](README-service.md)
 * [ipasudocmd](README-sudocmd.md)

--- a/utils/templates/README-module+member.md.in
+++ b/utils/templates/README-module+member.md.in
@@ -112,9 +112,6 @@ MORE EXAMPLE PLAYBOOKS HERE
 Variables
 ---------
 
-ipa$name
--------
-
 Variable | Description | Required
 -------- | ----------- | --------
 `ipaadmin_principal` | The admin principal is a string and defaults to `admin` | no

--- a/utils/templates/README-module.md.in
+++ b/utils/templates/README-module.md.in
@@ -77,9 +77,6 @@ MORE EXAMPLE PLAYBOOKS HERE
 Variables
 ---------
 
-ipa$name
--------
-
 Variable | Description | Required
 -------- | ----------- | --------
 `ipaadmin_principal` | The admin principal is a string and defaults to `admin` | no


### PR DESCRIPTION
- READNE.md: Add automount location, fix some README links
    
    automount location was missing in README.md in the feature and also in
    the README link section.
    
    The links for location, permission, privilege and selfservice have been
    wrongly using the ipa prefix for the module

- module README files: Drop extra module header in Variables section
    
    The Variables and also the Return Variables sections contained an extra
    header with the module name. This is only needed if there are more than
    one module in the README.