### PR TITLE
ipaautomountmap: Fix parameter evaluation.

### DIFF
--- a/plugins/modules/ipaautomountmap.py
+++ b/plugins/modules/ipaautomountmap.py
@@ -112,12 +112,12 @@ class AutomountMap(IPAAnsibleModule):
         state = self.params_get("state")
         if state == "present":
             if len(name) != 1:
-                self.fail_json(msg="Exactly one name must be provided \
-                                for state=present.")
+                self.fail_json(msg="Exactly one name must be provided for"
+                                   " 'state: present'.")
         if state == "absent":
             if len(name) == 0:
-                self.fail_json(msg="Argument 'map_type' can not be used with "
-                                   "state 'absent'")
+                self.fail_json(msg="At least one 'name' must be provided for"
+                                   " 'state: absent'")
             invalid = ["desc"]
 
         self.params_fail_used_invalid(invalid, state)

--- a/plugins/modules/ipaautomountmap.py
+++ b/plugins/modules/ipaautomountmap.py
@@ -123,9 +123,10 @@ class AutomountMap(IPAAnsibleModule):
         self.params_fail_used_invalid(invalid, state)
 
     def get_args(self, mapname, desc):  # pylint: disable=no-self-use
-        _args = {}
-        if mapname:
-            _args["automountmapname"] = mapname
+        # automountmapname is required for all automountmap operations.
+        if not mapname:
+            self.fail_json(msg="automountmapname cannot be None or empty.")
+        _args = {"automountmapname": mapname}
         # An empty string is valid and will clear the attribute.
         if desc is not None:
             _args["description"] = desc


### PR DESCRIPTION
This PR improves parameter checking and error messages
in `ipaautomountmap` module.

* Commit 1a31f62a6f63689ea2f35775cc1d16c446078b96:
    > Fix error messages when the wrong number of 'name' is
    provided

* Commit  23e07a9a17d76ed469ed03805d645503f27f7fde:
    > Ensure automountmapname is never None or empty, and
    is always set in calls to IPA API.