### PR TITLE
automountmap: Fix argument handling.

### DIFF
--- a/plugins/module_utils/ansible_freeipa_module.py
+++ b/plugins/module_utils/ansible_freeipa_module.py
@@ -338,52 +338,46 @@ else:
         filtered_args = [key for key in args if key not in ignore]
 
         for key in filtered_args:
-            if key not in ipa:  # pylint: disable=no-else-return
-                module.debug(
-                    base_debug_msg + "Command key not present in IPA: %s" % key
-                )
-                return False
+            arg = args[key]
+            ipa_arg = ipa.get(key, [""])
+            # If ipa_arg is a list and arg is not, replace arg
+            # with list containing arg. Most args in a find result
+            # are lists, but not all.
+            if isinstance(ipa_arg, tuple):
+                ipa_arg = list(ipa_arg)
+            if isinstance(ipa_arg, list):
+                if not isinstance(arg, list):
+                    arg = [arg]
+                if len(ipa_arg) != len(arg):
+                    module.debug(
+                        base_debug_msg
+                        + "List length doesn't match for key %s: %d %d"
+                        % (key, len(arg), len(ipa_arg),)
+                    )
+                    return False
+                if isinstance(ipa_arg[0], str) and isinstance(arg[0], int):
+                    arg = [to_text(_arg) for _arg in arg]
+                if isinstance(ipa_arg[0], unicode) \
+                   and isinstance(arg[0], int):
+                    arg = [to_text(_arg) for _arg in arg]
+            try:
+                arg_set = set(arg)
+                ipa_arg_set = set(ipa_arg)
+            except TypeError:
+                if arg != ipa_arg:
+                    module.debug(
+                        base_debug_msg
+                        + "Different values: %s %s" % (arg, ipa_arg)
+                    )
+                    return False
             else:
-                arg = args[key]
-                ipa_arg = ipa[key]
-                # If ipa_arg is a list and arg is not, replace arg
-                # with list containing arg. Most args in a find result
-                # are lists, but not all.
-                if isinstance(ipa_arg, tuple):
-                    ipa_arg = list(ipa_arg)
-                if isinstance(ipa_arg, list):
-                    if not isinstance(arg, list):
-                        arg = [arg]
-                    if len(ipa_arg) != len(arg):
-                        module.debug(
-                            base_debug_msg
-                            + "List length doesn't match for key %s: %d %d"
-                            % (key, len(arg), len(ipa_arg),)
-                        )
-                        return False
-                    if isinstance(ipa_arg[0], str) and isinstance(arg[0], int):
-                        arg = [to_text(_arg) for _arg in arg]
-                    if isinstance(ipa_arg[0], unicode) \
-                       and isinstance(arg[0], int):
-                        arg = [to_text(_arg) for _arg in arg]
-                try:
-                    arg_set = set(arg)
-                    ipa_arg_set = set(ipa_arg)
-                except TypeError:
-                    if arg != ipa_arg:
-                        module.debug(
-                            base_debug_msg
-                            + "Different values: %s %s" % (arg, ipa_arg)
-                        )
-                        return False
-                else:
-                    if arg_set != ipa_arg_set:
-                        module.debug(
-                            base_debug_msg
-                            + "Different set content: %s %s"
-                            % (arg_set, ipa_arg_set,)
-                        )
-                        return False
+                if arg_set != ipa_arg_set:
+                    module.debug(
+                        base_debug_msg
+                        + "Different set content: %s %s"
+                        % (arg_set, ipa_arg_set,)
+                    )
+                    return False
         return True
 
     def _afm_convert(value):

--- a/plugins/modules/ipaautomountmap.py
+++ b/plugins/modules/ipaautomountmap.py
@@ -123,10 +123,8 @@ class AutomountMap(IPAAnsibleModule):
         self.params_fail_used_invalid(invalid, state)
 
     def get_args(self, mapname, desc):  # pylint: disable=no-self-use
-        _args = {}
-        if mapname:
-            _args["automountmapname"] = mapname
-        if desc:
+        _args = {"automountmapname": mapname}
+        if desc is not None:
             _args["description"] = desc
         return _args
 

--- a/tests/automount/test_automountmap.yml
+++ b/tests/automount/test_automountmap.yml
@@ -71,6 +71,24 @@
       register: result
       failed_when: result.failed or result.changed
 
+    - name: ensure map TestMap has an empty description
+      ipaautomountmap:
+        ipaadmin_password: SomeADMINpassword
+        name: TestMap
+        location: TestLocation
+        desc: ""
+      register: result
+      failed_when: result.failed or not result.changed
+
+    - name: ensure map TestMap has an empty description, again
+      ipaautomountmap:
+        ipaadmin_password: SomeADMINpassword
+        name: TestMap
+        location: TestLocation
+        desc: ""
+      register: result
+      failed_when: result.failed or result.changed
+
     - name: ensure map TestMap is removed
       ipaautomountmap:
         ipaadmin_password: SomeADMINpassword


### PR DESCRIPTION
Ensure a failure is raised when map name is not provided for arguments,
and allows an empty description to be used to clear automount map
description.

Depends on PR #780 