### PR TITLE
molecule: Disable prerun for normal tests

### DIFF
--- a/molecule/centos-7/molecule.yml
+++ b/molecule/centos-7/molecule.yml
@@ -16,3 +16,4 @@ provisioner:
   name: ansible
   playbooks:
     prepare: ../resources/playbooks/prepare.yml
+prerun: false

--- a/molecule/centos-8/molecule.yml
+++ b/molecule/centos-8/molecule.yml
@@ -16,3 +16,4 @@ provisioner:
   name: ansible
   playbooks:
     prepare: ../resources/playbooks/prepare.yml
+prerun: false

--- a/molecule/centos-9/molecule.yml
+++ b/molecule/centos-9/molecule.yml
@@ -16,3 +16,4 @@ provisioner:
   name: ansible
   playbooks:
     prepare: ../resources/playbooks/prepare.yml
+prerun: false

--- a/molecule/fedora-latest/molecule.yml
+++ b/molecule/fedora-latest/molecule.yml
@@ -16,3 +16,4 @@ provisioner:
   name: ansible
   playbooks:
     prepare: ../resources/playbooks/prepare.yml
+prerun: false


### PR DESCRIPTION
This disables the generation of the collection using the default
galaxy.yml. The installation of the generated collection fails with
invalid version A.B.C.

The collection is not used in the tests and the generated collection
is not using proper name and namespace in the collection files.

Note: utils/build-galaxy-releasesh needs to be used to generate the correct
collection.