### PR TITLE
sudorule: Fix management of deny_sudocmdgroup.

### DIFF
--- a/plugins/modules/ipasudorule.py
+++ b/plugins/modules/ipasudorule.py
@@ -544,7 +544,7 @@ def main():
                     if deny_sudocmdgroup is not None:
                         deny_cmdgroup_add = gen_add_list(
                             deny_sudocmdgroup,
-                            res_find("memberdenycmd_sudocmdgroup")
+                            res_find.get("memberdenycmd_sudocmdgroup")
                         )
                     if sudooption is not None:
                         sudooption_add = gen_add_list(

--- a/tests/sudorule/test_sudorule.yml
+++ b/tests/sudorule/test_sudorule.yml
@@ -58,6 +58,7 @@
       name:
           - /sbin/ifconfig
           - /usr/bin/vim
+          - /usr/bin/emacs
       state: present
 
   - name: Ensure sudocmdgroup is available
@@ -66,6 +67,14 @@
       ipaapi_context: "{{ ipa_context | default(omit) }}"
       name: test_sudorule
       sudocmd: /usr/bin/vim
+      state: present
+
+  - name: Ensure sudocmdgroup is available
+    ipasudocmdgroup:
+      ipaadmin_password: SomeADMINpassword
+      ipaapi_context: "{{ ipa_context | default(omit) }}"
+      name: test_sudorule2
+      sudocmd: /usr/bin/emacs
       state: present
 
   - name: Ensure sudorules are absent
@@ -606,6 +615,7 @@
       ipaapi_context: "{{ ipa_context | default(omit) }}"
       name: testrule1
       allow_sudocmdgroup: test_sudorule
+      action: member
       state: present
     register: result
     failed_when: not result.changed or result.failed
@@ -616,6 +626,7 @@
       ipaapi_context: "{{ ipa_context | default(omit) }}"
       name: testrule1
       allow_sudocmdgroup: test_sudorule
+      action: member
       state: present
     register: result
     failed_when: result.changed or result.failed
@@ -648,6 +659,7 @@
       ipaapi_context: "{{ ipa_context | default(omit) }}"
       name: testrule1
       deny_sudocmdgroup: test_sudorule
+      action: member
       state: present
     register: result
     failed_when: not result.changed or result.failed
@@ -658,6 +670,7 @@
       ipaapi_context: "{{ ipa_context | default(omit) }}"
       name: testrule1
       deny_sudocmdgroup: test_sudorule
+      action: member
       state: present
     register: result
     failed_when: result.changed or result.failed
@@ -683,6 +696,114 @@
       state: absent
     register: result
     failed_when: result.changed or result.failed
+
+  - name: Ensure sudorule is present, with `test_sudorule` sudocmdgroup in allow_sudocmdgroup.
+    ipasudorule:
+      ipaadmin_password: SomeADMINpassword
+      ipaapi_context: "{{ ipa_context | default(omit) }}"
+      name: testrule1
+      allow_sudocmdgroup: test_sudorule
+      state: present
+    register: result
+    failed_when: not result.changed or result.failed
+
+  - name: Ensure sudorule is present, with `test_sudorule2` sudocmdgroup in allow_sudocmdgroup.
+    ipasudorule:
+      ipaadmin_password: SomeADMINpassword
+      ipaapi_context: "{{ ipa_context | default(omit) }}"
+      name: testrule1
+      allow_sudocmdgroup: test_sudorule2
+      state: present
+    register: result
+    failed_when: not result.changed or result.failed
+
+  - name: Ensure sudorule is present, with both sudocmdgroup in allow_sudocmdgroup.
+    ipasudorule:
+      ipaadmin_password: SomeADMINpassword
+      ipaapi_context: "{{ ipa_context | default(omit) }}"
+      name: testrule1
+      allow_sudocmdgroup:
+        - test_sudorule
+        - test_sudorule2
+      state: present
+    register: result
+    failed_when: not result.changed or result.failed
+
+  - name: Ensure sudorule is present, with both sudocmdgroup, again.
+    ipasudorule:
+      ipaadmin_password: SomeADMINpassword
+      ipaapi_context: "{{ ipa_context | default(omit) }}"
+      name: testrule1
+      allow_sudocmdgroup:
+        - test_sudorule
+        - test_sudorule2
+      state: present
+    register: result
+    failed_when: result.changed or result.failed
+
+  - name: Ensure sudorule is present, with only `test_sudorule` sudocmdgroup in allow_sudocmdgroup.
+    ipasudorule:
+      ipaadmin_password: SomeADMINpassword
+      ipaapi_context: "{{ ipa_context | default(omit) }}"
+      name: testrule1
+      allow_sudocmdgroup: test_sudorule
+      state: present
+    register: result
+    failed_when: not result.changed or result.failed
+
+  - name: Ensure sudorule is present, with `test_sudorule` sudocmdgroup in deny_sudocmdgroup.
+    ipasudorule:
+      ipaadmin_password: SomeADMINpassword
+      ipaapi_context: "{{ ipa_context | default(omit) }}"
+      name: testrule1
+      deny_sudocmdgroup: test_sudorule
+      state: present
+    register: result
+    failed_when: not result.changed or result.failed
+
+  - name: Ensure sudorule is present, with `test_sudorule2` sudocmdgroup in deny_sudocmdgroup.
+    ipasudorule:
+      ipaadmin_password: SomeADMINpassword
+      ipaapi_context: "{{ ipa_context | default(omit) }}"
+      name: testrule1
+      deny_sudocmdgroup: test_sudorule2
+      state: present
+    register: result
+    failed_when: not result.changed or result.failed
+
+  - name: Ensure sudorule is present, with both sudocmdgroup in deny_sudocmdgroup.
+    ipasudorule:
+      ipaadmin_password: SomeADMINpassword
+      ipaapi_context: "{{ ipa_context | default(omit) }}"
+      name: testrule1
+      deny_sudocmdgroup:
+        - test_sudorule
+        - test_sudorule2
+      state: present
+    register: result
+    failed_when: not result.changed or result.failed
+
+  - name: Ensure sudorule is present, with both sudocmdgroup, again.
+    ipasudorule:
+      ipaadmin_password: SomeADMINpassword
+      ipaapi_context: "{{ ipa_context | default(omit) }}"
+      name: testrule1
+      deny_sudocmdgroup:
+        - test_sudorule
+        - test_sudorule2
+      state: present
+    register: result
+    failed_when: result.changed or result.failed
+
+  - name: Ensure sudorule is present, with only `test_sudorule` sudocmdgroup in deny_sudocmdgroup.
+    ipasudorule:
+      ipaadmin_password: SomeADMINpassword
+      ipaapi_context: "{{ ipa_context | default(omit) }}"
+      name: testrule1
+      deny_sudocmdgroup: test_sudorule
+      state: present
+    register: result
+    failed_when: not result.changed or result.failed
 
   - name: Ensure sudorule is absent
     ipasudorule:
@@ -889,7 +1010,9 @@
     ipasudocmdgroup:
       ipaadmin_password: SomeADMINpassword
       ipaapi_context: "{{ ipa_context | default(omit) }}"
-      name: test_sudorule
+      name:
+      - test_sudorule
+      - test_sudorule2
       state: absent
 
   - name: Ensure sudocmds are absent
@@ -899,6 +1022,7 @@
       name:
       - /sbin/ifconfig
       - /usr/bin/vim
+      - /usr/bin/emacs
       state: absent
 
   - name: Ensure sudorules are absent


### PR DESCRIPTION
Upstream tests were not testing one path of code related to variable
`deny_sudocmdgroup`, and a regression was added.

This patch fixes a call to the current configuration dictionary, and
add tests so that the code path is executed in the upstream tests.