### PR TITLE
ipareplica: ipareplica_setup_adtrust fails while updating ipaNTFlatName

### DIFF
--- a/roles/ipareplica/tasks/install.yml
+++ b/roles/ipareplica/tasks/install.yml
@@ -201,6 +201,7 @@
       ### additional ###
       server: "{{ result_ipareplica_test.server }}"
       skip_conncheck: "{{ ipareplica_skip_conncheck }}"
+      sid_generation_always: "{{ result_ipareplica_test.sid_generation_always }}"
     register: result_ipareplica_prepare
 
   - name: Install - Add to ipaservers


### PR DESCRIPTION
The internal parameter sid_generation_always is generated in
ipareplica_test to enable SID generation if ipareplica_setup_adtrust is
not enabled.

This parameter was not used for ipareplica_prepare though, therefore
adtrust.install_check was not executed and did not set the attribute
adtrust.netbios_name. As a result adtrust.netbios_name was None and the
try to use this as the new NetBIOS domain name failed with an
INVALID_SYNTAX error in adtrustinstance while executing
ipareplica_setup_adtrust.

This issue only occurs if SIDs are not enabled in the domain yet for
example with an old deployment.