### PR TITLE
tests/server/test_server.yml: Fix generation of ipaserver_domain

### DIFF
--- a/tests/server/test_server.yml
+++ b/tests/server/test_server.yml
@@ -10,7 +10,7 @@
   - block:
       - name: Get server name from hostname
         set_fact:
-          ipa_server_name: "{{ ansible_facts['hostname'].split('.')[0] }}"
+          ipa_server_name: "{{ ansible_facts['fqdn'].split('.')[0] }}"
     rescue:
       - name: Fallback to 'ipaserver'
         set_fact:
@@ -20,7 +20,7 @@
   - block:
       - name: Get domain name from hostname.
         set_fact:
-          ipaserver_domain: "{{ ansible_facts['hostname'].split('.')[0][1:] }}"
+          ipaserver_domain: "{{ ansible_facts['fqdn'].split('.')[1:] | join('.') }}"
     rescue:
       - name: Fallback to 'ipa.test'
         set_fact:


### PR DESCRIPTION
The generation of ipaserver_domain has issues: At first
ansible_facts['hostname'] instead of ansible_facts['fqdn'] is used
and second the first entry after the split operation is used and third
the final join is missing.