### PR TITLE
Update pylint to version 2.12.2

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -68,7 +68,7 @@ jobs:
           python-version: "3.x"
       - name: Run pylint
         run: |
-            pip install pylint==2.10.2
+            pip install pylint==2.12.2
             pylint plugins roles --disable=import-error
 
   shellcheck:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,7 +24,7 @@ repos:
   hooks:
   - id: pydocstyle
 - repo: https://github.com/pycqa/pylint
-  rev: v2.10.2
+  rev: v2.12.2
   hooks:
   - id: pylint
     args:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,4 +2,4 @@
 ipdb
 pre-commit
 flake8-bugbear
-pylint==2.10.2
+pylint==2.12.2

--- a/roles/ipaclient/module_utils/ansible_ipa_client.py
+++ b/roles/ipaclient/module_utils/ansible_ipa_client.py
@@ -207,7 +207,7 @@ else:
                         cli_realm, cli_domain, cli_server, cli_kdc, dnsok,
                         filename, client_domain, client_hostname, force=False,
                         configure_sssd=True):
-                    # pylint: disable=global-statement
+                    # pylint: disable=global-variable-not-assigned
                     global options
                     options.force = force
                     options.sssd = configure_sssd

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,6 +34,7 @@ ignore = D1,D212,D203
 
 [pylint.MASTER]
 disable =
+    consider-using-f-string,  # f-string is not supported on Python2
     unspecified-encoding, # open() does not provide `encoding` in Python2
     use-maxsplit-arg,
     redundant-u-string-prefix,


### PR DESCRIPTION
Updated pylint to the latest version supported by
Fedora 36 and FreeIPA, and fix issues found with
this release.