### PR TITLE
upstream CI: Wait for KDC to be available.

### DIFF
--- a/molecule/resources/playbooks/prepare.yml
+++ b/molecule/resources/playbooks/prepare.yml
@@ -25,3 +25,24 @@
     ansible.builtin.service:
       name: ipa
       state: started
+
+  - name: Wait for krb5dkc to be running
+    ansible.builtin.service_facts:
+    no_log: True
+    register: result
+    until: "'krb5kdc.service' in result.ansible_facts.services and \
+            result.ansible_facts.services['krb5kdc.service'].state == 'running'"
+    retries: 30
+    delay: 5
+
+  - name: Check if TGT is available for admin.
+    ansible.builtin.shell:
+      cmd: echo SomeADMINpassword | kinit -c ansible_freeipa_cache admin
+    register: result
+    until: not result.failed
+    retries: 30
+    delay: 5
+
+  - name: Cleanup TGT.
+    ansible.builtin.shell:
+      cmd: kdestroy -c ansible_freeipa_cache -A


### PR DESCRIPTION
Sometimes the first test of a batch fails because it fails to grant a
TGT from Kerberos KDC as it is not yet fully working. By waiting until
a TGT can be acquired, these failures will not happen anymore.