### PR TITLE
upstream CI: Fix container builds in face of Ansible and CentOS changes.

### DIFF
--- a/molecule/centos-7-build/molecule.yml
+++ b/molecule/centos-7-build/molecule.yml
@@ -16,3 +16,4 @@ provisioner:
   name: ansible
   playbooks:
     prepare: ../resources/playbooks/prepare-build.yml
+prerun: false

--- a/molecule/centos-8-build/molecule.yml
+++ b/molecule/centos-8-build/molecule.yml
@@ -16,3 +16,4 @@ provisioner:
   name: ansible
   playbooks:
     prepare: ../resources/playbooks/prepare-build.yml
+prerun: false

--- a/molecule/centos-9-build/Dockerfile
+++ b/molecule/centos-9-build/Dockerfile
@@ -5,7 +5,6 @@ RUN rm -fv /var/cache/dnf/metadata_lock.pid; \
 dnf makecache; \
 dnf --assumeyes install \
     /usr/bin/python3 \
-    /usr/bin/python3-config \
     /usr/bin/dnf-3 \
     sudo \
     bash \

--- a/molecule/centos-9-build/molecule.yml
+++ b/molecule/centos-9-build/molecule.yml
@@ -16,3 +16,4 @@ provisioner:
   name: ansible
   playbooks:
     prepare: ../resources/playbooks/prepare-build.yml
+prerun: false

--- a/molecule/fedora-latest-build/molecule.yml
+++ b/molecule/fedora-latest-build/molecule.yml
@@ -16,3 +16,4 @@ provisioner:
   name: ansible
   playbooks:
     prepare: ../resources/playbooks/prepare-build.yml
+prerun: false

--- a/tests/azure/templates/build_container.yml
+++ b/tests/azure/templates/build_container.yml
@@ -6,6 +6,9 @@ parameters:
     type: string
   - name: build_scenario_name
     type: string
+  - name: python_version
+    type: string
+    default: 3.x
 
 jobs:
 - job: BuildTestImage${{ parameters.job_name_suffix }}
@@ -13,7 +16,7 @@ jobs:
   steps:
   - task: UsePythonVersion@0
     inputs:
-      versionSpec: '3.6'
+      versionSpec: '${{ parameters.python_version }}'
 
   - script: python -m pip install --upgrade pip setuptools wheel ansible
     displayName: Install tools


### PR DESCRIPTION
Due to changes in Ansible and CentOS, there were some
failures in the creation of testing containers for our upstream
CI.

This PR proposes fixes for three different failures:
* It allows the use of a new parameter to select a specific
Python version, or the latest available if not set.
* Disables `prerun` for molecule playbooks (as in PR #774).
* Remove installation of python3-devel from CentOS 9
Stream image, as it is not needed, and causing failures.

A pipeline showing the actual results can be seen at:
https://dev.azure.com/ansible-freeipa/ansible-freeipa/_build/results?buildId=2078&view=logs&j=51d2d85a-4fe0-5c9b-a9d4-926f090a5dc4

The CentOS 8 failure in the pipeline is expected and will
be adreessed in PR #732.