### PR TITLE
[DRAFT] upstream CI: enhance test selection

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -81,6 +81,8 @@ If none of this variables are defined, all tests will be executed.
 
 To configure the tests that will run for your pull request, add a TEMP commit, with the configuration defined in the file `tests/azure/templates/variables.yml`. Set the variables `ipa_enable_modules`, `ipa_enable_tests`, `ipa_disable_modules`, and `ipa_disable_tests`, in the same way as the equivalent environment variables.
 
+To disable tests, based on the container image Linux distribution used, set the variables `ipa_disabled_<distro>_<version>` in the Azure varibles template file. For example, `ipa_disabled_fedora_36: hbacrule, test_location` would disable all `hbacrule` tests and the `location::test_location` test for the jobs running using `Fedora 36`. 
+
 ### Types of tests
 
 #### Playbook tests

--- a/tests/azure/templates/galaxy_pytest_script.yml
+++ b/tests/azure/templates/galaxy_pytest_script.yml
@@ -50,6 +50,14 @@ jobs:
     env:
       IPA_SERVER_HOST: ${{ parameters.scenario }}
       RUN_TESTS_IN_DOCKER: true
+      IPA_DISABLED_MODULES: ${{ variables.ipa_disabled_modules }}
+      IPA_DISABLED_TESTS: ${{ variables.ipa_disabled_tests }}
+      IPA_ENABLED_MODULES: ${{ variables.ipa_enabled_modules }}
+      IPA_ENABLED_TESTS: ${{ variables.ipa_enabled_tests }}
+      IPA_DISABLED_FEDORA_36: ${{ variables.ipa_disabled_fedora_36 }}
+      IPA_DISABLED_CENTOS_7: ${{ variables.ipa_disabled_centos_7 }}
+      IPA_DISABLED_CENTOS_8: ${{ variables.ipa_disabled_centos_8 }}
+      IPA_DISABLED_CENTOS_9: ${{ variables.ipa_disabled_centos_8 }}
 
   - task: PublishTestResults@2
     inputs:

--- a/tests/azure/templates/galaxy_script.yml
+++ b/tests/azure/templates/galaxy_script.yml
@@ -67,6 +67,10 @@ jobs:
       IPA_DISABLED_TESTS: ${{ variables.ipa_disabled_tests }}
       IPA_ENABLED_MODULES: ${{ variables.ipa_enabled_modules }}
       IPA_ENABLED_TESTS: ${{ variables.ipa_enabled_tests }}
+      IPA_DISABLED_FEDORA_36: ${{ variables.ipa_disabled_fedora_36 }}
+      IPA_DISABLED_CENTOS_7: ${{ variables.ipa_disabled_centos_7 }}
+      IPA_DISABLED_CENTOS_8: ${{ variables.ipa_disabled_centos_8 }}
+      IPA_DISABLED_CENTOS_9: ${{ variables.ipa_disabled_centos_8 }}
 
   - task: PublishTestResults@2
     inputs:

--- a/tests/azure/templates/playbook_tests.yml
+++ b/tests/azure/templates/playbook_tests.yml
@@ -68,6 +68,10 @@ jobs:
       IPA_DISABLED_TESTS: ${{ variables.ipa_disabled_tests }}
       IPA_ENABLED_MODULES: ${{ variables.ipa_enabled_modules }}
       IPA_ENABLED_TESTS: ${{ variables.ipa_enabled_tests }}
+      IPA_DISABLED_FEDORA_36: ${{ variables.ipa_disabled_fedora_36 }}
+      IPA_DISABLED_CENTOS_7: ${{ variables.ipa_disabled_centos_7 }}
+      IPA_DISABLED_CENTOS_8: ${{ variables.ipa_disabled_centos_8 }}
+      IPA_DISABLED_CENTOS_9: ${{ variables.ipa_disabled_centos_9 }}
 
   - task: PublishTestResults@2
     inputs:

--- a/tests/azure/templates/pytest_tests.yml
+++ b/tests/azure/templates/pytest_tests.yml
@@ -59,6 +59,10 @@ jobs:
       IPA_DISABLED_TESTS: ${{ variables.ipa_disabled_tests }}
       IPA_ENABLED_MODULES: ${{ variables.ipa_enabled_modules }}
       IPA_ENABLED_TESTS: ${{ variables.ipa_enabled_tests }}
+      IPA_DISABLED_FEDORA_36: ${{ variables.ipa_disabled_fedora_36 }}
+      IPA_DISABLED_CENTOS_7: ${{ variables.ipa_disabled_centos_7 }}
+      IPA_DISABLED_CENTOS_8: ${{ variables.ipa_disabled_centos_8 }}
+      IPA_DISABLED_CENTOS_9: ${{ variables.ipa_disabled_centos_8 }}
 
   - task: PublishTestResults@2
     inputs:

--- a/tests/azure/templates/variables.yaml
+++ b/tests/azure/templates/variables.yaml
@@ -18,3 +18,7 @@ variables:
     dnsconfig,
     dnsforwardzone,
   # ipa_disabled_tests: >-
+  # ipa_disabled_fedora_36: >-
+  # ipa_disabled_centos_7: >-
+  # ipa_disabled_centos_8: >-
+  # ipa_disabled_centos_9: >-

--- a/tests/azure/templates/variables.yaml
+++ b/tests/azure/templates/variables.yaml
@@ -15,14 +15,15 @@ variables:
   # ipa_enabled_modules: >-
   ipa_enabled_tests: >-
     group, user
-  # ipa_disabled_modules: >-
-  #   dnsconfig,
-  #   dnsforwardzone,
+
+  ipa_disabled_modules: >-
+    dnsconfig,
+    dnsforwardzone,
   # ipa_disabled_tests: >-
-  ipa_disabled_fedora_36: >-
-    group
-  ipa_disabled_centos_7: >-
-    user
-  ipa_disabled_centos_8: >-
-    group, user
+  # ipa_disabled_fedora_36: >-
+  #   group
+  # ipa_disabled_centos_7: >-
+  #   user
+  # ipa_disabled_centos_8: >-
+  #   group, user
   # ipa_disabled_centos_9: >-

--- a/tests/azure/templates/variables.yaml
+++ b/tests/azure/templates/variables.yaml
@@ -13,12 +13,16 @@
 ---
 variables:
   # ipa_enabled_modules: >-
-  # ipa_enabled_tests: >-
-  ipa_disabled_modules: >-
-    dnsconfig,
-    dnsforwardzone,
+  ipa_enabled_tests: >-
+    group, user
+  # ipa_disabled_modules: >-
+  #   dnsconfig,
+  #   dnsforwardzone,
   # ipa_disabled_tests: >-
-  # ipa_disabled_fedora_36: >-
-  # ipa_disabled_centos_7: >-
-  # ipa_disabled_centos_8: >-
+  ipa_disabled_fedora_36: >-
+    group
+  ipa_disabled_centos_7: >-
+    user
+  ipa_disabled_centos_8: >-
+    group, user
   # ipa_disabled_centos_9: >-

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -95,12 +95,12 @@ def get_disabled_test(group_name, test_name):
 def get_enabled_test(group_name, test_name):
     enabled_modules = [
         enabled.strip()
-        for enabled in os.environ.get("IPA_ENABLED_MODULES", "").split(":")
+        for enabled in os.environ.get("IPA_ENABLED_MODULES", "").split(",")
         if enabled.strip()
     ]
     enabled_tests = [
         enabled.strip()
-        for enabled in os.environ.get("IPA_ENABLED_TESTS", "").split(":")
+        for enabled in os.environ.get("IPA_ENABLED_TESTS", "").split(",")
         if enabled.strip()
     ]
 
@@ -127,9 +127,6 @@ def get_skip_conditions(group_name, test_name):
             "condition": True,
             "reason": "Environment variable IPA_SERVER_HOST must be set",
         }
-
-    if not get_enabled_test(group_name, test_name):
-        return {"condition": True, "reason": "Test not configured to run"}
 
     if get_disabled_test(group_name, test_name):
         return {"condition": True, "reason": "Test configured to not run"}


### PR DESCRIPTION
As seen on PR #845, sometimes it is required that tests are
disabled based on the Linux distribution used, and that tests
that are not selected to be executed are not scheduled for
execution.

This PR addresses both issues by adding new environment
variables (and the corresponding variable to Azure variables
template file) to configure tests that should not run based on
the distribution used for testing.

The available variables are:
* IPA_DISABLED_FEDORA_36: for Fedora 36
* IPA_DISABLED_CENTOS_9: for CentOS 9 Stream
* IPA_DISABLED_CENTOS_8: for CentOS 8 Stream
* IPA_DISABLED_CENTOS_7: for CentOS 7
