### PR TITLE
automountmap: Add client context test playbook.

### DIFF
--- a/tests/automount/test_automountmap.yml
+++ b/tests/automount/test_automountmap.yml
@@ -1,6 +1,6 @@
 ---
 - name: Test automountmap
-  hosts: ipaserver
+  hosts: "{{ ipa_test_host | default('ipaserver') }}"
   become: no
   gather_facts: no
 

--- a/tests/automount/test_automountmap_client_context.yml
+++ b/tests/automount/test_automountmap_client_context.yml
@@ -1,0 +1,40 @@
+---
+- name: Test automountmap
+  hosts: ipaclients, ipaserver
+  become: no
+  gather_facts: no
+
+  tasks:
+  - name: Include FreeIPA facts.
+    include_tasks: ../env_freeipa_facts.yml
+
+  # Test will only be executed if host is not a server.
+  - name: Execute with server context in the client.
+    ipaautomountmap:
+      ipaadmin_password: SomeADMINpassword
+      ipaapi_context: server
+      location: default
+      name: ThisShouldNotWork
+    register: result
+    failed_when: not (result.failed and result.msg is regex("No module named '*ipaserver'*"))
+    when: ipa_host_is_client
+
+# Import basic module tests, and execute with ipa_context set to 'client'.
+# If ipaclients is set, it will be executed using the client, if not,
+# ipaserver will be used.
+#
+# With this setup, tests can be executed against an IPA client, against
+# an IPA server using "client" context, and ensure that tests are executed
+# in upstream CI.
+
+- name: Test automountmap using client context, in client host.
+  import_playbook: test_automountmap.yml
+  when: groups['ipaclients']
+  vars:
+    ipa_test_host: ipaclients
+
+- name: Test automountmap using client context, in server host.
+  import_playbook: test_automountmap.yml
+  when: groups['ipaclients'] is not defined or not groups['ipaclients']
+  vars:
+    ipa_context: client


### PR DESCRIPTION
The client context test playbook was missing for ipaautomountmap.