### PR TITLE
dnsconfig: Add 'action: member' to dnsconfig example playbooks.

### DIFF
--- a/playbooks/dnsconfig/forwarders-present.yml
+++ b/playbooks/dnsconfig/forwarders-present.yml
@@ -11,4 +11,3 @@
         - ip_address: 2001:4860:4860::8888
           port: 53
       action: member
-      state: absent


### PR DESCRIPTION
As of verison 1.6.1 of ansible-freeipa, ipadnsconfig supports
'action: member' to manage DNS forwardes, and requires the use of this
action if 'state: present'.

This patch fixes the playbook examples.