### PR TITLE
New idrange management module

### DIFF
--- a/README-idrange.md
+++ b/README-idrange.md
@@ -1,0 +1,196 @@
+Idrange module
+============
+
+Description
+-----------
+
+The idrange module allows the management of ID ranges.
+
+In general it is not necessary to modify or delete ID ranges. If there is no other way to achieve a certain configuration than to modify or delete an ID range it should be done with great care. Because UIDs are stored in the file system and are used for access control it might be possible that users are allowed to access files of other users if an ID range got deleted and reused for a different domain.
+
+
+Use cases
+---------
+
+* Add an ID range from a transitively trusted domain
+
+If the trusted domain (A) trusts another domain (B) as well and this trust is transitive 'ipa trust-add domain-A' will only create a range for domain A. The ID range for domain B must be added manually.
+
+* Add an additional ID range for the local domain
+
+If the ID range of the local domain is exhausted, i.e. no new IDs can be assigned to Posix users or groups by the DNA plugin, a new range has to be created to allow new users and groups to be added. (Currently there is no connection between this range CLI and the DNA plugin, but a future version might be able to modify the configuration of the DNS plugin as well).
+
+
+Features
+--------
+
+* ID Range management
+
+
+Supported FreeIPA Versions
+--------------------------
+
+FreeIPA versions 4.4.0 and up are supported by the ipaidrange module.
+
+
+Requirements
+------------
+
+**Controller**
+* Ansible version: 2.8+
+
+**Node**
+* Supported FreeIPA version (see above)
+
+
+Usage
+=====
+
+Example inventory file
+
+```ini
+[ipaserver]
+ipaserver.test.local
+```
+
+Example playbook to ensure a local domain idrange is present:
+
+```yaml
+---
+- name: Playbook to manage IPA idrange.
+  hosts: ipaserver
+  become: no
+
+  tasks:
+  - name: Ensure an ID Range for the local domain is present.
+    ipaidrange:
+      ipaadmin_password: SomeADMINpassword
+      name: local_domain_id_range
+      base_id: 150000
+      range_size: 200000
+```
+
+Example playbook to ensure a local domain idrange is present, with RID and secondary RID base values:
+
+```yaml
+---
+- name: Playbook to manage IPA idrange.
+  hosts: ipaserver
+  become: no
+
+  tasks:
+  - name: Ensure local idrange is present
+    ipaidrange:
+      ipaadmin_password: SomeADMINpassword
+      name: local_domain_id_range
+      base_id: 150000000
+      range_size: 200000
+      rid_base: 1000000
+      secondary_rid_base: 200000000
+```
+
+Example playbook to ensure an AD-trust idrange is present, with range type 'trust-ad' and using domain SID:
+
+```yaml
+---
+- name: Playbook to manage IPA idrange.
+  hosts: ipaserver
+  become: no
+
+  tasks:
+  - name: Ensure AD-trust idrange is present
+    ipaidrange:
+      ipaadmin_password: SomeADMINpassword
+      name: ad_id_range
+      base_id: 150000000
+      range_size: 200000
+      idrange_type: ipa-ad-trust
+      dom_sid: S-1-5-21-2870384104-3340008087-3140804251
+```
+
+Example playbook to ensure an AD-trust idrange is present, with range type 'trust-ad-posix' and using domain SID:
+
+```yaml
+---
+- name: Playbook to manage IPA idrange.
+  hosts: ipaserver
+  become: no
+
+  tasks:
+  - name: Ensure AD-trust idrange is present
+    ipaidrange:
+      name: ad_posix_id_range
+      base_id: 150000000
+      range_size: 200000
+      idrange_type: ipa-ad-trust-posix
+      dom_name: ad.ipa.test
+```
+
+Example playbook to ensure an AD-trust idrange has auto creation of groups set to 'hybrid':
+
+```yaml
+---
+- name: Playbook to manage IPA idrange.
+  hosts: ipaserver
+  become: no
+
+  tasks:
+  - name: Modify AD-trust idrange 'auto_private_groups'
+    ipaidrange:
+      ipaadmin_password: SomeADMINpassword
+      ipaapi_context: "{{ ipa_context | default(omit) }}"
+      name: ad_id_range
+      auto_private_groups: "hybrid"
+```
+
+Example playbook to make sure an idrange is absent:
+
+```yaml
+---
+- name: Playbook to manage IPA idrange.
+  hosts: ipaserver
+  become: no
+
+  tasks:
+  - name: Ensure ID range 'ad_id_range' is absent.
+    ipaidrange:
+      ipaadmin_password: SomeADMINpassword
+      name: ad_id_range
+      state: absent
+```
+
+
+Variables
+---------
+
+Variable | Description | Required
+-------- | ----------- | --------
+`ipaadmin_principal` | The admin principal is a string and defaults to `admin` | no
+`ipaadmin_password` | The admin password is a string and is required if there is no admin ticket available on the node | no
+`ipaapi_context` | The context in which the module will execute. Executing in a server context is preferred. If not provided context will be determined by the execution environment. Valid values are `server` and `client`. | no
+`ipaapi_ldap_cache` | Use LDAP cache for IPA connection. The bool setting defaults to yes. (bool) | no
+`name` \| `cn` | The list of idrange name strings. | yes
+`base_id` \| `ipabaseid` | First Posix ID of the range. (int) | yes, if `state: present`
+`range_size` \| `ipaidrangesize` | Number of IDs in the range. (int) | yes, if `state: present`
+`rid_base` \| `ipabaserid` | First RID of the corresponding RID range. (int) | no
+`secondary_rid_base` \| `ipasecondarybaserid` | First RID of the secondary RID range. (int) | no
+`dom_sid` \| `ipanttrusteddomainsid` | Domain SID of the trusted domain. | no
+`dom_name` \| `ipanttrusteddomainname` | Name of the trusted domain. | no
+`idrange_type` \| `iparangetype` | ID range type, one of `ipa-ad-trust`, `ipa-ad-trust-posix`, `ipa-local`. Only valid if idrange does not exist. | no
+`auto_private_groups` \| `ipaautoprivategroups` | Auto creation of private groups, one of `true`, `false`, `hybrid`. | no
+`delete_continue` \| `continue` | Continuous mode: don't stop on errors. Valid only if `state` is `absent`. Default: `no` (bool) | no
+`state` | The state to ensure. It can be one of `present`, `absent`, default: `present`. | no
+
+
+Notes
+=====
+
+DNA plugin in 389-ds will allocate IDs based on the ranges configured for the local domain. Currently the DNA plugin *cannot* be reconfigured itself based on the local ranges set via this family of commands.
+
+Manual configuration change has to be done in the DNA plugin configuration for the new local range. Specifically, The dnaNextRange attribute of 'cn=Posix IDs,cn=Distributed Numeric Assignment Plugin,cn=plugins,cn=config' has to be modified to match the new range.
+
+
+Authors
+=======
+
+Rafael Guterres Jeffman

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Features
 * Modules for hbacsvcgroup management
 * Modules for host management
 * Modules for hostgroup management
+* Modules for idrange management
 * Modules for location management
 * Modules for permission management
 * Modules for privilege management
@@ -444,6 +445,7 @@ Modules in plugin/modules
 * [ipahbacsvcgroup](README-hbacsvcgroup.md)
 * [ipahost](README-host.md)
 * [ipahostgroup](README-hostgroup.md)
+* [idrange](README-idrange.md)
 * [ipalocation](README-location.md)
 * [ipapermission](README-permission.md)
 * [ipaprivilege](README-privilege.md)

--- a/playbooks/idrange/idrange-absent.yml
+++ b/playbooks/idrange/idrange-absent.yml
@@ -1,0 +1,11 @@
+---
+- name: Idrange absent example
+  hosts: ipaserver
+  become: no
+
+  tasks:
+  - name: Ensure idrange is absent
+    ipaidrange:
+      ipaadmin_password: SomeADMINpassword
+      name: id_range
+      state: absent

--- a/playbooks/idrange/idrange-ad-posix-present.yml
+++ b/playbooks/idrange/idrange-ad-posix-present.yml
@@ -1,0 +1,15 @@
+---
+- name: Playbook to manage idrange
+  hosts: ipaserver
+  become: no
+
+  tasks:
+  - name: Ensure AD-trust idrange is present
+    ipaidrange:
+      name: id_range
+      base_id: 150000000
+      range_size: 200000
+      rid_base: 1000000
+      idrange_type: ipa-ad-trust-posix
+      dom_name: ad.ipa.test
+      auto_private_groups: "false"

--- a/playbooks/idrange/idrange-ad-present.yml
+++ b/playbooks/idrange/idrange-ad-present.yml
@@ -1,0 +1,16 @@
+---
+- name: Playbook to manage idrange
+  hosts: ipaserver
+  become: no
+
+  tasks:
+  - name: Ensure AD-trust idrange is present
+    ipaidrange:
+      ipaadmin_password: SomeADMINpassword
+      name: ad_id_range
+      base_id: 150000000
+      range_size: 200000
+      rid_base: 1000000
+      idrange_type: ipa-ad-trust
+      dom_sid: S-1-5-21-2870384104-3340008087-3140804251
+      auto_private_groups: "true"

--- a/playbooks/idrange/idrange-present.yml
+++ b/playbooks/idrange/idrange-present.yml
@@ -1,0 +1,14 @@
+---
+- name: Playbook to manage idrange
+  hosts: ipaserver
+  become: no
+
+  tasks:
+  - name: Ensure local idrange is present
+    ipaidrange:
+      ipaadmin_password: SomeADMINpassword
+      name: id_range
+      base_id: 150000000
+      range_size: 200000
+      rid_base: 1000000
+      secondary_rid_base: 200000000

--- a/plugins/modules/ipaidrange.py
+++ b/plugins/modules/ipaidrange.py
@@ -1,0 +1,332 @@
+# -*- coding: utf-8 -*-
+
+# Authors:
+#   Rafael Guterres Jeffman <rjeffman@redhat.com>
+#
+# Copyright (C) 2022 Red Hat
+# see file 'COPYING' for use and warranty information
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from __future__ import (absolute_import, division, print_function)
+
+__metaclass__ = type
+
+ANSIBLE_METADATA = {
+    "metadata_version": "1.0",
+    "supported_by": "community",
+    "status": ["preview"],
+}
+
+DOCUMENTATION = """
+---
+module: ipaidrange
+short description: Manage FreeIPA idrange
+description: Manage FreeIPA idrange
+extends_documentation_fragment:
+  - ipamodule_base_docs
+  - ipamodule_base_docs.delete_continue
+options:
+  name:
+    description: The list of idrange name strings.
+    required: true
+    aliases: ["cn"]
+  base_id:
+    description: First Posix ID of the range.
+    type: int
+    required: false
+    aliases: ["ipabaseid"]
+  range_size:
+    description: Number of IDs in the range.
+    type: int
+    required: false
+    aliases: ["ipaidrangesize"]
+  rid_base:
+    description: First RID of the corresponding RID range.
+    type: int
+    required: false
+    aliases: ["ipabaserid"]
+  secondary_rid_base:
+    description: First RID of the secondary RID range.
+    type: int
+    required: false
+    aliases: ["ipasecondarybaserid"]
+  idrange_type:
+    description: ID range type.
+    type: string
+    required: false
+    choices: ["ipa-ad-trust", "ipa-ad-trust-posix", "ipa-local"]
+    aliases: ["iparangetype"]
+  dom_sid:
+    description: Domain SID of the trusted domain.
+    type: string
+    required: false
+    aliases: ["ipanttrusteddomainsid"]
+  dom_name:
+    description: Domain name of the trusted domain.
+    type: string
+    required: false
+    aliases: ["ipanttrusteddomainname"]
+  auto_private_groups:
+    description: Auto creation of private groups.
+    type: string
+    required: false
+    choices: ["true", "false", "hybrid"]
+    aliases: ["ipaautoprivategroups"]
+  state:
+    description: The state to ensure.
+    choices: ["present", "absent"]
+    default: present
+    required: true
+"""
+
+EXAMPLES = """
+# Ensure local domain idrange is present
+- ipaidrange:
+    ipaadmin_password: SomeADMINpassword
+    name: id_range
+    base_id: 150000000
+    range_size: 200000
+    rid_base: 1000000
+    secondary_rid_base: 200000000
+
+# Ensure local domain idrange is absent
+- ipaidrange:
+    ipaadmin_password: SomeADMINpassword
+    name: id_range
+    state: absent
+
+# Ensure AD-trust idrange is present
+- ipaidrange:
+    name: id_range
+    base_id: 150000000
+    range_size: 200000
+    rid_base: 1000000
+    idrange_type: ipa-ad-trust
+    dom_sid: S-1-5-21-2870384104-3340008087-3140804251
+    auto_private_groups: "false"
+
+# Ensure AD-trust idrange is present, with range type ad-trust-posix,
+# and using domain name
+- ipaidrange:
+    name: id_range
+    base_id: 150000000
+    range_size: 200000
+    rid_base: 1000000
+    idrange_type: ipa-ad-trust-posix
+    dom_name: ad.ipa.test
+    auto_private_groups: "hybrid"
+"""
+
+RETURN = """
+"""
+
+
+from ansible.module_utils.ansible_freeipa_module import \
+    IPAAnsibleModule, compare_args_ipa
+from ansible.module_utils import six
+
+if six.PY3:
+    unicode = str
+
+
+def find_idrange(module, name):
+    """Find if a idrange with the given name already exist."""
+    try:
+        _result = module.ipa_command("idrange_show", name, {"all": True})
+    except Exception:  # pylint: disable=broad-except
+        # An exception is raised if idrange name is not found.
+        return None
+    else:
+        return _result["result"]
+
+
+def gen_args(
+    base_id, range_size, rid_base, secondary_rid_base, idrange_type, dom_sid,
+    auto_private_groups
+):
+    _args = {}
+    # Integer parameters are stored as strings.
+    # Converting them here allows the proper use of compare_args_ipa.
+    if base_id is not None:
+        _args["ipabaseid"] = base_id
+    if range_size is not None:
+        _args["ipaidrangesize"] = range_size
+    if rid_base is not None:
+        _args["ipabaserid"] = rid_base
+    if secondary_rid_base is not None:
+        _args["ipasecondarybaserid"] = secondary_rid_base
+    if idrange_type is not None:
+        _args["iparangetype"] = idrange_type
+    if dom_sid is not None:
+        _args["ipanttrusteddomainsid"] = dom_sid
+    if auto_private_groups is not None:
+        _args["ipaautoprivategroups"] = auto_private_groups
+    return _args
+
+
+def main():
+    ansible_module = IPAAnsibleModule(
+        argument_spec=dict(
+            # general
+            name=dict(type="list", aliases=["cn"],
+                      default=None, required=True),
+            # present
+            base_id=dict(required=False, type='int',
+                         aliases=["ipabaseid"], default=None),
+            range_size=dict(required=False, type='int',
+                            aliases=["ipaidrangesize"], default=None),
+            rid_base=dict(required=False, type='int',
+                          aliases=["ipabaserid"], default=None),
+            secondary_rid_base=dict(required=False, type='int', default=None,
+                                    aliases=["ipasecondarybaserid"]),
+            idrange_type=dict(required=False, aliases=["iparangetype"],
+                              type="str", default=None,
+                              choices=["ipa-ad-trust", "ipa-ad-trust-posix",
+                                       "ipa-local"]),
+            dom_sid=dict(required=False, type='str', default=None,
+                         aliases=["ipanttrusteddomainsid"]),
+            dom_name=dict(required=False, type='str', default=None,
+                          aliases=["ipanttrusteddomainname"]),
+            auto_private_groups=dict(required=False, type='str', default=None,
+                                     aliases=["ipaautoprivategroups"],
+                                     choices=['true', 'false', 'hybrid']),
+            # state
+            state=dict(type="str", default="present",
+                       choices=["present", "absent"]),
+        ),
+        mutually_exclusive=[
+            ["dom_sid", "secondary_rid_base"],
+            ["dom_name", "secondary_rid_base"],
+            ["dom_sid", "dom_name"],
+        ],
+        supports_check_mode=True,
+        ipa_module_options=["delete_continue"],
+    )
+
+    ansible_module._ansible_debug = True
+
+    # Get parameters
+
+    # general
+    names = ansible_module.params_get("name")
+    delete_continue = ansible_module.params_get("delete_continue")
+
+    # present
+    base_id = ansible_module.params_get("base_id")
+    range_size = ansible_module.params_get("range_size")
+    rid_base = ansible_module.params_get("rid_base")
+    secondary_rid_base = ansible_module.params_get("secondary_rid_base")
+    idrange_type = ansible_module.params_get("idrange_type")
+    dom_sid = ansible_module.params_get("dom_sid")
+    auto_private_groups = \
+        ansible_module.params_get_lowercase("auto_private_groups")
+
+    # state
+    state = ansible_module.params_get("state")
+
+    # Check parameters
+
+    invalid = []
+
+    if state == "present":
+        if len(names) != 1:
+            ansible_module.fail_json(
+                msg="Only one idrange can be added at a time.")
+
+    if state == "absent":
+        if len(names) < 1:
+            ansible_module.fail_json(msg="No name given.")
+        invalid = ["base_id", "range_size", "idrange_type", "dom_sid"]
+
+    ansible_module.params_fail_used_invalid(invalid, state)
+
+    # Init
+
+    changed = False
+    exit_args = {}
+
+    range_types = {
+        "Active Directory domain range": "ipa-ad-trust",
+        "Active Directory trust range with POSIX attributes":
+            "ipa-ad-trust-posix",
+        "local domain range": "ipa-local",
+    }
+
+    # Connect to IPA API
+    with ansible_module.ipa_connect():
+
+        commands = []
+        for name in names:
+            # Make sure idrange exists
+            res_find = find_idrange(ansible_module, name)
+
+            # Create command
+            if state == "present":
+
+                # Generate args
+                args = gen_args(
+                    base_id, range_size, rid_base, secondary_rid_base,
+                    idrange_type, dom_sid, auto_private_groups
+                )
+
+                # Found the idrange
+                if res_find is not None:
+                    # For all settings is args, check if there are
+                    # different settings in the find result.
+                    # If yes: modify
+                    if not compare_args_ipa(
+                        ansible_module, args, res_find, ignore=["iparangetype"]
+                    ):
+                        res_type = range_types.get(
+                            res_find.get("iparangetype")[0]
+                        )
+                        if res_type == "local_id_range":
+                            ansible_module.fail_json(
+                                "Cannot modify local IPA domain idrange."
+                            )
+
+                        arg_type = args.get("iparangetype")
+                        if arg_type:
+                            if arg_type != res_type:
+                                ansible_module.fail_json(
+                                    "Cannot modify idrange type."
+                                )
+                            del args["iparangetype"]
+                        commands.append([name, "idrange_mod", args])
+                else:
+                    commands.append([name, "idrange_add", args])
+
+            elif state == "absent":
+                if res_find is not None:
+                    commands.append([
+                        name,
+                        "idrange_del",
+                        {"continue": delete_continue or False}
+                    ])
+
+            else:
+                ansible_module.fail_json(msg="Unkown state '%s'" % state)
+
+        # Execute commands
+
+        changed = ansible_module.execute_ipa_commands(commands)
+
+    # Done
+
+    ansible_module.exit_json(changed=changed, **exit_args)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/idrange/tasks_remove_trust.yml
+++ b/tests/idrange/tasks_remove_trust.yml
@@ -1,0 +1,24 @@
+---
+- name: Ensure testing trust is absent
+  ipatrust:
+    ipaadmin_password: SomeADMINpassword
+    ipaapi_context: "{{ ipa_context | default(omit) }}"
+    realm: "{{ adserver.domain }}"
+    state: absent
+
+- name: Ensure testing idranges are absent
+  ipaidrange:
+    ipaadmin_password: SomeADMINpassword
+    ipaapi_context: "{{ ipa_context | default(omit) }}"
+    name:
+      - "{{ adserver.realm }}_id_range"
+    continue: yes
+    state: absent
+
+- name: Remove dns forward zone
+  ipadnsforwardzone:
+    ipaadmin_password: SomeADMINpassword
+    ipaapi_context: "{{ ipa_context | default(omit) }}"
+    name: "{{ adserver.domain }}"
+    state: absent
+  when: trust_dnszone is defined and trust_dnszone.changed

--- a/tests/idrange/tasks_set_trust.yml
+++ b/tests/idrange/tasks_set_trust.yml
@@ -1,0 +1,36 @@
+---
+- name: Ensure DNS forward zone to Windows AD
+  ipadnsforwardzone:
+    ipaadmin_password: SomeADMINpassword
+    ipaapi_context: "{{ ipa_context | default(omit) }}"
+    name: "{{ adserver.domain }}"
+    forwarders:
+      - ip_address: "{{ adserver.ip_address }}"
+    forwardpolicy: first
+  register: trust_dnszone
+
+- name: Set trust to Widows AD
+  ipatrust:
+    ipaadmin_password: SomeADMINpassword
+    ipaapi_context: "{{ ipa_context | default(omit) }}"
+    realm: "{{ adserver.domain }}"
+    admin: Administrator
+    password: "{{ adserver.password }}"
+    base_id: "{{ trust_base_id | default(omit) }}"
+    range_type: "{{ trust_range_type | default(omit) }}"
+    range_size: "{{ trust_range_size | default(omit) }}"
+  register: result
+  failed_when: result.failed
+
+- name: Retrieve Domain Security Identifier
+  shell:
+    cmd: |
+      kinit -c test_krb5_cache admin <<< SomeADMINpassword > /dev/null
+      KRB5CCNAME=test_krb5_cache ipa trust-show {{ adserver.domain }} | sed -n "/Domain Security Identifier/s/ //gp" | cut -d":" -f2
+      kdestroy -c test_krb5_cache -A -q > /dev/null
+  register: getsid
+  no_log: yes
+
+- name: Set ipa_domain_sid.
+  set_fact:
+    ipa_domain_sid: "{{ getsid.stdout }}"

--- a/tests/idrange/test_idrange.yml
+++ b/tests/idrange/test_idrange.yml
@@ -1,0 +1,280 @@
+---
+- name: Test idrange
+  hosts: "{{ ipa_test_host | default('ipaserver') }}"
+  become: no
+  gather_facts: no
+
+  vars:
+    adserver:
+      domain: "{{ winserver_domain | default('windows.local')}}"
+      realm: "{{ winserver_realm | default(winserver_domain) | default('windows.local') | upper }}"
+      password: "{{ winserver_admin_password | default('SomeW1Npassword') }}"
+      ip_address: "{{ winserver_ip | default(omit) }}"
+
+  tasks:
+  # CLEANUP TEST ITEMS
+  - name: Remove test trust.
+    include_tasks: tasks_remove_trust.yml
+    when: trust_test_is_supported | default(false)
+
+  - name: Ensure testing idranges are absent
+    ipaidrange:
+      ipaadmin_password: SomeADMINpassword
+      ipaapi_context: "{{ ipa_context | default(omit) }}"
+      name:
+        - "{{ adserver.realm }}_id_range"
+        - local_id_range
+        - ad_id_range
+        - ad_posix_id_range
+      continue: yes
+      state: absent
+
+  # CREATE TEST ITEMS
+
+  # TESTS
+
+  # Test local idrange, only if ipa-adtrust-install was not executed.
+  - block:
+      - name: Ensure idrange with minimal attributes is present
+        ipaidrange:
+          ipaadmin_password: SomeADMINpassword
+          ipaapi_context: "{{ ipa_context | default(omit) }}"
+          name: local_id_range
+          base_id: 150000000
+          range_size: 200000
+        register: result
+        failed_when:
+          not (result.failed or result.changed) or (result.failed and 'ipa-adtrust-install has already been run' not in result.msg)
+
+      - name: Ensure idrange with minimal attributes is present, again
+        ipaidrange:
+          ipaadmin_password: SomeADMINpassword
+          ipaapi_context: "{{ ipa_context | default(omit) }}"
+          name: local_id_range
+          base_id: 150000000
+          range_size: 200000
+        register: result
+        failed_when:
+          result.changed or (result.failed and 'ipa-adtrust-install has already been run' not in result.msg)
+
+      - name: Ensure idrange with minimal attributes is absent
+        ipaidrange:
+          ipaadmin_password: SomeADMINpassword
+          ipaapi_context: "{{ ipa_context | default(omit) }}"
+          name: local_id_range
+          state: absent
+        register: range_delete
+        failed_when: range_delete.failed or (result.changed and not range_delete.changed)
+
+      # Test local idrange, even after ipa-adtrust-install.
+      - name: Ensure local idrange is present
+        ipaidrange:
+          ipaadmin_password: SomeADMINpassword
+          ipaapi_context: "{{ ipa_context | default(omit) }}"
+          name: local_id_range
+          base_id: 150000000
+          range_size: 200000
+          rid_base: 1000000
+          secondary_rid_base: 200000000
+        register: result
+        failed_when: not result.changed or result.failed
+
+      - name: Ensure local idrange is present again
+        ipaidrange:
+          ipaadmin_password: SomeADMINpassword
+          ipaapi_context: "{{ ipa_context | default(omit) }}"
+          name: local_id_range
+          base_id: 150000000
+          range_size: 200000
+          rid_base: 1000000
+          secondary_rid_base: 200000000
+        register: result
+        failed_when: result.changed or result.failed
+
+      - name: Ensure local idrange is absent
+        ipaidrange:
+          ipaadmin_password: SomeADMINpassword
+          ipaapi_context: "{{ ipa_context | default(omit) }}"
+          name: local_id_range
+          state: absent
+          continue: no
+        register: result
+        failed_when: not result.changed or result.failed
+
+      - name: Ensure local idrange is absent again
+        ipaidrange:
+          ipaadmin_password: SomeADMINpassword
+          ipaapi_context: "{{ ipa_context | default(omit) }}"
+          name: local_id_range
+          state: absent
+          continue: no
+        register: result
+        failed_when: result.changed or result.failed
+
+    rescue:
+      - name: Ensure local idranges is absent
+        ipaidrange:
+          ipaadmin_password: SomeADMINpassword
+          ipaapi_context: "{{ ipa_context | default(omit) }}"
+          name: local_id_range
+
+  - block:
+      # Create trust with range_type: ipa-ad-trust-posix
+      - name: Create trust with range_type 'ipa-ad-trust'
+        include_tasks: tasks_set_trust.yml
+        vars:
+          trust_base_id: 10000000
+          trust_range_size: 200000
+          trust_range_type: ipa-ad-trust
+
+      # Can't user secondary_rid_base with dom_sid/dom_name
+      - name: Ensure AD-trust idrange is present
+        ipaidrange:
+          ipaadmin_password: SomeADMINpassword
+          ipaapi_context: "{{ ipa_context | default(omit) }}"
+          name: ad_id_range
+          base_id: 150000000
+          range_size: 200000
+          rid_base: 1000000
+          idrange_type: ipa-ad-trust
+          dom_sid: "{{ ipa_domain_sid }}"
+          auto_private_groups: "false"
+        register: result
+        failed_when: not result.changed or result.failed
+
+      - name: Ensure AD-trust idrange is present again
+        ipaidrange:
+          ipaadmin_password: SomeADMINpassword
+          ipaapi_context: "{{ ipa_context | default(omit) }}"
+          name: ad_id_range
+          base_id: 150000000
+          range_size: 200000
+          rid_base: 1000000
+          idrange_type: ipa-ad-trust
+          dom_sid: "{{ ipa_domain_sid }}"
+          auto_private_groups: "false"
+        register: result
+        failed_when: result.changed or result.failed
+
+      - name: Check if AD-trust idrange is present, uning domain name
+        ipaidrange:
+          ipaadmin_password: SomeADMINpassword
+          ipaapi_context: "{{ ipa_context | default(omit) }}"
+          name: ad_id_range
+          base_id: 150000000
+          range_size: 200000
+          rid_base: 1000000
+          idrange_type: ipa-ad-trust
+          dom_name: "{{ adserver.domain }}"
+          auto_private_groups: "false"
+        check_mode: true
+        register: result
+        failed_when: result.changed or result.failed
+
+      - name: Modify AD-trust idrange 'base_id'
+        ipaidrange:
+          ipaadmin_password: SomeADMINpassword
+          ipaapi_context: "{{ ipa_context | default(omit) }}"
+          name: ad_id_range
+          base_id: 151230000
+        register: result
+        failed_when: not result.changed or result.failed
+
+      - name: Modify AD-trust idrange 'base_id', again
+        ipaidrange:
+          ipaadmin_password: SomeADMINpassword
+          ipaapi_context: "{{ ipa_context | default(omit) }}"
+          name: ad_id_range
+          base_id: 151230000
+        register: result
+        failed_when: result.changed or result.failed
+
+      - name: Modify AD-trust idrange 'range_size'
+        ipaidrange:
+          ipaadmin_password: SomeADMINpassword
+          ipaapi_context: "{{ ipa_context | default(omit) }}"
+          name: ad_id_range
+          range_size: 100000
+        register: result
+        failed_when: not result.changed or result.failed
+
+      - name: Modify AD-trust idrange 'rid_base'
+        ipaidrange:
+          ipaadmin_password: SomeADMINpassword
+          ipaapi_context: "{{ ipa_context | default(omit) }}"
+          name: ad_id_range
+          rid_base: 12345678
+        register: result
+        failed_when: not result.changed or result.failed
+
+      - name: Modify AD-trust idrange 'auto_private_groups'
+        ipaidrange:
+          ipaadmin_password: SomeADMINpassword
+          ipaapi_context: "{{ ipa_context | default(omit) }}"
+          name: ad_id_range
+          auto_private_groups: "hybrid"
+        register: result
+        failed_when: not result.changed or result.failed
+
+      # Remove trust and idrange
+      - name: Remove test trust.
+        include_tasks: tasks_remove_trust.yml
+
+      - name: Ensure AD-trust idrange is absent
+        ipaidrange:
+          ipaadmin_password: SomeADMINpassword
+          ipaapi_context: "{{ ipa_context | default(omit) }}"
+          name: ad_id_range
+          state: absent
+
+      # Create trust with range_type: ipa-ad-trust-posix
+      - name: Create trust with range_type 'ipa-ad-trust-posix'
+        include_tasks: tasks_set_trust.yml
+        vars:
+          trust_base_id: 10000000
+          trust_range_size: 2000000
+          trust_range_type: ipa-ad-trust-posix
+
+      # Can't user secondary_rid_base or rid_base with "ad-trust-posix"
+      - name: Ensure AD-trust-posix idrange is present
+        ipaidrange:
+          ipaadmin_password: SomeADMINpassword
+          ipaapi_context: "{{ ipa_context | default(omit) }}"
+          name: ad_posix_id_range
+          base_id: 150000000
+          range_size: 200000
+          idrange_type: ipa-ad-trust-posix
+          dom_sid: "{{ ipa_domain_sid }}"
+        register: result
+        failed_when: not result.changed or result.failed
+
+      - name: Ensure AD-trust-posix idrange is present again
+        ipaidrange:
+          ipaadmin_password: SomeADMINpassword
+          ipaapi_context: "{{ ipa_context | default(omit) }}"
+          name: ad_posix_id_range
+          base_id: 150000000
+          range_size: 200000
+          idrange_type: ipa-ad-trust-posix
+          dom_sid: "{{ ipa_domain_sid }}"
+        register: result
+        failed_when: result.changed or result.failed
+
+    always:
+      # CLEANUP TEST ITEMS
+      - name: Remove test trust.
+        include_tasks: tasks_remove_trust.yml
+
+      - name: Ensure testing idranges are absent
+        ipaidrange:
+          ipaadmin_password: SomeADMINpassword
+          ipaapi_context: "{{ ipa_context | default(omit) }}"
+          name:
+            - "{{ adserver.realm }}_id_range"
+            - local_id_range
+            - ad_id_range
+            - ad_posix_id_range
+          continue: yes
+          state: absent
+
+    when: trust_test_is_supported | default(false)

--- a/tests/idrange/test_idrange_client_context.yml
+++ b/tests/idrange/test_idrange_client_context.yml
@@ -1,0 +1,39 @@
+---
+- name: Test idrange
+  hosts: ipaclients, ipaserver
+  # Change "become" or "gather_facts" to "yes",
+  # if you test playbook requires any.
+  become: no
+  gather_facts: no
+
+  tasks:
+  - name: Include FreeIPA facts.
+    include_tasks: ../env_freeipa_facts.yml
+
+  # Test will only be executed if host is not a server.
+  - name: Execute with server context in the client.
+    ipaidrange:
+      ipaadmin_password: SomeADMINpassword
+      ipaapi_context: server
+      name: ThisShouldNotWork
+    register: result
+    failed_when: not (result.failed and result.msg is regex("No module named '*ipaserver'*"))
+    when: ipa_host_is_client
+
+# Import basic module tests, and execute with ipa_context set to 'client'.
+# If ipaclients is set, it will be executed using the client, if not,
+# ipaserver will be used.
+#
+# With this setup, tests can be executed against an IPA client, against
+# an IPA server using "client" context, and ensure that tests are executed
+# in upstream CI.
+
+- name: Test idrange using client context, in client host.
+  import_playbook: test_idrange.yml
+  when: groups['ipaclients']
+  vars:
+    ipa_test_host: ipaclients
+
+- name: Test idrange using client context, in server host.
+  import_playbook: test_idrange.yml
+  when: groups['ipaclients'] is not defined or not groups['ipaclients']


### PR DESCRIPTION
> Note: PR #810 must be merged before this one. Commit 7c1f4c591a32a0f81f64c4ed6e7d2a3e2e120fe9 is part of #810 but is required to test `ipaidrange`.

There is a new idrange management module placed in the plugins folder:

    plugins/modules/ipaidrange.py


The idrange module allows to ensure presence and absence of idranges.

Here is the documentation of the module:

    README-idrange.md

New example playbooks have been added:

    playbooks/idrange/idrange-absent.yml
    playbooks/idrange/idrange-ad-posix-present.yml
    playbooks/idrange/idrange-ad-present.yml
    playbooks/idrange/idrange-present.yml

New tests for the module can be found at:

    tests/idrange/test_idrange.yml
    tests/idrange/test_idrange_client_context.yml