### PR TITLE
vault: add support for delete_continue.

### DIFF
--- a/README-vault.md
+++ b/README-vault.md
@@ -240,6 +240,7 @@ Variable | Description | Required
 `data` \|`vault_data` \| `ipavaultdata` | Data to be stored in the vault. | no
 `in` \| `datafile_in` | Path to file with data to be stored in the vault. | no
 `out` \| `datafile_out` | Path to file to store data retrieved from the vault. | no
+`delete_continue` \| `continue` | Continuous mode: don't stop on errors. Valid only if `state` is `absent`. Default: `yes` (bool) | no
 `action` | Work on vault or member level. It can be on of `member` or `vault` and defaults to `vault`. | no
 `state` | The state to ensure. It can be one of `present`, `absent` or `retrieved`, default: `present`. | no
 

--- a/plugins/modules/ipavault.py
+++ b/plugins/modules/ipavault.py
@@ -36,6 +36,7 @@ short description: Manage vaults and secret vaults.
 description: Manage vaults and secret vaults. KRA service must be enabled.
 extends_documentation_fragment:
   - ipamodule_base_docs
+  - ipamodule_base_docs.delete_continue
 options:
   name:
     description: The vault name
@@ -652,6 +653,7 @@ def main():
                             ['new_password', 'new_password_file'],
                             ['vault_password', 'vault_password_file'],
                             ['vault_public_key', 'vault_public_key_file']],
+        ipa_module_options=["delete_continue"],
     )
 
     ansible_module._ansible_debug = True
@@ -688,6 +690,8 @@ def main():
 
     datafile_in = ansible_module.params_get("datafile_in")
     datafile_out = ansible_module.params_get("datafile_out")
+
+    delete_continue = ansible_module.params_get("delete_continue")
 
     action = ansible_module.params_get("action")
     state = ansible_module.params_get("state")
@@ -921,6 +925,8 @@ def main():
                         args = {
                             k: v for k, v in args.items() if k not in remove
                         }
+                        if delete_continue:
+                            args["continue"] = delete_continue
                         commands.append([name, "vault_del", args])
 
                 elif action == "member":

--- a/tests/vault/env_cleanup.yml
+++ b/tests/vault/env_cleanup.yml
@@ -8,6 +8,7 @@
       - symvault
       - asymvault
       username: "{{ username }}"
+      continue: yes
       state: absent
     loop:
       - admin
@@ -21,6 +22,7 @@
       name:
       - sharedvault
       - svcvault
+      continue: yes
       state: absent
 
   - name: Ensure test users do not exist.

--- a/tests/vault/test_vault_asymmetric.yml
+++ b/tests/vault/test_vault_asymmetric.yml
@@ -227,6 +227,7 @@
       ipaadmin_password: SomeADMINpassword
       name: asymvault
       state: absent
+      continue: no
     register: result
     failed_when: not result.changed or result.failed
 
@@ -235,6 +236,7 @@
       ipaadmin_password: SomeADMINpassword
       name: asymvault
       state: absent
+      continue: no
     register: result
     failed_when: result.changed or result.failed
 
@@ -287,6 +289,7 @@
       ipaadmin_password: SomeADMINpassword
       name: asymvault
       state: absent
+      continue: yes
     register: result
     failed_when: not result.changed or result.failed
 
@@ -295,6 +298,7 @@
       ipaadmin_password: SomeADMINpassword
       name: asymvault
       state: absent
+      continue: yes
     register: result
     failed_when: result.changed or result.failed
 

--- a/tests/vault/test_vault_standard.yml
+++ b/tests/vault/test_vault_standard.yml
@@ -126,6 +126,7 @@
       ipaadmin_password: SomeADMINpassword
       name: stdvault
       state: absent
+      continue: no
     register: result
     failed_when: not result.changed or result.failed
 
@@ -134,6 +135,7 @@
       ipaadmin_password: SomeADMINpassword
       name: stdvault
       state: absent
+      continue: no
     register: result
     failed_when: result.changed or result.failed
 

--- a/tests/vault/test_vault_symmetric.yml
+++ b/tests/vault/test_vault_symmetric.yml
@@ -138,6 +138,7 @@
       ipaadmin_password: SomeADMINpassword
       name: symvault
       state: absent
+      continue: no
     register: result
     failed_when: result.failed or not result.changed
 
@@ -146,6 +147,7 @@
       ipaadmin_password: SomeADMINpassword
       name: symvault
       state: absent
+      continue: no
     register: result
     failed_when: result.failed or result.changed
 
@@ -293,6 +295,7 @@
       ipaadmin_password: SomeADMINpassword
       name: symvault
       state: absent
+      continue: yes
     register: result
     failed_when: result.failed or not result.changed
 
@@ -301,6 +304,7 @@
       ipaadmin_password: SomeADMINpassword
       name: symvault
       state: absent
+      continue: yes
     register: result
     failed_when: result.failed or result.changed
 


### PR DESCRIPTION
Add support for attribute 'delete_continue' in ipadnszone.

Fix #592 