### PR TITLE
ipatrust: Set valid choices for trust_type.

### DIFF
--- a/README-trust.md
+++ b/README-trust.md
@@ -105,6 +105,7 @@ Variable | Description | Required
 `password` | Active Directory domain administrator's password string. | no
 `server` | Domain controller for the Active Directory domain string. | no
 `trust_secret` | Shared secret for the trust string. | no
+`trust_type` | Trust type. Currently, only 'ad' for Active Directory is supported. | no
 `base_id` | First posix id for the trusted domain integer. | no
 `range_size` | Size of the ID range reserved for the trusted domain integer. | no
 `range_type` | Type of trusted domain ID range, It can be one of `ipa-ad-trust` or `ipa-ad-trust-posix`and defaults to `ipa-ad-trust`. | no

--- a/plugins/modules/ipatrust.py
+++ b/plugins/modules/ipatrust.py
@@ -44,7 +44,8 @@ options:
     description:
     - Trust type (ad for Active Directory, default)
     default: ad
-    required: true
+    required: false
+    choices: ["ad"]
   admin:
     description:
     - Active Directory domain administrator
@@ -103,7 +104,7 @@ EXAMPLES = """
     realm: ad.example.test
     trust_type: ad
     admin: Administrator
-    password: Welcome2020!
+    password: SomeW1Npassword
     state: present
 
 # delete ad-trust

--- a/plugins/modules/ipatrust.py
+++ b/plugins/modules/ipatrust.py
@@ -190,7 +190,8 @@ def main():
             state=dict(type="str", default="present",
                        choices=["present", "absent"]),
             # present
-            trust_type=dict(type="str", default="ad", required=False),
+            trust_type=dict(type="str", default="ad", required=False,
+                            choices=["ad"]),
             admin=dict(type="str", default=None, required=False),
             password=dict(type="str", default=None,
                           required=False, no_log=True),


### PR DESCRIPTION
Ensure only valid choices for trust_type ('ad')  are available for the
module parameter.