### PR TITLE
upstream CI: Enable CentOS 8 Stream for PR and nightly tests.

### DIFF
--- a/molecule/c8s-build/Dockerfile
+++ b/molecule/c8s-build/Dockerfile
@@ -1,0 +1,30 @@
+FROM quay.io/centos/centos:stream8
+ENV container=docker
+
+RUN rm -fv /var/cache/dnf/metadata_lock.pid; \
+dnf makecache; \
+dnf --assumeyes install \
+    /usr/bin/python3 \
+    /usr/bin/python3-config \
+    /usr/bin/dnf-3 \
+    sudo \
+    bash \
+    systemd \
+    procps-ng \
+    iproute && \
+dnf clean all; \
+(cd /lib/systemd/system/sysinit.target.wants/; for i in *; do [ $i == systemd-tmpfiles-setup.service ] || rm -f $i; done); \
+rm -f /lib/systemd/system/multi-user.target.wants/*;\
+rm -f /etc/systemd/system/*.wants/*;\
+rm -f /lib/systemd/system/local-fs.target.wants/*; \
+rm -f /lib/systemd/system/sockets.target.wants/*udev*; \
+rm -f /lib/systemd/system/sockets.target.wants/*initctl*; \
+rm -f /lib/systemd/system/basic.target.wants/*;\
+rm -f /lib/systemd/system/anaconda.target.wants/*; \
+rm -rf /var/cache/dnf/;
+
+STOPSIGNAL RTMIN+3
+
+VOLUME ["/sys/fs/cgroup"]
+
+CMD ["/usr/sbin/init"]

--- a/molecule/c8s-build/molecule.yml
+++ b/molecule/c8s-build/molecule.yml
@@ -1,0 +1,18 @@
+---
+driver:
+  name: docker
+platforms:
+  - name: c8s-build
+    image: "quay.io/centos/centos:stream8"
+    dockerfile: Dockerfile
+    hostname: ipaserver.test.local
+    dns_servers:
+      - 8.8.8.8
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    command: /usr/sbin/init
+    privileged: true
+provisioner:
+  name: ansible
+  playbooks:
+    prepare: ../resources/playbooks/prepare-build.yml

--- a/molecule/c8s-build/molecule.yml
+++ b/molecule/c8s-build/molecule.yml
@@ -16,3 +16,4 @@ provisioner:
   name: ansible
   playbooks:
     prepare: ../resources/playbooks/prepare-build.yml
+prerun: false

--- a/molecule/c8s/molecule.yml
+++ b/molecule/c8s/molecule.yml
@@ -1,0 +1,19 @@
+---
+driver:
+  name: docker
+platforms:
+  - name: c8s
+    image: quay.io/ansible-freeipa/upstream-tests:c8s
+    pre_build_image: true
+    hostname: ipaserver.test.local
+    dns_servers:
+      - 127.0.0.1
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    command: /usr/sbin/init
+    privileged: true
+provisioner:
+  name: ansible
+  playbooks:
+    prepare: ../resources/playbooks/prepare.yml
+prerun: false

--- a/tests/azure/azure-pipelines.yml
+++ b/tests/azure/azure-pipelines.yml
@@ -18,15 +18,26 @@ stages:
       scenario: fedora-latest
       ansible_version: ">=2.9,<2.10"
 
-# CentOS 9
+# CentOS 9 Stream
 
-- stage: CentOS9_Ansible_2_9
+- stage: c9s_Ansible_2_9
   dependsOn: []
   jobs:
   - template: templates/group_tests.yml
     parameters:
       build_number: $(Build.BuildNumber)
       scenario: centos-9
+      ansible_version: ">=2.9,<2.10"
+
+# CentOS 8 Stream
+
+- stage: c8s_Ansible_2_9
+  dependsOn: []
+  jobs:
+  - template: templates/group_tests.yml
+    parameters:
+      build_number: $(Build.BuildNumber)
+      scenario: c8s
       ansible_version: ">=2.9,<2.10"
 
 # CentOS 8

--- a/tests/azure/azure-pipelines.yml
+++ b/tests/azure/azure-pipelines.yml
@@ -40,16 +40,16 @@ stages:
       scenario: c8s
       ansible_version: ">=2.9,<2.10"
 
-# CentOS 8
-
-- stage: CentOS8_Ansible_2_9
-  dependsOn: []
-  jobs:
-  - template: templates/group_tests.yml
-    parameters:
-      build_number: $(Build.BuildNumber)
-      scenario: centos-8
-      ansible_version: ">=2.9,<2.10"
+# # CentOS 8
+#
+# - stage: CentOS8_Ansible_2_9
+#   dependsOn: []
+#   jobs:
+#   - template: templates/group_tests.yml
+#     parameters:
+#       build_number: $(Build.BuildNumber)
+#       scenario: centos-8
+#       ansible_version: ">=2.9,<2.10"
 
 # CentOS 7
 

--- a/tests/azure/build-containers.yml
+++ b/tests/azure/build-containers.yml
@@ -29,6 +29,12 @@ jobs:
 
 - template: templates/build_container.yml
   parameters:
+    job_name_suffix: C8S
+    container_name: c8s
+    build_scenario_name: c8s-build
+
+- template: templates/build_container.yml
+  parameters:
     job_name_suffix: Centos9
     container_name: centos-9
     build_scenario_name: centos-9-build

--- a/tests/azure/build-containers.yml
+++ b/tests/azure/build-containers.yml
@@ -21,11 +21,11 @@ jobs:
     container_name: centos-7
     build_scenario_name: centos-7-build
 
-- template: templates/build_container.yml
-  parameters:
-    job_name_suffix: Centos8
-    container_name: centos-8
-    build_scenario_name: centos-8-build
+# - template: templates/build_container.yml
+#   parameters:
+#     job_name_suffix: Centos8
+#     container_name: centos-8
+#     build_scenario_name: centos-8-build
 
 - template: templates/build_container.yml
   parameters:

--- a/tests/azure/nightly.yml
+++ b/tests/azure/nightly.yml
@@ -119,43 +119,43 @@ stages:
       scenario: c8s
       ansible_version: ""
 
-# CentOS 8
-
-- stage: CentOS8_Ansible_2_9
-  dependsOn: []
-  jobs:
-  - template: templates/group_tests.yml
-    parameters:
-      build_number: $(Build.BuildNumber)
-      scenario: centos-8
-      ansible_version: ">=2.9,<2.10"
-
-- stage: CentOS8_Ansible_Core_2_11
-  dependsOn: []
-  jobs:
-  - template: templates/group_tests.yml
-    parameters:
-      build_number: $(Build.BuildNumber)
-      scenario: centos-8
-      ansible_version: "-core >=2.11,<2.12"
-
-- stage: CentOS8_Ansible_Core_2_12
-  dependsOn: []
-  jobs:
-  - template: templates/group_tests.yml
-    parameters:
-      build_number: $(Build.BuildNumber)
-      scenario: centos-8
-      ansible_version: "-core >=2.12,<2.13"
-
-- stage: CentOS8_Ansible_latest
-  dependsOn: []
-  jobs:
-  - template: templates/group_tests.yml
-    parameters:
-      build_number: $(Build.BuildNumber)
-      scenario: centos-8
-      ansible_version: ""
+# # CentOS 8
+#
+# - stage: CentOS8_Ansible_2_9
+#   dependsOn: []
+#   jobs:
+#   - template: templates/group_tests.yml
+#     parameters:
+#       build_number: $(Build.BuildNumber)
+#       scenario: centos-8
+#       ansible_version: ">=2.9,<2.10"
+#
+# - stage: CentOS8_Ansible_Core_2_11
+#   dependsOn: []
+#   jobs:
+#   - template: templates/group_tests.yml
+#     parameters:
+#       build_number: $(Build.BuildNumber)
+#       scenario: centos-8
+#       ansible_version: "-core >=2.11,<2.12"
+#
+# - stage: CentOS8_Ansible_Core_2_12
+#   dependsOn: []
+#   jobs:
+#   - template: templates/group_tests.yml
+#     parameters:
+#       build_number: $(Build.BuildNumber)
+#       scenario: centos-8
+#       ansible_version: "-core >=2.12,<2.13"
+#
+# - stage: CentOS8_Ansible_latest
+#   dependsOn: []
+#   jobs:
+#   - template: templates/group_tests.yml
+#     parameters:
+#       build_number: $(Build.BuildNumber)
+#       scenario: centos-8
+#       ansible_version: ""
 
 # CentOS 7
 

--- a/tests/azure/nightly.yml
+++ b/tests/azure/nightly.yml
@@ -52,7 +52,7 @@ stages:
       scenario: fedora-latest
       ansible_version: ""
 
-# CentoOS 9
+# CentoOS 9 Stream
 
 - stage: CentOS9_Ansible_2_9
   dependsOn: []
@@ -79,6 +79,44 @@ stages:
     parameters:
       build_number: $(Build.BuildNumber)
       scenario: centos-9
+      ansible_version: ""
+
+# CentOS 8 Stream
+
+- stage: c8s_Ansible_2_9
+  dependsOn: []
+  jobs:
+  - template: templates/group_tests.yml
+    parameters:
+      build_number: $(Build.BuildNumber)
+      scenario: c8s
+      ansible_version: ">=2.9,<2.10"
+
+- stage: c8s_Ansible_Core_2_11
+  dependsOn: []
+  jobs:
+  - template: templates/group_tests.yml
+    parameters:
+      build_number: $(Build.BuildNumber)
+      scenario: centos-8
+      ansible_version: "-core >=2.11,<2.12"
+
+- stage: c8s_Ansible_Core_2_12
+  dependsOn: []
+  jobs:
+  - template: templates/group_tests.yml
+    parameters:
+      build_number: $(Build.BuildNumber)
+      scenario: c8s
+      ansible_version: "-core >=2.12,<2.13"
+
+- stage: c8s_Ansible_latest
+  dependsOn: []
+  jobs:
+  - template: templates/group_tests.yml
+    parameters:
+      build_number: $(Build.BuildNumber)
+      scenario: c8s
       ansible_version: ""
 
 # CentOS 8

--- a/tests/azure/templates/build_container.yml
+++ b/tests/azure/templates/build_container.yml
@@ -6,6 +6,9 @@ parameters:
     type: string
   - name: build_scenario_name
     type: string
+  - name: python_version
+    type: string
+    default: 3.x
 
 jobs:
 - job: BuildTestImage${{ parameters.job_name_suffix }}
@@ -13,7 +16,7 @@ jobs:
   steps:
   - task: UsePythonVersion@0
     inputs:
-      versionSpec: '3.6'
+      versionSpec: '${{ parameters.python_version }}'
 
   - script: python -m pip install --upgrade pip setuptools wheel ansible
     displayName: Install tools

--- a/tests/azure/templates/group_tests.yml
+++ b/tests/azure/templates/group_tests.yml
@@ -2,7 +2,7 @@
 parameters:
   - name: scenario
     type: string
-    default: centos-8
+    default: fedora-latest
   - name: build_number
     type: string
   - name: ansible_version

--- a/tests/azure/templates/playbook_tests.yml
+++ b/tests/azure/templates/playbook_tests.yml
@@ -8,7 +8,7 @@ parameters:
     default: 1
   - name: scenario
     type: string
-    default: centos-8
+    default: fedora-latest
   - name: ansible_version
     type: string
     default: ""

--- a/tests/azure/templates/pytest_tests.yml
+++ b/tests/azure/templates/pytest_tests.yml
@@ -4,6 +4,7 @@ parameters:
     type: string
   - name: scenario
     type: string
+    default: fedora-latest
   - name: ansible_version
     type: string
     default: ""


### PR DESCRIPTION
Add configuration to execute build a testing CentOS 8 stream image and
to execute upstream tests using that image in pull requests (Ansible
2.9) and on the nightly tests (all supported Ansible versions).