### PR TITLE
upstream ci: Fix scenario for Centos 8 Stream with Ansible 2.11.

### DIFF
--- a/tests/azure/nightly.yml
+++ b/tests/azure/nightly.yml
@@ -107,7 +107,7 @@ stages:
   - template: templates/group_tests.yml
     parameters:
       build_number: $(Build.BuildNumber)
-      scenario: centos-8
+      scenario: c8s
       ansible_version: "-core >=2.11,<2.12"
 
 - stage: c8s_Ansible_Core_2_12


### PR DESCRIPTION
Changed scenario from old CentOS 8 (centos-8) to current Centos 8
Stream (c8s).