### PR TITLE
iparole: Add state 'renamed'.

### DIFF
--- a/tests/role/test_role.yml
+++ b/tests/role/test_role.yml
@@ -36,6 +36,7 @@
       ipaapi_context: "{{ ipa_context | default(omit) }}"
       name: renamerole
       rename: testrole
+      state: renamed
     register: result
     failed_when: not result.changed or result.failed
 
@@ -47,8 +48,9 @@
       ipaapi_context: "{{ ipa_context | default(omit) }}"
       name: renamerole
       rename: testrole
+      state: renamed
     register: result
-    failed_when: result.changed
+    failed_when: result.changed or (not result.failed and "No role 'renamerole'" not in result.msg)
 
   - name: Ensure role has member has privileges.
     iparole:


### PR DESCRIPTION
All ansible-freeipa modules which allow object renaming should support
'state: renamed'.

This patch adds suport for the missing state, and fixes cases where a
user could try to rename the object and set its members, which would
fail depending on the operation order.

Fix #566