### PR TITLE
User tests: Extend expiration dates for client on server test

### DIFF
--- a/tests/user/test_user.yml
+++ b/tests/user/test_user.yml
@@ -51,8 +51,8 @@
       gid: 100
       phone: "+555123457"
       email: pinky@acme.com
-      principalexpiration: "20220119235959"
-      #passwordexpiration: "2022-01-19 23:59:59"
+      principalexpiration: "21220119235959"
+      passwordexpiration: "2122-01-19 23:59:59"
       first: pinky
       last: Acme
       initials: pa

--- a/tests/user/test_users.yml
+++ b/tests/user/test_users.yml
@@ -143,8 +143,8 @@
       gid: 100
       phone: "+555123457"
       email: pinky@acme.com
-      principalexpiration: "20220119235959"
-      #passwordexpiration: "2022-01-19 23:59:59"
+      principalexpiration: "21220119235959"
+      passwordexpiration: "2122-01-19 23:59:59"
       first: pinky
       last: Acme
       initials: pa
@@ -186,8 +186,8 @@
       gid: 100
       phone: "+555123457"
       email: pinky@acme.com
-      principalexpiration: "20220119235959"
-      #passwordexpiration: "2022-01-19 23:59:59"
+      principalexpiration: "21220119235959"
+      passwordexpiration: "2122-01-19 23:59:59"
       first: pinky
       last: Acme
       initials: pa


### PR DESCRIPTION
The client context on server test is failing with a date that is
expired. The server context on server test is not failing.

Setting an expired date with the command line is possible though.