### PR TITLE
ipareplica: Do not overwrite ipaclient_no_ntp for client part deployment

### DIFF
--- a/roles/ipareplica/tasks/install.yml
+++ b/roles/ipareplica/tasks/install.yml
@@ -116,8 +116,6 @@
       ipaclient_realm: "{{ result_ipareplica_test.realm | default(omit) }}"
       ipaclient_servers: "{{ ipareplica_servers | default(omit) }}"
       ipaclient_hostname: "{{ result_ipareplica_test.hostname }}"
-      ipaclient_no_ntp: "{{ result_ipareplica_test.ipa_python_version
-                            < 40690 }}"
       ipaclient_install_packages: "{{ ipareplica_install_packages }}"
     when: not result_ipareplica_test.client_enrolled
 


### PR DESCRIPTION
The NTP server chrony was always enabled and set up due to overwriting
the parameter ipaclient_no_ntp for the client part deployment.

For IPA deployments upt to 4.6 no_ntp was always used for the client
part deployment in ipa-replica-install. But afterwards ntp was
configured in the replica deployment part if no_ntp was not set.

The ipareplica roles always relied on the client for setting up the NTP
server but overwrote the setting for the client deployment part. This
did not result in a failure to enable the chrony server in RHEL and Fedora
based distributions as NTP server was always required by the ipa-server
package.

Fixes: #871 (ipa-replica-install with no-ntp is ignored)