### PR TITLE
ipaclient: Removed invalid call `logger.info()`

### DIFF
--- a/roles/ipaclient/library/ipaclient_test.py
+++ b/roles/ipaclient/library/ipaclient_test.py
@@ -880,7 +880,6 @@ def main():
                     is_ipaddr = False
 
             if is_ipaddr:
-                logger.info()
                 logger.warning(
                     "It seems that you are using an IP address "
                     "instead of FQDN as an argument to --server. The "


### PR DESCRIPTION
- Call was responsible for a `TypeError` exception
- Call was not useful (already followed by a proper `logger.warning` call)

Should fix issue #865: https://github.com/freeipa/ansible-freeipa/issues/865