### PR TITLE
Fix case sensitive issue with REALM

### DIFF
--- a/roles/ipaserver/tasks/install.yml
+++ b/roles/ipaserver/tasks/install.yml
@@ -64,7 +64,7 @@
     password: "{{ ipaadmin_password }}"
     master_password: "{{ ipaserver_master_password | default(omit) }}"
     domain: "{{ ipaserver_domain | default(omit) }}"
-    realm: "{{ ipaserver_realm | default(omit) }}"
+    realm: "{{ ipaserver_realm|upper | default(omit) }}"
     hostname: "{{ ipaserver_hostname | default(ansible_facts['fqdn']) }}"
     ca_cert_files: "{{ ipaserver_ca_cert_files | default(omit) }}"
     no_host_dns: "{{ ipaserver_no_host_dns }}"


### PR DESCRIPTION
Force upper case with REALM, ensures no failure if anyone defines lowercase in inventory or playbook for role.