### PR TITLE
ipagroup: Refactor and fix group member management.

### DIFF
--- a/tests/group/test_group.yml
+++ b/tests/group/test_group.yml
@@ -174,6 +174,129 @@
     register: result
     failed_when: result.changed or result.failed
 
+  - name: Ensure groups group3, group2, and group1 are absent
+    ipagroup:
+      ipaadmin_password: SomeADMINpassword
+      ipaapi_context: "{{ ipa_context | default(omit) }}"
+      name: group3,group2,group1
+      state: absent
+    register: result
+    failed_when: not result.changed or result.failed
+
+  - name: Ensure group group1 is present
+    ipagroup:
+      ipaadmin_password: SomeADMINpassword
+      ipaapi_context: "{{ ipa_context | default(omit) }}"
+      name: group1
+    register: result
+    failed_when: not result.changed or result.failed
+
+  - name: Ensure users user1, user2 are present in group group1
+    ipagroup:
+      ipaadmin_password: SomeADMINpassword
+      ipaapi_context: "{{ ipa_context | default(omit) }}"
+      name: group1
+      user:
+      - user1
+      - user2
+      action: member
+    register: result
+    failed_when: not result.changed or result.failed
+
+  - name: Ensure users user1, user2 and user3 are present in group group1
+    ipagroup:
+      ipaadmin_password: SomeADMINpassword
+      ipaapi_context: "{{ ipa_context | default(omit) }}"
+      name: group1
+      user:
+      - user1
+      - user2
+      - user3
+      action: member
+    register: result
+    failed_when: not result.changed or result.failed
+
+  - name: Ensure users user1, user2 are present in group group1, again
+    ipagroup:
+      ipaadmin_password: SomeADMINpassword
+      ipaapi_context: "{{ ipa_context | default(omit) }}"
+      name: group1
+      user:
+      - user1
+      - user2
+      action: member
+    register: result
+    failed_when: result.changed or result.failed
+
+  - name: Ensure users user1, user2 and user3 are present in group group1, again
+    ipagroup:
+      ipaadmin_password: SomeADMINpassword
+      ipaapi_context: "{{ ipa_context | default(omit) }}"
+      name: group1
+      user:
+      - user1
+      - user2
+      - user3
+      action: member
+    register: result
+    failed_when: result.changed or result.failed
+
+  - name: Ensure group group1 is absent
+    ipagroup:
+      ipaadmin_password: SomeADMINpassword
+      ipaapi_context: "{{ ipa_context | default(omit) }}"
+      name: group1
+      state: absent
+    register: result
+    failed_when: not result.changed or result.failed
+
+  - name: Ensure group group1 with users user1, user2 is present
+    ipagroup:
+      ipaadmin_password: SomeADMINpassword
+      ipaapi_context: "{{ ipa_context | default(omit) }}"
+      name: group1
+      user:
+      - user1
+      - user2
+    register: result
+    failed_when: not result.changed or result.failed
+
+  - name: Ensure group group1 with users user1, user2 and user3 is present
+    ipagroup:
+      ipaadmin_password: SomeADMINpassword
+      ipaapi_context: "{{ ipa_context | default(omit) }}"
+      name: group1
+      user:
+      - user1
+      - user2
+      - user3
+    register: result
+    failed_when: not result.changed or result.failed
+
+  - name: Ensure group group1 with users user1, user2 and user3 is present, again
+    ipagroup:
+      ipaadmin_password: SomeADMINpassword
+      ipaapi_context: "{{ ipa_context | default(omit) }}"
+      name: group1
+      user:
+      - user1
+      - user2
+      - user3
+      action: member
+    register: result
+    failed_when: result.changed or result.failed
+
+  - name: Ensure only users user1, user2 are present in group group1
+    ipagroup:
+      ipaadmin_password: SomeADMINpassword
+      ipaapi_context: "{{ ipa_context | default(omit) }}"
+      name: group1
+      user:
+      - user1
+      - user2
+    register: result
+    failed_when: not result.changed or result.failed
+
   - name: Ensure group group3, group2 and group1 are absent
     ipagroup:
       ipaadmin_password: SomeADMINpassword


### PR DESCRIPTION
Currently, when adding an overlapping set of members causes playbook to
fail as the already existing members are added twice.

This patch refactors membership management by removing duplicate logic
and handling all changes to members in a single place. This change
removed code that was causing the execution failures.

Fix #707 