### PR TITLE
DNS forward policy: ensure consistency between module parameters.

### DIFF
--- a/README-dnsconfig.md
+++ b/README-dnsconfig.md
@@ -129,7 +129,7 @@ Variable | Description | Required
 `forwarders` | The list of forwarders dicts. Each `forwarders` dict entry has:| no
 &nbsp; | `ip_address` - The IPv4 or IPv6 address of the DNS server. | yes
 &nbsp; | `port` - The custom port that should be used on this server. | no
-`forward_policy` | The global forwarding policy. It can be one of `only`, `first`, or `none`.  | no
+`forward_policy` \| `forwardpolicy` | The global forwarding policy. It can be one of `only`, `first`, or `none`.  | no
 `allow_sync_ptr` | Allow synchronization of forward (A, AAAA) and reverse (PTR) records (bool). | yes
 `action` | Work on dnsconfig or member level. It can be one of `member` or `dnsconfig` and defaults to `dnsconfig`. Only `forwarders` can be managed with `action: member`. | no
 `state` | The state to ensure. It can be one of `present` or `absent`, default: `present`. `absent` can only be used with `action: member` and `forwarders`. | yes

--- a/README-dnsforwardzone.md
+++ b/README-dnsforwardzone.md
@@ -110,7 +110,7 @@ Variable | Description | Required
 `forwarders` \| `idnsforwarders` |  Per-zone forwarders. A custom port can be specified for each forwarder. Options | no
 &nbsp; | `ip_address`: The forwarder IP address. | yes
 &nbsp; | `port`: The forwarder IP port. | no
-`forwardpolicy` \| `idnsforwardpolicy` | Per-zone conditional forwarding policy. Possible values are `only`, `first`, `none`. Set to "none" to disable forwarding to global forwarder for this zone. In that case, conditional zone forwarders are disregarded. | no
+`forwardpolicy` \| `idnsforwardpolicy` \| `forward_policy` | Per-zone conditional forwarding policy. Possible values are `only`, `first`, `none`. Set to "none" to disable forwarding to global forwarder for this zone. In that case, conditional zone forwarders are disregarded. | no
 `skip_overlap_check` | Force DNS zone creation even if it will overlap with an existing zone. Defaults to False. | no
 `permission` | Allow DNS Forward Zone to be managed. (bool) | no
 `action` | Work on group or member level. It can be on of `member` or `dnsforwardzone` and defaults to `dnsforwardzone`. | no

--- a/plugins/modules/ipadnsconfig.py
+++ b/plugins/modules/ipadnsconfig.py
@@ -54,6 +54,7 @@ options:
       global forwarders.
     required: false
     choices: ['only', 'first', 'none']
+    alias: ["forwardpolicy"]
   allow_sync_ptr:
     description:
       Allow synchronization of forward (A, AAAA) and reverse (PTR) records.
@@ -189,7 +190,8 @@ def main():
             forwarders=dict(type='list', default=None, required=False,
                             options=dict(**forwarder_spec)),
             forward_policy=dict(type='str', required=False, default=None,
-                                choices=['only', 'first', 'none']),
+                                choices=['only', 'first', 'none'],
+                                aliases=["forwardpolicy"]),
             allow_sync_ptr=dict(type='bool', required=False, default=None),
 
             # general

--- a/plugins/modules/ipadnsforwardzone.py
+++ b/plugins/modules/ipadnsforwardzone.py
@@ -68,7 +68,7 @@ options:
     required: false
     default: only
     choices: ["only", "first", "none"]
-    aliases: ["idnsforwarders"]
+    aliases: ["idnsforwarders", "forward_policy"]
   skip_overlap_check:
     description:
     - Force DNS zone creation even if it will overlap with an existing zone.
@@ -189,7 +189,8 @@ def main():
                                  port=dict(type='int', required=False,
                                            default=None),
                             )),
-            forwardpolicy=dict(type='str', aliases=["idnsforwardpolicy"],
+            forwardpolicy=dict(type='str',
+                               aliases=["idnsforwardpolicy", "forward_policy"],
                                required=False,
                                choices=['only', 'first', 'none']),
             skip_overlap_check=dict(type='bool', required=False),


### PR DESCRIPTION
Modules ipadnsconfig and ipadnsforwardzone allow the setting of forward
policy for zone forwarders, but the parameter names differ between the
modules.

This patch ensures that the same parameter names can be used in each
module. To keep backwar compatibility in both modules, both
`forward_policy` and `forwardpolicy` are now supported.