### PR TITLE
dnsconfig: add support for 'action: member'.

### DIFF
--- a/README-dnsconfig.md
+++ b/README-dnsconfig.md
@@ -71,6 +71,7 @@ Example playbook to ensure a global forwarder, with a custom port, is absent:
       forwarders:
           - ip_address: 2001:4860:4860::8888
             port: 53
+      action: member
       state: absent
 ```
 
@@ -130,7 +131,8 @@ Variable | Description | Required
 &nbsp; | `port` - The custom port that should be used on this server. | no
 `forward_policy` | The global forwarding policy. It can be one of `only`, `first`, or `none`.  | no
 `allow_sync_ptr` | Allow synchronization of forward (A, AAAA) and reverse (PTR) records (bool). | yes
-`state` | The state to ensure. It can be one of `present` or `absent`, default: `present`. | yes
+`action` | Work on dnsconfig or member level. It can be one of `member` or `dnsconfig` and defaults to `dnsconfig`. Only `forwarders` can be managed with `action: member`. | no
+`state` | The state to ensure. It can be one of `present` or `absent`, default: `present`. `absent` can only be used with `action: member` and `forwarders`. | yes
 
 
 Authors

--- a/tests/dnsconfig/test_dnsconfig.yml
+++ b/tests/dnsconfig/test_dnsconfig.yml
@@ -17,6 +17,7 @@
         - ip_address: 2001:4860:4860::8888
           port: 53
       state: absent
+      action: member
 
   # Tests.
   - name: Set config to invalid IPv4.
@@ -74,23 +75,72 @@
     register: result
     failed_when: result.changed or result.failed
 
-  - name: Ensure forwarder is absent.
+  - name: Ensure forwarder 8.8.8.8 is absent.
     ipadnsconfig:
       ipaadmin_password: SomeADMINpassword
       ipaapi_context: "{{ ipa_context | default(omit) }}"
       forwarders:
         - ip_address: 8.8.8.8
       state: absent
+      action: member
     register: result
     failed_when: not result.changed or result.failed
 
-  - name: Ensure forwarder is absent, again.
+  - name: Ensure forwarder 8.8.8.8 is absent, again.
     ipadnsconfig:
       ipaadmin_password: SomeADMINpassword
       ipaapi_context: "{{ ipa_context | default(omit) }}"
       forwarders:
         - ip_address: 8.8.8.8
       state: absent
+      action: member
+    register: result
+    failed_when: result.changed or result.failed
+
+  - name: Ensure forwarder 8.8.4.4 is present.
+    ipadnsconfig:
+      ipaadmin_password: SomeADMINpassword
+      ipaapi_context: "{{ ipa_context | default(omit) }}"
+      forwarders:
+        - ip_address: 8.8.4.4
+    register: result
+    failed_when: not result.changed or result.failed
+
+  - name: Ensure forwarder 8.8.8.8 is present.
+    ipadnsconfig:
+      ipaadmin_password: SomeADMINpassword
+      ipaapi_context: "{{ ipa_context | default(omit) }}"
+      forwarders:
+        - ip_address: 8.8.8.8
+    register: result
+    failed_when: not result.changed or result.failed
+
+  - name: Ensure forwarder 8.8.4.4 is present.
+    ipadnsconfig:
+      ipaadmin_password: SomeADMINpassword
+      ipaapi_context: "{{ ipa_context | default(omit) }}"
+      forwarders:
+        - ip_address: 8.8.4.4
+    register: result
+    failed_when: not result.changed or result.failed
+
+  - name: Ensure forwarders are absent.
+    ipadnsconfig:
+      ipaadmin_password: SomeADMINpassword
+      ipaapi_context: "{{ ipa_context | default(omit) }}"
+      forwarders:
+        - ip_address: 8.8.4.4
+        - ip_address: 8.8.8.8
+    register: result
+    failed_when: not result.changed or result.failed
+
+  - name: Ensure forwarders are absent, again.
+    ipadnsconfig:
+      ipaadmin_password: SomeADMINpassword
+      ipaapi_context: "{{ ipa_context | default(omit) }}"
+      forwarders:
+        - ip_address: 8.8.4.4
+        - ip_address: 8.8.8.8
     register: result
     failed_when: result.changed or result.failed
 
@@ -168,6 +218,7 @@
         - ip_address: 2001:4860:4860::8888
           port: 53
       state: absent
+      action: member
     register: result
     failed_when: not result.changed or result.failed
 
@@ -181,6 +232,7 @@
         - ip_address: 2001:4860:4860::8888
           port: 53
       state: absent
+      action: member
     register: result
     failed_when: result.changed or result.failed
 
@@ -193,6 +245,16 @@
     register: result
     failed_when: not result.changed or result.failed
 
+  - name: Ensure forwarders is not present.
+    ipadnsconfig:
+      ipaadmin_password: SomeADMINpassword
+      ipaapi_context: "{{ ipa_context | default(omit) }}"
+      forwarders:
+        - ip_address: 8.8.4.4
+    check_mode: yes
+    register: result
+    failed_when: not result.changed or result.failed
+
   - name: Ensure forwarders are present.
     ipadnsconfig:
       ipaadmin_password: SomeADMINpassword
@@ -200,6 +262,7 @@
       forwarders:
         - ip_address: 8.8.4.4
         - ip_address: 8.8.8.8
+      action: member
     register: result
     failed_when: not result.changed or result.failed
 
@@ -210,6 +273,7 @@
       forwarders:
         - ip_address: 8.8.4.4
         - ip_address: 8.8.8.8
+      action: member
     register: result
     failed_when: result.changed or result.failed
 
@@ -219,6 +283,7 @@
       ipaapi_context: "{{ ipa_context | default(omit) }}"
       forwarders:
         - ip_address: 8.8.4.4
+      action: member
     register: result
     failed_when: result.changed or result.failed
 
@@ -229,6 +294,7 @@
       forwarders:
         - ip_address: 8.8.4.4
         - ip_address: 8.8.8.8
+      action: member
     register: result
     failed_when: result.changed or result.failed
 
@@ -244,3 +310,4 @@
         - ip_address: 2001:4860:4860::8888
           port: 53
       state: absent
+      action: member


### PR DESCRIPTION
This patch adds support for 'action: member' for ipadnsconfig plugin,
impacting management of DNS forwarders setting.

Use of 'state: absent' now requires 'action: member'. With 'state:
present', orwarders can be either defined through 'action: dnsconfig'
or added using 'action: member'.

This PR includes commit 95a3da8a73def6c223c806f86411b94c258a4d8f from #735