### PR TITLE
ansible-lint: Remove warning on 'ignore_errors'.

### DIFF
--- a/tests/dnsrecord/env_setup.yml
+++ b/tests/dnsrecord/env_setup.yml
@@ -31,4 +31,3 @@
       dnssec: yes
       skip_nameserver_check: yes
       skip_overlap_check: yes
-    ignore_errors: yes


### PR DESCRIPTION
The test for dnsrecord creates a DNSSEC zone, and was forcing the task
to ignore errors using `ignore_errors: true`. The test environment
should be clean at that point, and without the zone, tests would fail,
so there is no need to keep the attribute set. If the task fails, it
should be fixed.