### PR TITLE
Force upper case in realm

### DIFF
--- a/roles/ipareplica/tasks/install.yml
+++ b/roles/ipareplica/tasks/install.yml
@@ -71,7 +71,7 @@
     domain: "{{ ipareplica_domain | default(ipaserver_domain) |
             default(omit) }}"
     servers: "{{ ipareplica_servers | default(omit) }}"
-    realm: "{{ ipareplica_realm | default(ipaserver_realm) |default(omit) }}"
+    realm: "{{ ipareplica_realm |upper | default(ipaserver_realm) |upper |default(omit) }}"
     hostname: "{{ ipareplica_hostname | default(ansible_facts['fqdn']) }}"
     ca_cert_files: "{{ ipareplica_ca_cert_files | default([]) }}"
     hidden_replica: "{{ ipareplica_hidden_replica }}"


### PR DESCRIPTION
Force upper case in REALM to avoid failures if not defined in upper case in inventory or playbook variable.