### PR TITLE
upstream CI: enable tests on Fedora Rawide.

### DIFF
--- a/molecule/fedora-rawhide-build/Dockerfile
+++ b/molecule/fedora-rawhide-build/Dockerfile
@@ -1,0 +1,30 @@
+FROM fedora:rawhide
+ENV container=docker
+
+RUN rm -fv /var/cache/dnf/metadata_lock.pid; \
+dnf makecache; \
+dnf --assumeyes install \
+    /usr/bin/python3 \
+    /usr/bin/python3-config \
+    /usr/bin/dnf-3 \
+    sudo \
+    bash \
+    systemd \
+    procps-ng \
+    iproute && \
+dnf clean all; \
+(cd /lib/systemd/system/sysinit.target.wants/; for i in *; do [ $i == systemd-tmpfiles-setup.service ] || rm -f $i; done); \
+rm -f /lib/systemd/system/multi-user.target.wants/*;\
+rm -f /etc/systemd/system/*.wants/*;\
+rm -f /lib/systemd/system/local-fs.target.wants/*; \
+rm -f /lib/systemd/system/sockets.target.wants/*udev*; \
+rm -f /lib/systemd/system/sockets.target.wants/*initctl*; \
+rm -f /lib/systemd/system/basic.target.wants/*;\
+rm -f /lib/systemd/system/anaconda.target.wants/*; \
+rm -rf /var/cache/dnf/;
+
+STOPSIGNAL RTMIN+3
+
+VOLUME ["/sys/fs/cgroup"]
+
+CMD ["/usr/sbin/init"]

--- a/molecule/fedora-rawhide-build/molecule.yml
+++ b/molecule/fedora-rawhide-build/molecule.yml
@@ -1,0 +1,19 @@
+---
+driver:
+  name: docker
+platforms:
+  - name: fedora-rawhide-build
+    image: "fedora:rawhide"
+    dockerfile: Dockerfile
+    hostname: ipaserver.test.local
+    dns_servers:
+      - 8.8.8.8
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    command: /usr/sbin/init
+    privileged: true
+provisioner:
+  name: ansible
+  playbooks:
+    prepare: ../resources/playbooks/prepare-build.yml
+prerun: false

--- a/molecule/fedora-rawhide/molecule.yml
+++ b/molecule/fedora-rawhide/molecule.yml
@@ -1,0 +1,19 @@
+---
+driver:
+  name: docker
+platforms:
+  - name: fedora-rawhide
+    image: quay.io/ansible-freeipa/upstream-tests:fedora-rawhide
+    pre_build_image: true
+    hostname: ipaserver.test.local
+    dns_servers:
+      - 127.0.0.1
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    command: /usr/sbin/init
+    privileged: true
+provisioner:
+  name: ansible
+  playbooks:
+    prepare: ../resources/playbooks/prepare.yml
+prerun: false

--- a/tests/azure/build-containers.yml
+++ b/tests/azure/build-containers.yml
@@ -38,3 +38,9 @@ jobs:
     job_name_suffix: FedoraLatest
     container_name: fedora-latest
     build_scenario_name: fedora-latest-build
+
+- template: templates/build_container.yml
+  parameters:
+    job_name_suffix: FedoraRawhide
+    container_name: fedora-rawhide
+    build_scenario_name: fedora-rawhide-build

--- a/tests/azure/nightly.yml
+++ b/tests/azure/nightly.yml
@@ -90,6 +90,44 @@ stages:
       scenario: fedora-latest
       ansible_version: "-core"
 
+# Fedora Rawhide
+
+- stage: FedoraRawhide_Ansible_Core_2_11
+  dependsOn: []
+  jobs:
+  - template: templates/group_tests.yml
+    parameters:
+      build_number: $(Build.BuildNumber)
+      scenario: fedora-rawhide
+      ansible_version: "-core >=2.11,<2.12"
+
+- stage: FedoraRawhide_Ansible_Core_2_12
+  dependsOn: []
+  jobs:
+  - template: templates/group_tests.yml
+    parameters:
+      build_number: $(Build.BuildNumber)
+      scenario: fedora-rawhide
+      ansible_version: "-core >=2.12,<2.13"
+
+- stage: FedoraRawhide_Ansible_latest
+  dependsOn: []
+  jobs:
+  - template: templates/group_tests.yml
+    parameters:
+      build_number: $(Build.BuildNumber)
+      scenario: fedora-rawhide
+      ansible_version: ""
+
+- stage: FedoraRawhide_Ansible_Core_latest
+  dependsOn: []
+  jobs:
+  - template: templates/group_tests.yml
+    parameters:
+      build_number: $(Build.BuildNumber)
+      scenario: fedora-rawhide
+      ansible_version: "-core"
+
 # CentoOS 9 Stream
 
 - stage: c9s_Ansible_Core_2_11


### PR DESCRIPTION
This patch enable upstream CI to build a testing Fedora Rawhide
container and enables its use in nightly and weekly test runs.