### PR TITLE
module_utils: Fix comparison of elements not in IPA object.

### DIFF
--- a/plugins/modules/ipaautomountmap.py
+++ b/plugins/modules/ipaautomountmap.py
@@ -126,7 +126,8 @@ class AutomountMap(IPAAnsibleModule):
         _args = {}
         if mapname:
             _args["automountmapname"] = mapname
-        if desc:
+        # An empty string is valid and will clear the attribute.
+        if desc is not None:
             _args["description"] = desc
         return _args
 

--- a/plugins/modules/ipauser.py
+++ b/plugins/modules/ipauser.py
@@ -1103,20 +1103,6 @@ def main():
                         if "noprivate" in args:
                             del args["noprivate"]
 
-                        # Ignore sshpubkey if it is empty (for resetting)
-                        # and not set in for the user
-                        if "ipasshpubkey" not in res_find and \
-                           "ipasshpubkey" in args and \
-                           args["ipasshpubkey"] == ['']:
-                            del args["ipasshpubkey"]
-
-                        # Ignore userauthtype if it is empty (for resetting)
-                        # and not set in for the user
-                        if "ipauserauthtype" not in res_find and \
-                           "ipauserauthtype" in args and \
-                           args["ipauserauthtype"] == ['']:
-                            del args["ipauserauthtype"]
-
                         # For all settings is args, check if there are
                         # different settings in the find result.
                         # If yes: modify

--- a/tests/automount/test_automountmap.yml
+++ b/tests/automount/test_automountmap.yml
@@ -71,6 +71,24 @@
       register: result
       failed_when: result.failed or result.changed
 
+    - name: ensure map TestMap has an empty description
+      ipaautomountmap:
+        ipaadmin_password: SomeADMINpassword
+        name: TestMap
+        location: TestLocation
+        desc: ""
+      register: result
+      failed_when: result.failed or not result.changed
+
+    - name: ensure map TestMap has an empty description, again
+      ipaautomountmap:
+        ipaadmin_password: SomeADMINpassword
+        name: TestMap
+        location: TestLocation
+        desc: ""
+      register: result
+      failed_when: result.failed or result.changed
+
     - name: ensure map TestMap is removed
       ipaautomountmap:
         ipaadmin_password: SomeADMINpassword

--- a/tests/user/test_user_empty_lists.yml
+++ b/tests/user/test_user_empty_lists.yml
@@ -1,0 +1,71 @@
+---
+- name: Test users
+  hosts: "{{ ipa_test_host | default('ipaserver') }}"
+  become: no
+  gather_facts: no
+
+  tasks:
+  # SETUP
+  - name: Remove test users
+    ipauser:
+      ipaadmin_password: SomeADMINpassword
+      ipaapi_context: "{{ ipa_context | default(omit) }}"
+      name: testuser
+      state: absent
+
+  - name: Ensure user testuser is present
+    ipauser:
+      ipaadmin_password: SomeADMINpassword
+      ipaapi_context: "{{ ipa_context | default(omit) }}"
+      name: testuser
+      first: test
+      last: user
+      userauthtype: password,radius,otp
+      sshpubkey:
+      # yamllint disable-line rule:line-length
+      - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCqmVDpEX5gnSjKuv97AyzOhaUMMKz8ahOA3GY77tVC4o68KNgMCmDSEG1/kOIaElngNLaCha3p/2iAcU9Bi1tLKUlm2bbO5NHNwHfRxY/3cJtq+/7D1vxJzqThYwI4F9vr1WxyY2+mMTv3pXbfAJoR8Mu06XaEY5PDetlDKjHLuNWF+/O7ZU8PsULTa1dJZFrtXeFpmUoLoGxQBvlrlcPI1zDciCSU24t27Zan5Py2l5QchyI7yhCyMM77KDtj5+AFVpmkb9+zq50rYJAyFVeyUvwjzErvQrKJzYpA0NyBp7vskWbt36M16/M/LxEK7HA6mkcakO3ESWx5MT1LAjvdlnxbWG3787MxweHXuB8CZU+9bZPFBaJ+VQtOfJ7I8eH0S16moPC4ak8FlcFvOH8ERDPWLFDqfy09yaZ7bVIF0//5ZI7Nf3YDe3S7GrBX5ieYuECyP6UNkTx9BRsAQeVvXEc6otzB7iCSnYBMGUGzCqeigoAWaVQUONsSR3Uatks= pinky@ipaserver.el81.local  # noqa 204
+
+  # TESTS - action: user
+  - name: Ensure user testuser present with empty sshpubkey
+    ipauser:
+      ipaadmin_password: SomeADMINpassword
+      ipaapi_context: "{{ ipa_context | default(omit) }}"
+      name: testuser
+      sshpubkey: ""
+    register: result
+    failed_when: not result.changed or result.failed
+
+  - name: Ensure user testuser present with empty sshpubkey, again
+    ipauser:
+      ipaadmin_password: SomeADMINpassword
+      ipaapi_context: "{{ ipa_context | default(omit) }}"
+      name: testuser
+      sshpubkey: ""
+    register: result
+    failed_when: result.changed or result.failed
+
+  - name: Ensure user testuser present with empty userauthtype
+    ipauser:
+      ipaadmin_password: SomeADMINpassword
+      ipaapi_context: "{{ ipa_context | default(omit) }}"
+      name: testuser
+      userauthtype: ""
+    register: result
+    failed_when: not result.changed or result.failed
+
+  - name: Ensure user testuser present with empty userauthtype, again
+    ipauser:
+      ipaadmin_password: SomeADMINpassword
+      ipaapi_context: "{{ ipa_context | default(omit) }}"
+      name: testuser
+      userauthtype: ""
+    register: result
+    failed_when: result.changed or result.failed
+
+  # CLEANUP
+  - name: Remove test users
+    ipauser:
+      ipaadmin_password: SomeADMINpassword
+      ipaapi_context: "{{ ipa_context | default(omit) }}"
+      name: testuser
+      state: absent


### PR DESCRIPTION
This change modifies the comparison of the retrieved IPA object and the
provided arguments on ansible_freeipa_module.compare_args_ipa when the
provider argument is an empty string.
    
If an attribute is not available in 'ipa', its value is considered to be
a list with an empty string (['']), possibly forcing the conversion of
the 'args' attribute to a list for comparison. This allows, for example,
the usage of empty strings which should compare as equals to inexistent
attributes (None), as is done in IPA API.

Modules `ipauser` and `ipaautomountmap` are modified to use the new
behavior. 