### PR TITLE
requirements-dev: Update requirements for virtual environments

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,12 @@
 -r requirements-tests.txt
-ipdb
+ipdb==0.13.4
 pre-commit
+flake8==4.0.1
 flake8-bugbear
-pylint==2.12.2
+pylint==2.13.7
+pydocstyle==6.0.0
+yamllint==1.26.3
+ansible-lint==5.3.2
+dnspython==2.2.0
+netaddr==0.8.0
+gssapi==1.7.2


### PR DESCRIPTION
When developing ansible-freeipa using a Python virtual environment,
some ansible-freeipa utility scripts failed to execute due to missing
tools.

This patch add the required tools and modules to requirements-dev.txt
and pin the versions to the same available in Fedora 36.