### PR TITLE
ansible-lint: Identify env_*.yml and tasks_*.yml as task files.

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -14,6 +14,8 @@ exclude_paths:
 kinds:
   - playbook: '**/tests/**/test_*.yml'
   - playbook: '**/playbooks/**/*.yml'
+  - tasks: '**/tasks_*.yml'
+  - tasks: '**/env_*.yml'
 
 parseable: true
 


### PR DESCRIPTION
Failing to identify task files included by playbooks raised false
positives when runnnig ansible lint. This change force ansible-lint to
correctly identify YAML files named "env_*.yml" or "tasks_*.yml" as task
files that are imported by other playbooks, and treat them accordingly.