### PR TITLE
Temporarily ignore dns forwarder errors.

### DIFF
--- a/tests/sanity/ignore-2.12.txt
+++ b/tests/sanity/ignore-2.12.txt
@@ -43,7 +43,6 @@ tests/sanity/sanity.sh shebang!skip
 tests/user/users.sh shebang!skip
 tests/user/users_absent.sh shebang!skip
 tests/utils.py pylint:ansible-format-automatic-specification
-tests/utils.py pylint:subprocess-run-check
 utils/ansible-doc-test shebang!skip
 utils/ansible-ipa-client-install shebang!skip
 utils/ansible-ipa-replica-install shebang!skip

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -112,6 +112,7 @@ def _run_playbook(playbook):
             inventory_file.name,
             playbook,
         ]
+        # pylint: disable=subprocess-run-check
         process = subprocess.run(
             cmd, cwd=SCRIPT_DIR, stdout=subprocess.PIPE, stderr=subprocess.PIPE
         )
@@ -238,9 +239,11 @@ class AnsibleFreeIPATestCase(TestCase):
             host_connection_info, ssh_identity_file=ssh_identity_file,
         )
 
+    # pylint:disable=no-self-use
     def run_playbook(self, playbook, allow_failures=False):
         return run_playbook(playbook, allow_failures)
 
+    # pylint:enable=no-self-use
     def run_playbook_with_exp_msg(self, playbook, expected_msg):
         result = self.run_playbook(playbook, allow_failures=True)
         assert (

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -199,6 +199,9 @@ def get_test_playbooks():
     test_dirs = os.listdir(SCRIPT_DIR)
     groups = {}
     for test_group_dir in sorted(test_dirs):
+        # TODO: Remove this when forwarders with port issue is fixed.
+        if test_group_dir in ['dnsconfig', 'dnsforwardzone']:
+            continue
         group_dir_path = os.path.join(SCRIPT_DIR, test_group_dir)
         if not os.path.isdir(group_dir_path):
             continue


### PR DESCRIPTION
Due to a [FreeIPA issue](https://pagure.io/freeipa/issue/9158), `dnsconfig` and `dnsforwardzone` tests must be disabled.
