### PR TITLE
Cast runasuser property to list, consider externaluser members

### DIFF
--- a/plugins/modules/ipasudorule.py
+++ b/plugins/modules/ipasudorule.py
@@ -487,8 +487,8 @@ def main():
                     runasuser_add, runasuser_del = gen_add_del_lists(
                         runasuser,
                         (
-                            res_find.get('ipasudorunas_user', [])
-                            + res_find.get('ipasudorunasextuser', [])
+                            list(res_find.get('ipasudorunas_user', []))
+                            + list(res_find.get('ipasudorunasextuser', []))
                         )
                     )
 
@@ -522,7 +522,12 @@ def main():
                             hostgroup, res_find.get("memberhost_hostgroup"))
                     if user is not None:
                         user_add = gen_add_list(
-                            user, res_find.get("memberuser_user"))
+                            user, 
+                            (
+                                res_find.get("memberuser_user", [])
+                                + list(res_find.get("externaluser", []))
+                            )
+                        )
                     if group is not None:
                         group_add = gen_add_list(
                             group, res_find.get("memberuser_group"))


### PR DESCRIPTION
* Cast runasuser property from tuple to list

  The get method for ipasudorunas_user and ipasudorunasextuser returns
    a tuple instead of a list. Casting to list.

* Consider externaluser members into user list

  The externaluser property was not taken into consideration while
    building the list of users to add to the sudorule.