### PR TITLE
ipavault: Fix missing whitespace after keyword issue

### DIFF
--- a/plugins/modules/ipavault.py
+++ b/plugins/modules/ipavault.py
@@ -525,7 +525,7 @@ def check_encryption_params(  # pylint: disable=unused-argument
 
         if (
             salt is not None
-            and not(
+            and not (
                 any([password, password_file])
                 and any([new_password, new_password_file])
             )


### PR DESCRIPTION
flake8 reports an issue in ipavault:

  plugins/modules/ipavault.py:528:20: E275 missing whitespace after keyword

The missing whitespace has been added: "and not(" -> "and not ("