### PR TITLE
build-galaxy-release: Fix refs for all doc_fragments in plugins/doc_fragments

### DIFF
--- a/utils/build-galaxy-release.sh
+++ b/utils/build-galaxy-release.sh
@@ -118,11 +118,15 @@ sed -i -e "s/ansible.module_utils.ansible_freeipa_module/ansible_collections.${c
     ln -sf ../../roles/*/action_plugins/*.py .
 })
 
-echo "Fixing doc fragments in plugins/modules..."
-for file in plugins/modules/*.py; do
-    sed -i -e "s/- ipamodule_base_docs/- ${collection_prefix}.ipamodule_base_docs/" "$file"
+for doc_fragment in plugins/doc_fragments/*.py; do
+    fragment=$(basename -s .py "$doc_fragment")
+
+    echo "Fixing doc fragments for ${fragment} in plugins/modules..."
+    for file in plugins/modules/*.py; do
+        sed -i -e "s/- ${fragment}/- ${collection_prefix}.${fragment}/" "$file"
+    done
+    echo -e "\033[AFixing doc framents for ${fragment} in plugins/modules... \033[32;1mDONE\033[0m"
 done
-echo -e "\033[AFixing doc framents in plugins/modules... \033[32;1mDONE\033[0m"
 
 echo "Fixing examples in plugins/modules..."
 find plugins/modules -name "*.py" -print0 |


### PR DESCRIPTION
The script now fixes the references for all doc_fragments in the
plugins/doc_fragments folder. So far it was only fixing the references
for ipamodule_base_docs.

PR #762 (automount location: add support for delete_continue) added an
other doc_fragment and the references have not been fixes as needed.