### PR TITLE
Remove Ubuntu from Supported Distributions

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,6 @@ Supported Distributions
 
 * RHEL/CentOS 7.4+
 * Fedora 26+
-* Ubuntu
 * Debian 10+ (ipaclient only, no server or replica!)
 
 Requirements


### PR DESCRIPTION
Ubuntu 16.04: No module named 'ipapython',  `pip install ipapython` get no error
Ubuntu 18.04: sysctl crypto.fips_enabled -bn failed
Ubuntu 20.04 don`t have package freeipa-server