### PR TITLE
ipaserver: Use jinja for list concatenation

### DIFF
--- a/roles/ipaserver/tasks/copy_external_cert.yml
+++ b/roles/ipaserver/tasks/copy_external_cert.yml
@@ -11,4 +11,4 @@
     force: yes
 - name: Install - Extend ipaserver_external_cert_files with "/root/{{ item | basename }}"
   set_fact:
-    ipaserver_external_cert_files: "{{ ipaserver_external_cert_files }} + [ '/root/{{ item | basename }}' ]"
+    ipaserver_external_cert_files: "{{ ipaserver_external_cert_files + [ '/root/' + (item | basename) ] }}"


### PR DESCRIPTION
With ansible-2.13 it is required to use jinja for list concatenation.

  list: "[] + ['a'] + ['b']"

needs to become

  list: "{{ [] + ['a'] + ['b'] }}"

copy_external_cert.yml needed to be changed.