### PR TITLE
ipaclient: Don't pull idm:DL1 on client hosts.

### DIFF
--- a/roles/ipaclient/vars/RedHat-8.yml
+++ b/roles/ipaclient/vars/RedHat-8.yml
@@ -1,4 +1,4 @@
 # defaults file for ipaclient
 # vars/RedHat-8.yml
 ---
-ipaclient_packages: [ "@idm:DL1/client" ]
+ipaclient_packages: [ "@idm:client" ]


### PR DESCRIPTION
This change allows ipaclient role to install only the minimum required
packages for a client using module stream 'idm:client'. Before, it was
bringing in all server components as it installed 'idm:DL1' stream.