### PR TITLE
upstream CI: Update nightly Ansible versions.

### DIFF
--- a/tests/azure/nightly.yml
+++ b/tests/azure/nightly.yml
@@ -16,15 +16,6 @@ stages:
 
 # Fedora
 
-- stage: FedoraLatest_Ansible_2_9
-  dependsOn: []
-  jobs:
-  - template: templates/group_tests.yml
-    parameters:
-      build_number: $(Build.BuildNumber)
-      scenario: fedora-latest
-      ansible_version: ">=2.9,<2.10"
-
 - stage: FedoraLatest_Ansible_Core_2_11
   dependsOn: []
   jobs:
@@ -62,15 +53,6 @@ stages:
       ansible_version: "-core"
 
 # Galaxy on Fedora
-
-- stage: Galaxy_FedoraLatest_Ansible_2_9
-  dependsOn: []
-  jobs:
-  - template: templates/galaxy_tests.yml
-    parameters:
-      build_number: $(Build.BuildNumber)
-      scenario: fedora-latest
-      ansible_version: ">=2.9,<2.10"
 
 - stage: Galaxy_FedoraLatest_Ansible_Core_2_11
   dependsOn: []
@@ -110,15 +92,6 @@ stages:
 
 # CentoOS 9 Stream
 
-- stage: c9s_Ansible_2_9
-  dependsOn: []
-  jobs:
-  - template: templates/group_tests.yml
-    parameters:
-      build_number: $(Build.BuildNumber)
-      scenario: c9s
-      ansible_version: ">=2.9,<2.10"
-
 - stage: c9s_Ansible_Core_2_11
   dependsOn: []
   jobs:
@@ -157,15 +130,6 @@ stages:
 
 # CentOS 8 Stream
 
-- stage: c8s_Ansible_2_9
-  dependsOn: []
-  jobs:
-  - template: templates/group_tests.yml
-    parameters:
-      build_number: $(Build.BuildNumber)
-      scenario: c8s
-      ansible_version: ">=2.9,<2.10"
-
 - stage: c8s_Ansible_Core_2_11
   dependsOn: []
   jobs:
@@ -203,15 +167,6 @@ stages:
       ansible_version: "-core"
 
 # CentOS 7
-
-- stage: CentOS7_Ansible_2_9
-  dependsOn: []
-  jobs:
-  - template: templates/group_tests.yml
-    parameters:
-      build_number: $(Build.BuildNumber)
-      scenario: centos-7
-      ansible_version: ">=2.9,<2.10"
 
 - stage: CentOS7_Ansible_Core_2_11
   dependsOn: []

--- a/tests/azure/nightly.yml
+++ b/tests/azure/nightly.yml
@@ -25,14 +25,14 @@ stages:
       scenario: fedora-latest
       ansible_version: "-core >=2.11,<2.12"
 
-# - stage: FedoraLatest_Ansible_Core_2_12
-#   dependsOn: []
-#   jobs:
-#   - template: templates/group_tests.yml
-#     parameters:
-#       build_number: $(Build.BuildNumber)
-#       scenario: fedora-latest
-#       ansible_version: "-core >=2.12,<2.13"
+- stage: FedoraLatest_Ansible_Core_2_12
+  dependsOn: []
+  jobs:
+  - template: templates/group_tests.yml
+    parameters:
+      build_number: $(Build.BuildNumber)
+      scenario: fedora-latest
+      ansible_version: "-core >=2.12,<2.13"
 
 - stage: FedoraLatest_Ansible_latest
   dependsOn: []
@@ -63,14 +63,14 @@ stages:
       scenario: fedora-latest
       ansible_version: "-core >=2.11,<2.12"
 
-# - stage: Galaxy_FedoraLatest_Ansible_Core_2_12
-#   dependsOn: []
-#   jobs:
-#   - template: templates/galaxy_tests.yml
-#     parameters:
-#       build_number: $(Build.BuildNumber)
-#       scenario: fedora-latest
-#       ansible_version: "-core >=2.12,<2.13"
+- stage: Galaxy_FedoraLatest_Ansible_Core_2_12
+  dependsOn: []
+  jobs:
+  - template: templates/galaxy_tests.yml
+    parameters:
+      build_number: $(Build.BuildNumber)
+      scenario: fedora-latest
+      ansible_version: "-core >=2.12,<2.13"
 
 - stage: Galaxy_FedoraLatest_Ansible_latest
   dependsOn: []
@@ -101,14 +101,14 @@ stages:
       scenario: c9s
       ansible_version: "-core >=2.11,<2.12"
 
-# - stage: c9s_Ansible_Core_2_12
-#   dependsOn: []
-#   jobs:
-#   - template: templates/group_tests.yml
-#     parameters:
-#       build_number: $(Build.BuildNumber)
-#       scenario: c9s
-#       ansible_version: "-core >=2.12,<2.13"
+- stage: c9s_Ansible_Core_2_12
+  dependsOn: []
+  jobs:
+  - template: templates/group_tests.yml
+    parameters:
+      build_number: $(Build.BuildNumber)
+      scenario: c9s
+      ansible_version: "-core >=2.12,<2.13"
 
 - stage: c9s_Ansible_latest
   dependsOn: []
@@ -139,14 +139,14 @@ stages:
       scenario: c8s
       ansible_version: "-core >=2.11,<2.12"
 
-# - stage: c8s_Ansible_Core_2_12
-#   dependsOn: []
-#   jobs:
-#   - template: templates/group_tests.yml
-#     parameters:
-#       build_number: $(Build.BuildNumber)
-#       scenario: c8s
-#       ansible_version: "-core >=2.12,<2.13"
+- stage: c8s_Ansible_Core_2_12
+  dependsOn: []
+  jobs:
+  - template: templates/group_tests.yml
+    parameters:
+      build_number: $(Build.BuildNumber)
+      scenario: c8s
+      ansible_version: "-core >=2.12,<2.13"
 
 - stage: c8s_Ansible_latest
   dependsOn: []
@@ -177,14 +177,14 @@ stages:
       scenario: centos-7
       ansible_version: "-core >=2.11,<2.12"
 
-# - stage: CentOS7_Ansible_Core_2_12
-#   dependsOn: []
-#   jobs:
-#   - template: templates/group_tests.yml
-#     parameters:
-#       build_number: $(Build.BuildNumber)
-#       scenario: centos-7
-#       ansible_version: "-core >=2.12,<2.13"
+- stage: CentOS7_Ansible_Core_2_12
+  dependsOn: []
+  jobs:
+  - template: templates/group_tests.yml
+    parameters:
+      build_number: $(Build.BuildNumber)
+      scenario: centos-7
+      ansible_version: "-core >=2.12,<2.13"
 
 - stage: CentOS7_Ansible_latest
   dependsOn: []


### PR DESCRIPTION
In upstream, Ansible only supports the latest version and the two
previous versions. Today, the versions supported are 2.13 (latest),
2.12 and 2.11.

ansible-freeipa upstream tests should only use Ansible upstream
supported versions as a way to reduce the number of jobs in
the tests, and to avoid errors due to unsupported features.

This PR ensures that only Ansible versions, supported in upstream,
are used in ansible-freeipa test matrix.

This should not be merged before #825