### PR TITLE
automember: Remove debug output

### DIFF
--- a/plugins/modules/ipaautomember.py
+++ b/plugins/modules/ipaautomember.py
@@ -587,7 +587,6 @@ def main():
                         commands.append([None,
                                          'automember_default_group_remove',
                                          {'type': automember_type}])
-                        ansible_module.warn("commands: %s" % repr(commands))
 
                 else:
                     dn_default_group = [DN(('cn', default_group),


### PR DESCRIPTION
The warn debug line was added with "Add automember default group
handling" d2648b142a44511e6841e08bd3a14ff877c34c74