### PR TITLE
pre-commit: Update ansible-lint version to v5.3.2

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 ---
 repos:
 - repo: https://github.com/ansible/ansible-lint.git
-  rev: v5.1.2
+  rev: v5.3.2
   hooks:
   - id: ansible-lint
     always_run: false


### PR DESCRIPTION
This fixes the import error for render_group from rich.console.