### PR TITLE
ipadnsconfig: Fix boolean values comparison

### DIFF
--- a/plugins/modules/ipadnsconfig.py
+++ b/plugins/modules/ipadnsconfig.py
@@ -173,7 +173,10 @@ def gen_args(module, state, action, dnsconfig, forwarders, forward_policy,
         _args['idnsforwardpolicy'] = forward_policy
 
     if allow_sync_ptr is not None:
-        _args['idnsallowsyncptr'] = 'TRUE' if allow_sync_ptr else 'FALSE'
+        if module.ipa_check_version("<", "4.9.10"):
+            _args['idnsallowsyncptr'] = "TRUE" if allow_sync_ptr else "FALSE"
+        else:
+            _args['idnsallowsyncptr'] = allow_sync_ptr
 
     return _args
 

--- a/plugins/modules/ipadnsconfig.py
+++ b/plugins/modules/ipadnsconfig.py
@@ -202,7 +202,8 @@ def main():
                         choices=["member", "dnsconfig"]),
             state=dict(type="str", default="present",
                        choices=["present", "absent"]),
-        )
+        ),
+        supports_check_mode=True,
     )
 
     ansible_module._ansible_debug = True

--- a/tests/azure/templates/variables.yaml
+++ b/tests/azure/templates/variables.yaml
@@ -16,5 +16,5 @@ variables:
   # ipa_enabled_tests: >-
   ipa_disabled_modules: >-
     dnsconfig,
-    dnsforwardzone,
-  # ipa_disabled_tests: >-
+  ipa_disabled_tests: >-
+    test_dnsconfig_forwarders_ports

--- a/tests/dnsconfig/test_dnsconfig.yml
+++ b/tests/dnsconfig/test_dnsconfig.yml
@@ -13,14 +13,11 @@
       forwarders:
         - ip_address: 8.8.8.8
         - ip_address: 8.8.4.4
-        - ip_address: 2001:4860:4860::8888
-        - ip_address: 2001:4860:4860::8888
-          port: 53
       state: absent
       action: member
 
   # Tests.
-  - name: Set config to invalid IPv4.
+  - name: Set forward with invalid IPv4.
     ipadnsconfig:
       ipaadmin_password: SomeADMINpassword
       ipaapi_context: "{{ ipa_context | default(omit) }}"
@@ -54,8 +51,6 @@
       forwarders:
         - ip_address: 8.8.8.8
         - ip_address: 8.8.4.4
-        - ip_address: 2001:4860:4860::8888
-          port: 53
       forward_policy: only
       allow_sync_ptr: yes
     register: result
@@ -68,8 +63,6 @@
       forwarders:
         - ip_address: 8.8.8.8
         - ip_address: 8.8.4.4
-        - ip_address: 2001:4860:4860::8888
-          port: 53
       forward_policy: only
       allow_sync_ptr: yes
     register: result
@@ -97,14 +90,15 @@
     register: result
     failed_when: result.changed or result.failed
 
-  - name: Ensure forwarder 8.8.4.4 is present.
+  - name: Check if forwarder 8.8.4.4 is present.
     ipadnsconfig:
       ipaadmin_password: SomeADMINpassword
       ipaapi_context: "{{ ipa_context | default(omit) }}"
       forwarders:
         - ip_address: 8.8.4.4
+    check_mode: yes
     register: result
-    failed_when: not result.changed or result.failed
+    failed_when: result.changed or result.failed
 
   - name: Ensure forwarder 8.8.8.8 is present.
     ipadnsconfig:
@@ -115,34 +109,15 @@
     register: result
     failed_when: not result.changed or result.failed
 
-  - name: Ensure forwarder 8.8.4.4 is present.
+  - name: Check forwarder 8.8.4.4 is still present.
     ipadnsconfig:
       ipaadmin_password: SomeADMINpassword
       ipaapi_context: "{{ ipa_context | default(omit) }}"
       forwarders:
         - ip_address: 8.8.4.4
+    check_mode: yes
     register: result
     failed_when: not result.changed or result.failed
-
-  - name: Ensure forwarders are absent.
-    ipadnsconfig:
-      ipaadmin_password: SomeADMINpassword
-      ipaapi_context: "{{ ipa_context | default(omit) }}"
-      forwarders:
-        - ip_address: 8.8.4.4
-        - ip_address: 8.8.8.8
-    register: result
-    failed_when: not result.changed or result.failed
-
-  - name: Ensure forwarders are absent, again.
-    ipadnsconfig:
-      ipaadmin_password: SomeADMINpassword
-      ipaapi_context: "{{ ipa_context | default(omit) }}"
-      forwarders:
-        - ip_address: 8.8.4.4
-        - ip_address: 8.8.8.8
-    register: result
-    failed_when: result.changed or result.failed
 
   - name: Disable global forwarders.
     ipadnsconfig:
@@ -208,97 +183,6 @@
     register: result
     failed_when: result.changed or result.failed
 
-  - name: Ensure all forwarders are absent.
-    ipadnsconfig:
-      ipaadmin_password: SomeADMINpassword
-      ipaapi_context: "{{ ipa_context | default(omit) }}"
-      forwarders:
-        - ip_address: 8.8.8.8
-        - ip_address: 8.8.4.4
-        - ip_address: 2001:4860:4860::8888
-          port: 53
-      state: absent
-      action: member
-    register: result
-    failed_when: not result.changed or result.failed
-
-  - name: Ensure all forwarders are absent, again.
-    ipadnsconfig:
-      ipaadmin_password: SomeADMINpassword
-      ipaapi_context: "{{ ipa_context | default(omit) }}"
-      forwarders:
-        - ip_address: 8.8.8.8
-        - ip_address: 8.8.4.4
-        - ip_address: 2001:4860:4860::8888
-          port: 53
-      state: absent
-      action: member
-    register: result
-    failed_when: result.changed or result.failed
-
-  - name: Ensure forwarder is present.
-    ipadnsconfig:
-      ipaadmin_password: SomeADMINpassword
-      ipaapi_context: "{{ ipa_context | default(omit) }}"
-      forwarders:
-        - ip_address: 8.8.8.8
-    register: result
-    failed_when: not result.changed or result.failed
-
-  - name: Ensure forwarders is not present.
-    ipadnsconfig:
-      ipaadmin_password: SomeADMINpassword
-      ipaapi_context: "{{ ipa_context | default(omit) }}"
-      forwarders:
-        - ip_address: 8.8.4.4
-    check_mode: yes
-    register: result
-    failed_when: not result.changed or result.failed
-
-  - name: Ensure forwarders are present.
-    ipadnsconfig:
-      ipaadmin_password: SomeADMINpassword
-      ipaapi_context: "{{ ipa_context | default(omit) }}"
-      forwarders:
-        - ip_address: 8.8.4.4
-        - ip_address: 8.8.8.8
-      action: member
-    register: result
-    failed_when: not result.changed or result.failed
-
-  - name: Ensure forwarders are present, again.
-    ipadnsconfig:
-      ipaadmin_password: SomeADMINpassword
-      ipaapi_context: "{{ ipa_context | default(omit) }}"
-      forwarders:
-        - ip_address: 8.8.4.4
-        - ip_address: 8.8.8.8
-      action: member
-    register: result
-    failed_when: result.changed or result.failed
-
-  - name: Ensure another forwarder is present.
-    ipadnsconfig:
-      ipaadmin_password: SomeADMINpassword
-      ipaapi_context: "{{ ipa_context | default(omit) }}"
-      forwarders:
-        - ip_address: 8.8.4.4
-      action: member
-    register: result
-    failed_when: result.changed or result.failed
-
-  - name: Ensure forwarders are present.
-    ipadnsconfig:
-      ipaadmin_password: SomeADMINpassword
-      ipaapi_context: "{{ ipa_context | default(omit) }}"
-      forwarders:
-        - ip_address: 8.8.4.4
-        - ip_address: 8.8.8.8
-      action: member
-    register: result
-    failed_when: result.changed or result.failed
-
-  # Cleanup.
   - name: Ensure forwarders are absent.
     ipadnsconfig:
       ipaadmin_password: SomeADMINpassword
@@ -306,8 +190,5 @@
       forwarders:
         - ip_address: 8.8.8.8
         - ip_address: 8.8.4.4
-        - ip_address: 2001:4860:4860::8888
-        - ip_address: 2001:4860:4860::8888
-          port: 53
       state: absent
       action: member

--- a/tests/dnsconfig/test_dnsconfig_forwarders_ports.yml
+++ b/tests/dnsconfig/test_dnsconfig_forwarders_ports.yml
@@ -1,0 +1,81 @@
+---
+- name: Test dnsconfig forwarders with custom ports
+  hosts: "{{ ipa_test_host | default('ipaserver') }}"
+  become: true
+  gather_facts: no
+
+  tasks:
+  - block:
+    # Setup.
+    - name: Ensure forwarder with custom port is absent.
+      ipadnsconfig:
+        ipaadmin_password: SomeADMINpassword
+        ipaapi_context: "{{ ipa_context | default(omit) }}"
+        forwarders:
+          - ip_address: 2001:4860:4860::8888
+            port: 53
+        state: absent
+        action: member
+
+    # Tests.
+
+    - name: Ensure forwarder with custom port is present.
+      ipadnsconfig:
+        ipaadmin_password: SomeADMINpassword
+        ipaapi_context: "{{ ipa_context | default(omit) }}"
+        forwarders:
+          - ip_address: 2001:4860:4860::8888
+            port: 53
+        state: present
+        action: member
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: Ensure forwarder with custom port is present, again.
+      ipadnsconfig:
+        ipaadmin_password: SomeADMINpassword
+        ipaapi_context: "{{ ipa_context | default(omit) }}"
+        forwarders:
+          - ip_address: 2001:4860:4860::8888
+            port: 53
+        state: present
+        action: member
+      register: result
+      failed_when: result.changed or result.failed
+
+    - name: Ensure forwarder with custom port is absent.
+      ipadnsconfig:
+        ipaadmin_password: SomeADMINpassword
+        ipaapi_context: "{{ ipa_context | default(omit) }}"
+        forwarders:
+          - ip_address: 2001:4860:4860::8888
+            port: 53
+        state: absent
+        action: member
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: Ensure forwarder with custom port is absent, again.
+      ipadnsconfig:
+        ipaadmin_password: SomeADMINpassword
+        ipaapi_context: "{{ ipa_context | default(omit) }}"
+        forwarders:
+          - ip_address: 2001:4860:4860::8888
+            port: 53
+        state: absent
+        action: member
+      register: result
+      failed_when: result.changed or result.failed
+
+    always:
+
+    # Cleanup.
+    - name: Ensure forwarder with custom port is absent.
+      ipadnsconfig:
+        ipaadmin_password: SomeADMINpassword
+        ipaapi_context: "{{ ipa_context | default(omit) }}"
+        forwarders:
+          - ip_address: 2001:4860:4860::8888
+            port: 53
+        state: absent
+        action: member


### PR DESCRIPTION
In later versions of FreeIPA (4.9.10+) the handling of LDAP
boolean values has been fixed, but this changes were not
applied to ipadnsconfig.

This PR fixes this issues and split the ipadnsconfig tests
so that at least part of the tests can be executed while
there is still an issue with FreeIPA and python-dns 2.2.0.

Fix issue #862