### PR TITLE
dnsconfig: Fix management of forwarders.

### DIFF
--- a/plugins/modules/ipadnsconfig.py
+++ b/plugins/modules/ipadnsconfig.py
@@ -144,8 +144,8 @@ def gen_args(module, state, dnsconfig, forwarders, forward_policy,
                 _args['idnsforwarders'] = ['']
 
         elif state == 'present':
-            _args['idnsforwarders'] = [
-                fwd for fwd in _forwarders if fwd not in global_forwarders]
+            _args['idnsforwarders'] = \
+                list(set(list(_forwarders) + list(global_forwarders)))
             # If no forwarders should be added, remove argument.
             if not _args['idnsforwarders']:
                 del _args['idnsforwarders']

--- a/tests/dnsconfig/test_dnsconfig.yml
+++ b/tests/dnsconfig/test_dnsconfig.yml
@@ -171,7 +171,6 @@
     register: result
     failed_when: not result.changed or result.failed
 
-
   - name: Ensure all forwarders are absent, again.
     ipadnsconfig:
       ipaadmin_password: SomeADMINpassword
@@ -182,6 +181,54 @@
         - ip_address: 2001:4860:4860::8888
           port: 53
       state: absent
+    register: result
+    failed_when: result.changed or result.failed
+
+  - name: Ensure forwarder is present.
+    ipadnsconfig:
+      ipaadmin_password: SomeADMINpassword
+      ipaapi_context: "{{ ipa_context | default(omit) }}"
+      forwarders:
+        - ip_address: 8.8.8.8
+    register: result
+    failed_when: not result.changed or result.failed
+
+  - name: Ensure forwarders are present.
+    ipadnsconfig:
+      ipaadmin_password: SomeADMINpassword
+      ipaapi_context: "{{ ipa_context | default(omit) }}"
+      forwarders:
+        - ip_address: 8.8.4.4
+        - ip_address: 8.8.8.8
+    register: result
+    failed_when: not result.changed or result.failed
+
+  - name: Ensure forwarders are present, again.
+    ipadnsconfig:
+      ipaadmin_password: SomeADMINpassword
+      ipaapi_context: "{{ ipa_context | default(omit) }}"
+      forwarders:
+        - ip_address: 8.8.4.4
+        - ip_address: 8.8.8.8
+    register: result
+    failed_when: result.changed or result.failed
+
+  - name: Ensure another forwarder is present.
+    ipadnsconfig:
+      ipaadmin_password: SomeADMINpassword
+      ipaapi_context: "{{ ipa_context | default(omit) }}"
+      forwarders:
+        - ip_address: 8.8.4.4
+    register: result
+    failed_when: result.changed or result.failed
+
+  - name: Ensure forwarders are present.
+    ipadnsconfig:
+      ipaadmin_password: SomeADMINpassword
+      ipaapi_context: "{{ ipa_context | default(omit) }}"
+      forwarders:
+        - ip_address: 8.8.4.4
+        - ip_address: 8.8.8.8
     register: result
     failed_when: result.changed or result.failed
 


### PR DESCRIPTION
If one tries to set a list of forwarders which include an already
existing forwarder, the existing forwarder is removed, and the list
of configured forwarders contain only the new ones.

This patch fixes this behavior by setting a union of the currently
available forwarders and the list of forwarders provided in the
playbook.

Tests were added to ensure this behavior.

Fix issue #512