### PR TITLE
servicedelegation: Do not fail for not existing members with state absent

### DIFF
--- a/plugins/module_utils/ansible_freeipa_module.py
+++ b/plugins/module_utils/ansible_freeipa_module.py
@@ -551,7 +551,8 @@ else:
             return False
         return True
 
-    def servicedelegation_normalize_principals(module, principal):
+    def servicedelegation_normalize_principals(module, principal,
+                                               check_exists=False):
         """
         Normalize servicedelegation principals.
 
@@ -620,12 +621,13 @@ else:
                     _host = _host[:-len(realm) - 1]
 
                 # Seach for host
-                if not _check_exists(module, "host", _host):
+                if check_exists and not _check_exists(module, "host", _host):
                     module.fail_json(msg="Host '%s' does not exist" % _host)
 
             # Check the service principal exists
             else:
-                if not _check_exists(module, "service", princ):
+                if check_exists and \
+                   not _check_exists(module, "service", princ):
                     module.fail_json(msg="Service %s does not exist" % princ)
 
             _principal.append(princ)

--- a/plugins/modules/ipaservicedelegationrule.py
+++ b/plugins/modules/ipaservicedelegationrule.py
@@ -221,9 +221,9 @@ def main():
 
         # Normalize principals
         if principal:
-            principal = servicedelegation_normalize_principals(ansible_module,
-                                                               principal)
-        if target:
+            principal = servicedelegation_normalize_principals(
+                ansible_module, principal, state == "present")
+        if target and state == "present":
             check_targets(ansible_module, target)
 
         commands = []

--- a/plugins/modules/ipaservicedelegationtarget.py
+++ b/plugins/modules/ipaservicedelegationtarget.py
@@ -177,8 +177,8 @@ def main():
 
         # Normalize principals
         if principal:
-            principal = servicedelegation_normalize_principals(ansible_module,
-                                                               principal)
+            principal = servicedelegation_normalize_principals(
+                ansible_module, principal, state == "present")
 
         commands = []
         principal_add = principal_del = []

--- a/tests/servicedelegationrule/test_servicedelegationrule.yml
+++ b/tests/servicedelegationrule/test_servicedelegationrule.yml
@@ -21,7 +21,9 @@
     ipaservice:
       ipaadmin_password: SomeADMINpassword
       ipaapi_context: "{{ ipa_context | default(omit) }}"
-      name: "{{ 'test-service/' + ansible_facts['fqdn'] }}"
+      name:
+      - "{{ 'test-service/' + ansible_facts['fqdn'] }}"
+      - "{{ 'not-existing-test-service/' + ansible_facts['fqdn'] }}"
       state: absent
       continue: yes
 
@@ -29,7 +31,9 @@
     ipaservicedelegationtarget:
       ipaadmin_password: SomeADMINpassword
       ipaapi_context: "{{ ipa_context | default(omit) }}"
-      name: test-delegation-target
+      name:
+      - test-delegation-target
+      - not-existing-test-delegation-target
       state: absent
 
   # CREATE TEST ITEMS
@@ -65,6 +69,28 @@
       ipaadmin_password: SomeADMINpassword
       ipaapi_context: "{{ ipa_context | default(omit) }}"
       name: test-delegation-rule
+    register: result
+    failed_when: result.changed or result.failed
+
+  - name: Do not fail to ensure absence of not existing servicedelegationrule test-delegation-rule member principal
+    ipaservicedelegationrule:
+      ipaadmin_password: SomeADMINpassword
+      ipaapi_context: "{{ ipa_context | default(omit) }}"
+      name: test-delegation-rule
+      principal: "{{ 'not-existing-test-service/' + ansible_facts['fqdn'] }}"
+      action: member
+      state: absent
+    register: result
+    failed_when: result.changed or result.failed
+
+  - name: Do not fail to ensure absence of not existing servicedelegationrule test-delegation-rule member target
+    ipaservicedelegationrule:
+      ipaadmin_password: SomeADMINpassword
+      ipaapi_context: "{{ ipa_context | default(omit) }}"
+      name: test-delegation-rule
+      target: not-existing-test-delegation-target
+      action: member
+      state: absent
     register: result
     failed_when: result.changed or result.failed
 

--- a/tests/servicedelegationtarget/test_servicedelegationtarget.yml
+++ b/tests/servicedelegationtarget/test_servicedelegationtarget.yml
@@ -25,6 +25,7 @@
       - "{{ 'test-service1/' + ansible_facts['fqdn'] }}"
       - "{{ 'test-service2/' + ansible_facts['fqdn'] }}"
       - "{{ 'test-service3/' + ansible_facts['fqdn'] }}"
+      - "{{ 'not-existing-test-service/' + ansible_facts['fqdn'] }}"
       state: absent
       continue: yes
 
@@ -69,6 +70,17 @@
       ipaadmin_password: SomeADMINpassword
       ipaapi_context: "{{ ipa_context | default(omit) }}"
       name: test-delegation-target
+    register: result
+    failed_when: result.changed or result.failed
+
+  - name: Do not fail to ensure absence of not existing servicedelegationtarget test-delegation-target member principal
+    ipaservicedelegationtarget:
+      ipaadmin_password: SomeADMINpassword
+      ipaapi_context: "{{ ipa_context | default(omit) }}"
+      name: test-delegation-target
+      principal: "{{ 'not-existing-test-service/' + ansible_facts['fqdn'] }}"
+      action: member
+      state: absent
     register: result
     failed_when: result.changed or result.failed
 


### PR DESCRIPTION
Ensuring absence of members (services and targets) that do not exist may
not fail as they are not members for servicedelegationtarget and
servicedelegationrule.

servicedelegation_normalize_principals in ansible_freeipa_module has
been extended with a check_exists argument that defaults to False. state
== "present" is now given as this argument to turn on the element exists
check only if elements should be added.