### PR TITLE
ipaclient_get_keytab: Do not use gssapi for kinit_keytab

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,6 @@ Requirements
 **Controller**
 * Ansible version: 2.8+ (ansible-freeipa is an Ansible Collection)
 * /usr/bin/kinit is required on the controller if a one time password (OTP) is used
-* python3-gssapi is required on the controller if a one time password (OTP) is used with keytab to install the client.
 
 **Node**
 * Supported FreeIPA version (see above)
@@ -285,7 +284,8 @@ ipaserver_domain=test.local
 ipaserver_realm=TEST.LOCAL
 ```
 
-For enhanced security it is possible to use a auto-generated one-time-password (OTP). This will be generated on the controller using the (first) server. It is needed to have the python-gssapi bindings installed on the controller for this.
+For enhanced security it is possible to use a auto-generated one-time-password (OTP). This will be generated on the controller using the (first) server.
+
 To enable the generation of the one-time-password:
 ```yaml
 [ipaclients:vars]

--- a/roles/ipaclient/README.md
+++ b/roles/ipaclient/README.md
@@ -33,7 +33,6 @@ Requirements
 **Controller**
 * Ansible version: 2.8+
 * /usr/bin/kinit is required on the controller if a one time password (OTP) is used
-* python3-gssapi is required on the controller if a one time password (OTP) is used with keytab
 
 **Node**
 * Supported FreeIPA version (see above)

--- a/roles/ipaclient/action_plugins/ipaclient_get_otp.py
+++ b/roles/ipaclient/action_plugins/ipaclient_get_otp.py
@@ -21,10 +21,6 @@ from __future__ import (absolute_import, division, print_function)
 
 __metaclass__ = type
 
-try:
-    import gssapi
-except ImportError:
-    gssapi = None
 import os
 import shutil
 import subprocess
@@ -82,22 +78,17 @@ def kinit_keytab(principal, keytab, ccache_name, config):
     It uses the specified config file to kinit and stores the TGT
     in ccache_name.
     """
-    if gssapi is None:
-        raise ImportError("gssapi is not available")
-
+    args = ["/usr/bin/kinit", "-kt", keytab, "-c", ccache_name, principal]
     old_config = os.environ.get('KRB5_CONFIG')
-    os.environ['KRB5_CONFIG'] = config
+    os.environ["KRB5_CONFIG"] = config
+
     try:
-        name = gssapi.Name(principal, gssapi.NameType.kerberos_principal)
-        store = {'ccache': ccache_name,
-                 'client_keytab': keytab}
-        cred = gssapi.Credentials(name=name, store=store, usage='initiate')
-        return cred
+        return run_cmd(args)
     finally:
         if old_config is not None:
-            os.environ['KRB5_CONFIG'] = old_config
+            os.environ["KRB5_CONFIG"] = old_config
         else:
-            os.environ.pop('KRB5_CONFIG', None)
+            os.environ.pop("KRB5_CONFIG", None)
 
 
 KRB5CONF_TEMPLATE = """


### PR DESCRIPTION
Due to a change in Ansible to depend on Python 3.8 it is needed to only
use bindings that are provided by Python and Ansible core. gssapi is
therefore not usable any more.

The kinit_keytab function was using gssapi and now has to use the kinit
command insead.