### PR TITLE
upstream CI: Add support for testing ansible-freeipa as a collection.

### DIFF
--- a/tests/azure/azure-pipelines.yml
+++ b/tests/azure/azure-pipelines.yml
@@ -18,6 +18,17 @@ stages:
       scenario: fedora-latest
       ansible_version: "-core >=2.12,<2.13"
 
+# Galaxy on Fedora
+
+- stage: Galaxy_Fedora_Latest
+  dependsOn: []
+  jobs:
+  - template: templates/galaxy_tests.yml
+    parameters:
+      build_number: $(Build.BuildNumber)
+      scenario: fedora-latest
+      ansible_version: "-core >=2.12,<2.13"
+
 # CentOS 9 Stream
 
 - stage: CentOS_9_Stream

--- a/tests/azure/nightly.yml
+++ b/tests/azure/nightly.yml
@@ -61,6 +61,53 @@ stages:
       scenario: fedora-latest
       ansible_version: "-core"
 
+# Galaxy on Fedora
+
+- stage: Galaxy_FedoraLatest_Ansible_2_9
+  dependsOn: []
+  jobs:
+  - template: templates/galaxy_tests.yml
+    parameters:
+      build_number: $(Build.BuildNumber)
+      scenario: fedora-latest
+      ansible_version: ">=2.9,<2.10"
+
+- stage: Galaxy_FedoraLatest_Ansible_Core_2_11
+  dependsOn: []
+  jobs:
+  - template: templates/galaxy_tests.yml
+    parameters:
+      build_number: $(Build.BuildNumber)
+      scenario: fedora-latest
+      ansible_version: "-core >=2.11,<2.12"
+
+# - stage: Galaxy_FedoraLatest_Ansible_Core_2_12
+#   dependsOn: []
+#   jobs:
+#   - template: templates/galaxy_tests.yml
+#     parameters:
+#       build_number: $(Build.BuildNumber)
+#       scenario: fedora-latest
+#       ansible_version: "-core >=2.12,<2.13"
+
+- stage: Galaxy_FedoraLatest_Ansible_latest
+  dependsOn: []
+  jobs:
+  - template: templates/galaxy_tests.yml
+    parameters:
+      build_number: $(Build.BuildNumber)
+      scenario: fedora-latest
+      ansible_version: ""
+
+- stage: Galaxy_FedoraLatest_Ansible_Core_latest
+  dependsOn: []
+  jobs:
+  - template: templates/galaxy_tests.yml
+    parameters:
+      build_number: $(Build.BuildNumber)
+      scenario: fedora-latest
+      ansible_version: "-core"
+
 # CentoOS 9 Stream
 
 - stage: c9s_Ansible_2_9

--- a/tests/azure/templates/galaxy_pytest_script.yml
+++ b/tests/azure/templates/galaxy_pytest_script.yml
@@ -1,0 +1,58 @@
+---
+parameters:
+  - name: build_number
+    type: string
+  - name: scenario
+    type: string
+    default: fedora-latest
+  - name: ansible_version
+    type: string
+    default: ""
+  - name: python_version
+    type: string
+    default: 3.x
+
+jobs:
+- job: Test_PyTests
+  displayName: Run pytests on ${{ parameters.scenario }}
+  timeoutInMinutes: 120
+  steps:
+  - task: UsePythonVersion@0
+    inputs:
+      versionSpec: '${{ parameters.python_version }}'
+
+  - script: |
+      pip install \
+        "molecule[docker]>=3" \
+        "ansible${{ parameters.ansible_version }}"
+    displayName: Install molecule and Ansible
+
+  - script: ansible-galaxy collection install community.docker ansible.posix
+    displayName: Install Ansible collections
+
+  - script: pip install -r requirements-tests.txt
+    displayName: Install dependencies
+  - script: |
+      utils/build-galaxy-release.sh -i
+      molecule create -s ${{ parameters.scenario }}
+    displayName: Setup test container
+    env:
+      ANSIBLE_LIBRARY: ./molecule
+
+  - script: |
+      cd ~/.ansible/collections/ansible_collections/freeipa/ansible_freeipa
+      pytest \
+        -m "not playbook" \
+        --verbose \
+        --color=yes \
+        --junit-xml=TEST-results-pytests.xml
+    displayName: Run tests
+    env:
+      IPA_SERVER_HOST: ${{ parameters.scenario }}
+      RUN_TESTS_IN_DOCKER: true
+
+  - task: PublishTestResults@2
+    inputs:
+      mergeTestResults: true
+      testRunTitle: PlaybookTests-Build${{ parameters.build_number }}
+    condition: succeededOrFailed()

--- a/tests/azure/templates/galaxy_script.yml
+++ b/tests/azure/templates/galaxy_script.yml
@@ -1,0 +1,75 @@
+---
+parameters:
+  - name: group_number
+    type: number
+    default: 1
+  - name: number_of_groups
+    type: number
+    default: 1
+  - name: scenario
+    type: string
+    default: fedora-latest
+  - name: ansible_version
+    type: string
+    default: ""
+  - name: python_version
+    type: string
+    default: 3.x
+  - name: build_number
+    type: string
+
+
+jobs:
+- job: Test_Group${{ parameters.group_number }}
+  displayName: Run playbook tests ${{ parameters.scenario }} (${{ parameters.group_number }}/${{ parameters.number_of_groups }})
+  timeoutInMinutes: 120
+  variables:
+  - template: variables.yaml
+  steps:
+  - task: UsePythonVersion@0
+    inputs:
+      versionSpec: '${{ parameters.python_version }}'
+
+  - script: |
+      pip install \
+        "molecule[docker]>=3" \
+        "ansible${{ parameters.ansible_version }}"
+    displayName: Install molecule and Ansible
+
+  - script: ansible-galaxy collection install community.docker ansible.posix
+    displayName: Install Ansible collections
+
+  - script: pip install -r requirements-tests.txt
+    displayName: Install dependencies
+
+  - script: |
+      utils/build-galaxy-release.sh -i
+      molecule create -s ${{ parameters.scenario }}
+    displayName: Setup test container
+    env:
+      ANSIBLE_LIBRARY: ./molecule
+
+  - script: |
+      cd ~/.ansible/collections/ansible_collections/freeipa/ansible_freeipa
+      pytest \
+        -m "playbook" \
+        --verbose \
+        --color=yes \
+        --test-group-count=${{ parameters.number_of_groups }} \
+        --test-group=${{ parameters.group_number }} \
+        --test-group-random-seed=97943259814 \
+        --junit-xml=TEST-results-group-${{ parameters.group_number }}.xml
+    displayName: Run playbook tests
+    env:
+      IPA_SERVER_HOST: ${{ parameters.scenario }}
+      RUN_TESTS_IN_DOCKER: true
+      IPA_DISABLED_MODULES: ${{ variables.ipa_disabled_modules }}
+      IPA_DISABLED_TESTS: ${{ variables.ipa_disabled_tests }}
+      IPA_ENABLED_MODULES: ${{ variables.ipa_enabled_modules }}
+      IPA_ENABLED_TESTS: ${{ variables.ipa_enabled_tests }}
+
+  - task: PublishTestResults@2
+    inputs:
+      mergeTestResults: true
+      testRunTitle: PlaybookTests-Build${{ parameters.build_number }}
+    condition: succeededOrFailed()

--- a/tests/azure/templates/galaxy_tests.yml
+++ b/tests/azure/templates/galaxy_tests.yml
@@ -1,0 +1,41 @@
+---
+parameters:
+  - name: scenario
+    type: string
+    default: fedora-latest
+  - name: build_number
+    type: string
+  - name: ansible_version
+    type: string
+    default: ""
+
+jobs:
+- template: galaxy_script.yml
+  parameters:
+    group_number: 1
+    number_of_groups: 3
+    build_number: ${{ parameters.build_number }}
+    scenario: ${{ parameters.scenario }}
+    ansible_version: ${{ parameters.ansible_version }}
+
+- template: galaxy_script.yml
+  parameters:
+    group_number: 2
+    number_of_groups: 3
+    build_number: ${{ parameters.build_number }}
+    scenario: ${{ parameters.scenario }}
+    ansible_version: ${{ parameters.ansible_version }}
+
+- template: galaxy_script.yml
+  parameters:
+    group_number: 3
+    number_of_groups: 3
+    build_number: ${{ parameters.build_number }}
+    scenario: ${{ parameters.scenario }}
+    ansible_version: ${{ parameters.ansible_version }}
+
+- template: galaxy_pytest_script.yml
+  parameters:
+    build_number: ${{ parameters.build_number }}
+    scenario: ${{ parameters.scenario }}
+    ansible_version: ${{ parameters.ansible_version }}


### PR DESCRIPTION
Provide a pipeline to test ansible-freeipa as an Ansible Galaxy
collection. The tests will use 'utils/build-galaxy-release.sh' to
create the galaxy release file, install it as a collection, andrun the
tests in it, which were modified to use FQCN.

The tests will run only on 'fedora-latest' for each PR, and on all
platforms for nightly and weekly tests.