### PR TITLE
ansible_freeipa_module: pylint fixes.

### DIFF
--- a/plugins/module_utils/ansible_freeipa_module.py
+++ b/plugins/module_utils/ansible_freeipa_module.py
@@ -900,6 +900,8 @@ else:
             # pylint: disable=super-with-arguments
             super(IPAAnsibleModule, self).__init__(*args, **kwargs)
 
+            self.__ipa_api_domain = None
+
         @contextmanager
         def ipa_connect(self, context=None):
             """
@@ -1029,9 +1031,9 @@ else:
 
         def ipa_get_domain(self):
             """Retrieve IPA API domain."""
-            if not hasattr(self, "__ipa_api_domain"):
-                setattr(self, "__ipa_api_domain", api_get_domain())
-            return getattr(self, "__ipa_api_domain")
+            if self.__ipa_api_domain is None:
+                self.__ipa_api_domain = api_get_domain()
+            return self.__ipa_api_domain
 
         @staticmethod
         def ipa_get_realm():

--- a/setup.cfg
+++ b/setup.cfg
@@ -71,7 +71,8 @@ ignored-modules =
     ipaplatform, ipaplatform.paths, ipaplatform.tasks, ipapython.admintool,
     ipaserver.install.installutils, ipaserver.install.server.install,
     ipaserver.install,
-    ipaclient.install.ipachangeconf, ipaclient.install.client
+    ipaclient.install.ipachangeconf, ipaclient.install.client,
+    SSSDConfig
 
 [pylint.REFACTORING]
 max-nested-blocks = 9


### PR DESCRIPTION
With current pylint version on Fedora 36, pylint complain of a few
issues in module_utils/ansible_freeipa_module.py.

To fix the issues, a module was added to the 'ignored modules' list,
and an instance variable was added to IPAAnsibleModule.