### PR TITLE
[WIP] For new PRs, run tests only if a plugin or a test was modified.

### DIFF
--- a/.github/workflows/fast_test.yml
+++ b/.github/workflows/fast_test.yml
@@ -19,6 +19,7 @@ jobs:
           --memory 3g
           --hostname ipaserver.ipa.test
           --memory-swap -1
+          --name fedora_latest
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v4
@@ -32,8 +33,8 @@ jobs:
           ansible-galaxy collection install community.docker
           cat <<EOF > ansible.cfg
           [defaults]
-          library = ./plugins
-          module_utils = ./plugins/module_utils
+          library = ${PWD}/plugins
+          module_utils = ${PWD}/plugins/module_utils
           EOF
           cat <<EOF > debug_inventory
           [ipaserver]
@@ -49,4 +50,3 @@ jobs:
           # ANSIBLE_MODULE_UTILS: plugins/module_utils
           # ANSIBLE_LIBRARY: plugins
           ANSIBLE_DOC_FRAGMENT_PLUGINS: plugins/doc_fragments
-          

--- a/.github/workflows/fast_test.yml
+++ b/.github/workflows/fast_test.yml
@@ -34,11 +34,11 @@ jobs:
           echo "$ANSIBLE_MODULE_UTILS"
           echo "$ANSIBLE_LIBRARY"
           ls plugins
-          pytest -m "playbook" --verbose --color=yes
+          ANSIBLE_MODULE_UTILS=plugins/module_utils ANSIBLE_LIBRARY=plugins pytest -m "playbook" --verbose --color=yes
         env:
           RUN_IN_DOCKER: docker
           IPA_SERVER_HOST: fedora_latest
-          ANSIBLE_MODULE_UTILS: plugins/module_utils
-          ANSIBLE_LIBRARY: plugins
+          # ANSIBLE_MODULE_UTILS: plugins/module_utils
+          # ANSIBLE_LIBRARY: plugins
           ANSIBLE_DOC_FRAGMENT_PLUGINS: plugins/doc_fragments
           

--- a/.github/workflows/fast_test.yml
+++ b/.github/workflows/fast_test.yml
@@ -38,6 +38,6 @@ jobs:
           RUN_IN_DOCKER: docker
           IPA_SERVER_HOST: fedora_latest
           ANSIBLE_MODULE_UTILS: plugins/module_utils
-          ANSIBLE_LIBRARY: plugins/modules
+          ANSIBLE_LIBRARY: plugins
           ANSIBLE_DOC_FRAGMENT_PLUGINS: plugins/doc_fragments
           

--- a/.github/workflows/fast_test.yml
+++ b/.github/workflows/fast_test.yml
@@ -30,9 +30,14 @@ jobs:
           pip install -r requirements-tests.txt
           pip install ansible-core
           ansible-galaxy collection install community.docker
+          cat <<EOF > ansible.cfg
+          [defaults]
+          library = ./plugins/modules
+          module_utils = ./plugins/module_utils
+          EOF
+          ls ansible.cfg
+          cat ansible.cfg
           . utils/filter_tests
-          echo "$ANSIBLE_MODULE_UTILS"
-          echo "$ANSIBLE_LIBRARY"
           ANSIBLE_MODULE_UTILS=plugins/module_utils ANSIBLE_LIBRARY=plugins pytest -m "playbook" --verbose --color=yes
         env:
           RUN_IN_DOCKER: docker

--- a/.github/workflows/fast_test.yml
+++ b/.github/workflows/fast_test.yml
@@ -19,7 +19,6 @@ jobs:
           --memory 3g
           --hostname ipaserver.ipa.test
           --memory-swap -1
-          --name fedora_latest
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v4

--- a/.github/workflows/fast_test.yml
+++ b/.github/workflows/fast_test.yml
@@ -18,7 +18,7 @@ jobs:
       #     python-version: "3.x"
       - name: Run tests
         run: |
-          dnf install pip ansible-core
+          dnf install -y pip ansible-core
           pip install -r requirements-test.txt
           . utils/filter_steps
           pytest -m "playbook" --verbose --color=yes

--- a/.github/workflows/fast_test.yml
+++ b/.github/workflows/fast_test.yml
@@ -8,9 +8,9 @@ jobs:
   fedora_latest:
     name: Test plugins against Fedora-latest
     runs-on: ubuntu-latest
-    container:
-      image: quay.io/ansible-freeipa/upstream-tests:fedora-latest
-      options: --cpus 1 --memory 3g --hostname ipaserver.ipa.tes --memory-swap -1 --name fedora_latest
+    # container:
+    #   image: quay.io/ansible-freeipa/upstream-tests:fedora-latest
+    #   options: --cpus 1 --memory 3g --hostname ipaserver.ipa.tes --memory-swap -1 --name fedora_latest
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v4
@@ -18,13 +18,13 @@ jobs:
           python-version: "3.10"
       - name: Run tests
         run: |
-          python -m pip install --upgrade pip --trusted-host pypi.org --trusted-host pip.pypa.io
+          python -m pip install --upgrade pip
           pip install -r requirements-tests.txt
           . utils/filter_steps
           pytest -m "playbook" --verbose --color=yes
         env:
           RUN_IN_DOCKER: docker
-          IPA_SERVER_NAME: fedora_latest
+          IPA_SERVER_HOST: fedora_latest
           ANSIBLE_MODULE_UTILS: plugins/module_utils
           ANSIBLE_LIBRARY: plugins/modules
           ANSIBLE_DOC_FRAGMENT_PLUGINS: plugins/doc_fragments

--- a/.github/workflows/fast_test.yml
+++ b/.github/workflows/fast_test.yml
@@ -15,10 +15,7 @@ jobs:
       fedora_latest:
         image: quay.io/ansible-freeipa/upstream-tests:fedora-latest
         options: >-
-          --cpus 1
-          --memory 3g
           --hostname ipaserver.ipa.test
-          --memory-swap -1
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v4
@@ -37,7 +34,7 @@ jobs:
           EOF
           cat <<EOF > debug_inventory
           [ipaserver]
-          fedora_latest  ansible_connection=docker
+          fedora_latest
           EOF
           ansible -m ping -i debug_inventory ipaserver
           . utils/filter_tests

--- a/.github/workflows/fast_test.yml
+++ b/.github/workflows/fast_test.yml
@@ -11,6 +11,14 @@ jobs:
     # container:
     #   image: quay.io/ansible-freeipa/upstream-tests:fedora-latest
     #   options: --cpus 1 --memory 3g --hostname ipaserver.ipa.tes --memory-swap -1 --name fedora_latest
+    service:
+      fedora_latest:
+        image: quay.io/ansible-freeipa/upstream-tests:fedora-latest
+        options: >-
+          --cpus 1
+          --memory 3g
+          --hostname ipaserver.ipa.test
+          --memory-swap -1
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v4
@@ -20,7 +28,9 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements-tests.txt
-          . utils/filter_steps
+          pip install ansible-core
+          ansible-galaxy collection install community.docker
+          . utils/filter_tests
           pytest -m "playbook" --verbose --color=yes
         env:
           RUN_IN_DOCKER: docker

--- a/.github/workflows/fast_test.yml
+++ b/.github/workflows/fast_test.yml
@@ -30,9 +30,10 @@ jobs:
           pip install -r requirements-tests.txt
           pip install ansible-core
           ansible-galaxy collection install community.docker
-          ls
-          git status
           . utils/filter_tests
+          echo "$ANSIBLE_MODULE_UTILS"
+          echo "$ANSIBLE_LIBRARY"
+          ls plugins
           pytest -m "playbook" --verbose --color=yes
         env:
           RUN_IN_DOCKER: docker

--- a/.github/workflows/fast_test.yml
+++ b/.github/workflows/fast_test.yml
@@ -32,13 +32,17 @@ jobs:
           ansible-galaxy collection install community.docker
           cat <<EOF > ansible.cfg
           [defaults]
-          library = ./plugins/modules
+          library = ./plugins
           module_utils = ./plugins/module_utils
           EOF
-          echo "DIRECTORY: ${PWD}"
-          ls
+          cat <<EOF > inventory
+          [ipaserver]
+          fedora_latest  ansible_connection:podman
+          EOF
+          ansible -m ping -i inventory
           . utils/filter_tests
-          ANSIBLE_MODULE_UTILS=plugins/module_utils ANSIBLE_LIBRARY=plugins pytest -m "playbook" --verbose --color=yes
+          ansible -m ping -i 
+          pytest -m "playbook" --verbose --color=yes
         env:
           RUN_IN_DOCKER: docker
           IPA_SERVER_HOST: fedora_latest

--- a/.github/workflows/fast_test.yml
+++ b/.github/workflows/fast_test.yml
@@ -33,8 +33,7 @@ jobs:
           . utils/filter_tests
           echo "$ANSIBLE_MODULE_UTILS"
           echo "$ANSIBLE_LIBRARY"
-          ls plugins/modules
-          ANSIBLE_MODULE_UTILS=plugins/module_utils ANSIBLE_LIBRARY=plugins/modules pytest -m "playbook" --verbose --color=yes
+          ANSIBLE_MODULE_UTILS=plugins/module_utils ANSIBLE_LIBRARY=plugins pytest -m "playbook" --verbose --color=yes
         env:
           RUN_IN_DOCKER: docker
           IPA_SERVER_HOST: fedora_latest

--- a/.github/workflows/fast_test.yml
+++ b/.github/workflows/fast_test.yml
@@ -1,5 +1,5 @@
 ---
-name: readme test
+name: Test Plugins
 on:
   - push
   - pull_request
@@ -13,12 +13,12 @@ jobs:
       options: --cpus 1 --memory 3g --hostname ipaserver.ipa.tes --memory-swap -1 --name fedora_latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
-        with:
-          python-version: "3.x"
+      # - uses: actions/setup-python@v2
+      #   with:
+      #     python-version: "3.x"
       - name: Run tests
         run: |
-          pip install ansible-core
+          dnf install pip ansible-core
           pip install -r requirements-test.txt
           . utils/filter_steps
           pytest -m "playbook" --verbose --color=yes

--- a/.github/workflows/fast_test.yml
+++ b/.github/workflows/fast_test.yml
@@ -37,7 +37,7 @@ jobs:
           EOF
           cat <<EOF > debug_inventory
           [ipaserver]
-          fedora_latest  ansible_connection:podman
+          fedora_latest  ansible_connection=podman
           EOF
           ansible -m ping -i debug_inventory ipaserver
           . utils/filter_tests

--- a/.github/workflows/fast_test.yml
+++ b/.github/workflows/fast_test.yml
@@ -37,7 +37,7 @@ jobs:
           EOF
           cat <<EOF > debug_inventory
           [ipaserver]
-          fedora_latest  ansible_connection=podman
+          fedora_latest  ansible_connection=docker
           EOF
           ansible -m ping -i debug_inventory ipaserver
           . utils/filter_tests

--- a/.github/workflows/fast_test.yml
+++ b/.github/workflows/fast_test.yml
@@ -1,0 +1,31 @@
+---
+name: readme test
+on:
+  - push
+  - pull_request
+
+jobs:
+  fedora_latest:
+    name: Test plugins against Fedora-latest
+    runs-on: ubuntu-latest
+    container:
+      image: quay.io/ansible-freeipa/upstream-tests:fedora-latest
+      options: --cpus 1 --mem 3g --hostname ipaserver.ipa.tes --memory-swap -1 --name fedora_latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: "3.x"
+      - name: Run tests
+        run: |
+          pip install ansible-core
+          pip install -r requirements-test.txt
+          . utils/filter_steps
+          pytest -m "playbook" --verbose --color=yes
+        env:
+          RUN_IN_DOCKER: docker
+          IPA_SERVER_NAME: fedora_latest
+          ANSIBLE_MODULE_UTILS: plugins/module_utils
+          ANSIBLE_LIBRARY: plugins/modules
+          ANSIBLE_DOC_FRAGMENT_PLUGINS: plugins/doc_fragments
+          

--- a/.github/workflows/fast_test.yml
+++ b/.github/workflows/fast_test.yml
@@ -11,7 +11,7 @@ jobs:
     # container:
     #   image: quay.io/ansible-freeipa/upstream-tests:fedora-latest
     #   options: --cpus 1 --memory 3g --hostname ipaserver.ipa.tes --memory-swap -1 --name fedora_latest
-    service:
+    services:
       fedora_latest:
         image: quay.io/ansible-freeipa/upstream-tests:fedora-latest
         options: >-

--- a/.github/workflows/fast_test.yml
+++ b/.github/workflows/fast_test.yml
@@ -18,7 +18,7 @@ jobs:
           python-version: "3.10"
       - name: Run tests
         run: |
-          python -m pip install --upgrade pip
+          python -m pip install --upgrade pip --trusted-host pypi.org --trusted-host pip.pypa.io
           pip install -r requirements-tests.txt
           . utils/filter_steps
           pytest -m "playbook" --verbose --color=yes

--- a/.github/workflows/fast_test.yml
+++ b/.github/workflows/fast_test.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: quay.io/ansible-freeipa/upstream-tests:fedora-latest
-      options: --cpus 1 --mem 3g --hostname ipaserver.ipa.tes --memory-swap -1 --name fedora_latest
+      options: --cpus 1 --memory 3g --hostname ipaserver.ipa.tes --memory-swap -1 --name fedora_latest
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2

--- a/.github/workflows/fast_test.yml
+++ b/.github/workflows/fast_test.yml
@@ -30,6 +30,8 @@ jobs:
           pip install -r requirements-tests.txt
           pip install ansible-core
           ansible-galaxy collection install community.docker
+          ls
+          git status
           . utils/filter_tests
           pytest -m "playbook" --verbose --color=yes
         env:

--- a/.github/workflows/fast_test.yml
+++ b/.github/workflows/fast_test.yml
@@ -13,13 +13,13 @@ jobs:
       options: --cpus 1 --memory 3g --hostname ipaserver.ipa.tes --memory-swap -1 --name fedora_latest
     steps:
       - uses: actions/checkout@v2
-      # - uses: actions/setup-python@v2
-      #   with:
-      #     python-version: "3.x"
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
       - name: Run tests
         run: |
-          dnf install -y pip ansible-core
-          pip install -r requirements-test.txt
+          python -m pip install --upgrade pip
+          pip install -r requirements-tests.txt
           . utils/filter_steps
           pytest -m "playbook" --verbose --color=yes
         env:

--- a/.github/workflows/fast_test.yml
+++ b/.github/workflows/fast_test.yml
@@ -33,8 +33,8 @@ jobs:
           . utils/filter_tests
           echo "$ANSIBLE_MODULE_UTILS"
           echo "$ANSIBLE_LIBRARY"
-          ls plugins
-          ANSIBLE_MODULE_UTILS=plugins/module_utils ANSIBLE_LIBRARY=plugins pytest -m "playbook" --verbose --color=yes
+          ls plugins/modules
+          ANSIBLE_MODULE_UTILS=plugins/module_utils ANSIBLE_LIBRARY=plugins/modules pytest -m "playbook" --verbose --color=yes
         env:
           RUN_IN_DOCKER: docker
           IPA_SERVER_HOST: fedora_latest

--- a/.github/workflows/fast_test.yml
+++ b/.github/workflows/fast_test.yml
@@ -39,7 +39,7 @@ jobs:
           [ipaserver]
           fedora_latest  ansible_connection:podman
           EOF
-          ansible -m ping -i debug_inventory
+          ansible -m ping -i debug_inventory ipaserver
           . utils/filter_tests
           ansible -m ping -i 
           pytest -m "playbook" --verbose --color=yes

--- a/.github/workflows/fast_test.yml
+++ b/.github/workflows/fast_test.yml
@@ -35,11 +35,11 @@ jobs:
           library = ./plugins
           module_utils = ./plugins/module_utils
           EOF
-          cat <<EOF > inventory
+          cat <<EOF > debug_inventory
           [ipaserver]
           fedora_latest  ansible_connection:podman
           EOF
-          ansible -m ping -i inventory
+          ansible -m ping -i debug_inventory
           . utils/filter_tests
           ansible -m ping -i 
           pytest -m "playbook" --verbose --color=yes

--- a/.github/workflows/fast_test.yml
+++ b/.github/workflows/fast_test.yml
@@ -35,8 +35,8 @@ jobs:
           library = ./plugins/modules
           module_utils = ./plugins/module_utils
           EOF
-          ls ansible.cfg
-          cat ansible.cfg
+          echo "DIRECTORY: ${PWD}"
+          ls
           . utils/filter_tests
           ANSIBLE_MODULE_UTILS=plugins/module_utils ANSIBLE_LIBRARY=plugins pytest -m "playbook" --verbose --color=yes
         env:

--- a/.github/workflows/fast_test.yml
+++ b/.github/workflows/fast_test.yml
@@ -34,11 +34,11 @@ jobs:
           EOF
           cat <<EOF > debug_inventory
           [ipaserver]
-          fedora_latest
+          fedora_latest ansible_connection=docker
           EOF
+          echo "RUNNING: ansible -m ping -i debug_inventory ipaserver"
           ansible -m ping -i debug_inventory ipaserver
           . utils/filter_tests
-          ansible -m ping -i 
           pytest -m "playbook" --verbose --color=yes
         env:
           RUN_IN_DOCKER: docker

--- a/plugins/modules/ipaautomember.py
+++ b/plugins/modules/ipaautomember.py
@@ -20,6 +20,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+# rafasg
+
 from __future__ import (absolute_import, division, print_function)
 
 __metaclass__ = type

--- a/plugins/modules/ipatopologysegment.py
+++ b/plugins/modules/ipatopologysegment.py
@@ -23,6 +23,8 @@ from __future__ import (absolute_import, division, print_function)
 
 __metaclass__ = type
 
+# rafasgj
+
 ANSIBLE_METADATA = {
     "metadata_version": "1.0",
     "supported_by": "community",

--- a/tests/dnszone/test_dnszone_client_context.yml
+++ b/tests/dnszone/test_dnszone_client_context.yml
@@ -1,3 +1,4 @@
+# rafasgj
 ---
 - name: Test dnszone
   hosts: ipaclients, ipaserver

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -66,12 +66,12 @@ def get_disabled_test(group_name, test_name):
 def get_enabled_test(group_name, test_name):
     enabled_modules = [
         enabled.strip()
-        for enabled in os.environ.get("IPA_ENABLED_MODULES", "").split(":")
+        for enabled in os.environ.get("IPA_ENABLED_MODULES", "").split(",")
         if enabled.strip()
     ]
     enabled_tests = [
         enabled.strip()
-        for enabled in os.environ.get("IPA_ENABLED_TESTS", "").split(":")
+        for enabled in os.environ.get("IPA_ENABLED_TESTS", "").split(",")
         if enabled.strip()
     ]
 

--- a/utils/filter_tests
+++ b/utils/filter_tests
@@ -1,0 +1,33 @@
+#!/bin/bash
+# This file shoud be source'd (. filter_tests) rather than executed.
+
+RED="\033[31;1m"
+RST="\033[0m"
+
+die() {
+    echo -e "${RED}${*}${RST}"
+}
+
+TOPDIR="$(dirname "${BASH_SOURCE[0]}")/.."
+
+pushd "${TOPDIR}" >/dev/null 2>&1 || die "Failed to change directory."
+
+files_list=$(mktemp)
+
+since_tag="upstream/master"
+git diff "${since_tag}" --name-only > "${files_list}"
+
+# Get all modules that should have tests executed
+mapfile -t suites < <(sed -n "s#^plugins/modules/ipa\([^.]*\)\.py#\1#p" "${files_list}")
+[ ${#suites[@]} -gt 0 ] && IPA_ENABLED_MODULES=$(IFS=, ; echo "${suites[*]}")
+
+# Get individual tests that should be executed
+mapfile -t suites < <(sed -n "s#.*/\(test_[^/]*\).yml#\1#p" "${files_list}")
+[ ${#suites[@]} -gt 0 ] && IPA_ENABLED_TESTS=$(IFS=, ; echo "${suites[*]}")
+
+rm -f "${test_list}"
+
+export IPA_ENABLED_MODULES
+export IPA_ENABLED_TESTS
+
+popd >/dev/null 2>&1 || die "Failed to change back to original directory."

--- a/utils/filter_tests
+++ b/utils/filter_tests
@@ -14,8 +14,13 @@ pushd "${TOPDIR}" >/dev/null 2>&1 || die "Failed to change directory."
 
 files_list=$(mktemp)
 
-since_tag="upstream/master"
+temp_remote="ansible-freeipa-upstream"
+del_remote=""
+git remote add "${temp_remote}" "https://github.com/freeipa/ansible-freeipa" 2>/dev/null && del_remote="Y"
+git fetch "${temp_remote}" master >/dev/null 2>&1
+since_tag="${temp_remote}/master"
 git diff "${since_tag}" --name-only > "${files_list}"
+[ -n "${del_remote}" ] &&  git remote del "${temp_remote}"
 
 # Get all modules that should have tests executed
 mapfile -t suites < <(sed -n "s#^plugins/modules/ipa\([^.]*\)\.py#\1#p" "${files_list}")

--- a/utils/filter_tests
+++ b/utils/filter_tests
@@ -27,12 +27,15 @@ mapfile -t suites < <(sed -n "s#^plugins/modules/ipa\([^.]*\)\.py#\1#p" "${files
 [ ${#suites[@]} -gt 0 ] && IPA_ENABLED_MODULES=$(IFS=, ; echo "${suites[*]}")
 
 # Get individual tests that should be executed
-mapfile -t suites < <(sed -n "s#.*/\(test_[^/]*\).yml#\1#p" "${files_list}")
-[ ${#suites[@]} -gt 0 ] && IPA_ENABLED_TESTS=$(IFS=, ; echo "${suites[*]}")
+mapfile -t tests < <(sed -n "s#.*/\(test_[^/]*\).yml#\1#p" "${files_list}")
+[ ${#tests[@]} -gt 0 ] && IPA_ENABLED_TESTS=$(IFS=, ; echo "${tests[*]}")
 
 rm -f "${test_list}"
 
 export IPA_ENABLED_MODULES
 export IPA_ENABLED_TESTS
+
+echo IPA_ENABLED_MODULES = ${IPA_ENABLED_MODULES}
+echo IPA_ENABLED_TESTS = ${IPA_ENABLED_TESTS}
 
 popd >/dev/null 2>&1 || die "Failed to change back to original directory."

--- a/utils/filter_tests
+++ b/utils/filter_tests
@@ -20,7 +20,7 @@ git remote add "${temp_remote}" "https://github.com/freeipa/ansible-freeipa" 2>/
 git fetch "${temp_remote}" master >/dev/null 2>&1
 since_tag="${temp_remote}/master"
 git diff "${since_tag}" --name-only > "${files_list}"
-[ -n "${del_remote}" ] &&  git remote del "${temp_remote}"
+[ -n "${del_remote}" ] &&  git remote remove "${temp_remote}"
 
 # Get all modules that should have tests executed
 mapfile -t suites < <(sed -n "s#^plugins/modules/ipa\([^.]*\)\.py#\1#p" "${files_list}")

--- a/utils/filter_tests
+++ b/utils/filter_tests
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -eu
 # This file shoud be source'd (. filter_tests) rather than executed.
 
 RED="\033[31;1m"


### PR DESCRIPTION
During the review of new modules, or modules changes, all
the test suite is executed, even if the change was on a README
file.

This patch reduces the number of tests executed automatically
for new Pull Requests, by starting only the tests that are related
to the changes.

Another change is that the tests use Github workflows rather than
Azure pipelines.

The full test suites can still be started using
Github/Azure integration through comments.