### PR TITLE
IPAAnsibleModule: Provide base configuration for delete_continue.

### DIFF
--- a/plugins/doc_fragments/ipamodule_base_docs.py
+++ b/plugins/doc_fragments/ipamodule_base_docs.py
@@ -45,3 +45,13 @@ options:
     type: bool
     default: true
 """
+
+    DELETE_CONTINUE = r"""
+options:
+  delete_continue:
+    description: |
+      Continuous mode. Don't stop on errors. Valid only if `state` is `absent`.
+    aliases: ["continue"]
+    type: bool
+    default: True
+"""

--- a/plugins/module_utils/ansible_freeipa_module.py
+++ b/plugins/module_utils/ansible_freeipa_module.py
@@ -826,12 +826,28 @@ else:
             ipaapi_ldap_cache=dict(type="bool", default="True"),
         )
 
+        ipa_module_options_spec = dict(
+            delete_continue=dict(
+                type="bool", default=True, aliases=["continue"]
+            )
+        )
+
         def __init__(self, *args, **kwargs):
             # Extend argument_spec with ipa_module_base_spec
             if "argument_spec" in kwargs:
                 _spec = kwargs["argument_spec"]
                 _spec.update(self.ipa_module_base_spec)
                 kwargs["argument_spec"] = _spec
+
+            if "ipa_module_options" in kwargs:
+                _update = {
+                    k: self.ipa_module_options_spec[k]
+                    for k in kwargs["ipa_module_options"]
+                }
+                _spec = kwargs.get("argument_spec", {})
+                _spec.update(_update)
+                kwargs["argument_spec"] = _spec
+                del kwargs["ipa_module_options"]
 
             # pylint: disable=super-with-arguments
             super(IPAAnsibleModule, self).__init__(*args, **kwargs)


### PR DESCRIPTION
Allows the creation of IPAAnsibleModule objects with specific
`ipa_arguments` which are defined in a dictionary of argumets in
the base class.

Every module using `delete_continue` should provide the proper behavior
and the module must be instantiated with:

  ansible_module = IPAAnsibleModule(
      ...,
      ipa_arguments=["delete_continue"]
  )

The plugin documentation must be extended with
'ipamodule_arguments.delete_continue'.