### PR TITLE
Fixes `no_log` warning for `ipahost` module

### DIFF
--- a/plugins/modules/ipahost.py
+++ b/plugins/modules/ipahost.py
@@ -709,7 +709,7 @@ def main():
                        elements='dict', required=False),
 
             # mod
-            update_password=dict(type='str', default=None,
+            update_password=dict(type='str', default=None, no_log=False,
                                  choices=['always', 'on_create']),
 
             # general


### PR DESCRIPTION
Similar to [PR 286](https://github.com/freeipa/ansible-freeipa/pull/286), but applicable to the `ipahost` module.

This PR explicitly sets `no_log` option for `update_password` attribute to `False`, so that the warning on `no_log` not being set is not issued anymore. Ansible incorrectly issued the warning, as `update_password` does not carry sensitive information.