### PR TITLE
Fix ipatrust tests to execute locally

### DIFF
--- a/tests/trust/test_trust.yml
+++ b/tests/trust/test_trust.yml
@@ -8,6 +8,7 @@
     adserver:
       domain: "{{ winserver_domain | default('windows.local')}}"
       realm: "{{ winserver_realm | default(winserver_domain) | default('windows.local') | upper }}"
+      password: "{{ winserver_admin_password | default('SomeW1Npassword') }}"
     trust_exists: 'Realm name: {{ adserver.domain }}'
     range_exists: 'Range name: {{ adserver.realm }}_id_range'
 
@@ -19,27 +20,25 @@
       ipatrust:
         ipaadmin_password: SomeADMINpassword
         ipaapi_context: "{{ ipa_context | default(omit) }}"
-        realm: windows.local
+        realm: "{{ adserver.domain }}"
         state: absent
-      register: del_trust
 
     - name: check for trust
       shell: |
         echo 'SomeADMINpassword' | kinit admin
-        ipa trust-find windows.local
+        ipa trust-find {{ adserver.domain }}
       register: check_find_trust
       failed_when: "trust_exists in check_find_trust.stdout"
 
     - name: delete id range
       shell: |
         echo 'SomeADMINpassword' | kinit admin
-        ipa idrange-del WINDOWS.LOCAL_id_range
-      when: del_trust['changed'] | bool
+        ipa idrange-del {{ adserver.realm }}_id_range
 
     - name: check for range
       shell: |
         echo 'SomeADMINpassword' | kinit admin
-        ipa idrange-find WINDOWS.LOCAL_id_range
+        ipa idrange-find {{ adserver.realm }}_id_range
       register: check_del_idrange
       failed_when: "range_exists in check_find_trust.stdout"
 
@@ -47,16 +46,25 @@
       ipatrust:
         ipaadmin_password: SomeADMINpassword
         ipaapi_context: "{{ ipa_context | default(omit) }}"
-        realm: windows.local
+        realm: "{{ adserver.domain }}"
         admin: Administrator
-        password: secret_ad_pw
+        password: "{{ adserver.password }}"
         state: present
+      register: result
+      failed_when: result.failed or not result.changed
 
-    - name: check for trust
+    - name: check if trust exists
       shell: |
         echo 'SomeADMINpassword' | kinit admin
-        ipa trust-find windows.local
+        ipa trust-find {{ adserver.domain }}
       register: check_add_trust
-      failed_when: "trust_exists in check_find_trust.stdout"
+      failed_when: "trust_exists not in check_add_trust.stdout"
+
+    - name: check if range exists
+      shell: |
+        echo 'SomeADMINpassword' | kinit admin
+        ipa idrange-find {{ adserver.realm }}_id_range
+      register: check_add_trust
+      failed_when: "range_exists not in check_add_trust.stdout"
 
     when: trust_test_is_supported | default(false)

--- a/tests/trust/test_trust.yml
+++ b/tests/trust/test_trust.yml
@@ -4,6 +4,13 @@
   become: true
   gather_facts: false
 
+  vars:
+    adserver:
+      domain: "{{ winserver_domain | default('windows.local')}}"
+      realm: "{{ winserver_realm | default(winserver_domain) | default('windows.local') | upper }}"
+    trust_exists: 'Realm name: {{ adserver.domain }}'
+    range_exists: 'Range name: {{ adserver.realm }}_id_range'
+
   tasks:
 
   - block:
@@ -21,7 +28,7 @@
         echo 'SomeADMINpassword' | kinit admin
         ipa trust-find windows.local
       register: check_find_trust
-      failed_when: "'0 trusts matched' not in check_find_trust.stdout"
+      failed_when: "trust_exists in check_find_trust.stdout"
 
     - name: delete id range
       shell: |
@@ -34,7 +41,7 @@
         echo 'SomeADMINpassword' | kinit admin
         ipa idrange-find WINDOWS.LOCAL_id_range
       register: check_del_idrange
-      failed_when: "'0 ranges matched' not in check_del_idrange.stdout"
+      failed_when: "range_exists in check_find_trust.stdout"
 
     - name: add trust
       ipatrust:
@@ -50,6 +57,6 @@
         echo 'SomeADMINpassword' | kinit admin
         ipa trust-find windows.local
       register: check_add_trust
-      failed_when: "'1 trust matched' not in check_add_trust.stdout"
+      failed_when: "trust_exists in check_find_trust.stdout"
 
     when: trust_test_is_supported | default(false)

--- a/tests/trust/test_trust_client_context.yml
+++ b/tests/trust/test_trust_client_context.yml
@@ -13,7 +13,7 @@
     ipatrust:
       ipaadmin_password: SomeADMINpassword
       ipaapi_context: server
-      realm: windows.local
+      realm: this.test.should.fail
     register: result
     failed_when: not (result.failed and result.msg is regex("No module named '*ipaserver'*"))
     when: ipa_host_is_client


### PR DESCRIPTION
We don't yet have a way to run tests that requirex IPA-AD trust
in upstream CI, but it is possible to use a local environment to
execute these tests.

This patch makes the tests configurable through environment,
inventory, or command line parameters and allow more flexibility
on the testing environment.

The changes have been tested with a trust setting using a trust
between FreeIPA on Fedora 35 and AD on Windows Server 2022.