### PR TITLE
ansible-test fixes

### DIFF
--- a/plugins/modules/ipaautomountmap.py
+++ b/plugins/modules/ipaautomountmap.py
@@ -115,7 +115,7 @@ class AutomountMap(IPAAnsibleModule):
                 self.fail_json(msg="Exactly one name must be provided \
                                 for state=present.")
         if state == "absent":
-            if len(name) == 0 :
+            if len(name) == 0:
                 self.fail_json(msg="Argument 'map_type' can not be used with "
                                    "state 'absent'")
             invalid = ["desc"]

--- a/tests/sanity/ignore-2.12.txt
+++ b/tests/sanity/ignore-2.12.txt
@@ -23,6 +23,8 @@ plugins/modules/ipaserver_setup_ca.py import-2.6!skip
 plugins/modules/ipaserver_test.py pylint:ansible-format-automatic-specification
 plugins/modules/ipaservice.py compile-2.6!skip
 plugins/modules/ipaservice.py import-2.6!skip
+plugins/modules/ipasudorule.py compile-2.6!skip
+plugins/modules/ipasudorule.py import-2.6!skip
 plugins/modules/ipavault.py compile-2.6!skip
 plugins/modules/ipavault.py import-2.6!skip
 roles/ipaclient/library/ipaclient_api.py pylint:ansible-format-automatic-specification


### PR DESCRIPTION
ERROR: plugins/modules/ipaautomountmap.py:118:30: E203: whitespace before ':'

ERROR: Found 1 compile issue(s) on python 2.6 which need to be resolved:
ERROR: plugins/modules/ipasudorule.py:382:63: SyntaxError: {ensure_fqdn(value.lower(), default_domain) for value in host}