### PR TITLE
upstream CI: enable/disable tests based on test image

### DIFF
--- a/tests/azure/templates/galaxy_script.yml
+++ b/tests/azure/templates/galaxy_script.yml
@@ -51,6 +51,10 @@ jobs:
       ANSIBLE_LIBRARY: ./molecule
 
   - script: |
+      python utils/check_test_configuration.py ${{ parameters.scenario }}
+    displayName: Check scenario test configuration
+
+  - script: |
       cd ~/.ansible/collections/ansible_collections/freeipa/ansible_freeipa
       pytest \
         -m "playbook" \

--- a/tests/azure/templates/galaxy_script.yml
+++ b/tests/azure/templates/galaxy_script.yml
@@ -25,6 +25,7 @@ jobs:
   timeoutInMinutes: 120
   variables:
   - template: variables.yaml
+  - template: variables_${{ parameters.scenario }}.yaml
   steps:
   - task: UsePythonVersion@0
     inputs:

--- a/tests/azure/templates/playbook_tests.yml
+++ b/tests/azure/templates/playbook_tests.yml
@@ -24,6 +24,7 @@ jobs:
   timeoutInMinutes: 120
   variables:
   - template: variables.yaml
+  - template: variables_${{ parameters.scenario }}.yaml
   steps:
   - task: UsePythonVersion@0
     inputs:

--- a/tests/azure/templates/playbook_tests.yml
+++ b/tests/azure/templates/playbook_tests.yml
@@ -53,6 +53,10 @@ jobs:
       ANSIBLE_LIBRARY: ./molecule
 
   - script: |
+      python utils/check_test_configuration.py ${{ parameters.scenario }}
+    displayName: Check scenario test configuration
+
+  - script: |
       pytest \
         -m "playbook" \
         --verbose \

--- a/tests/azure/templates/pytest_tests.yml
+++ b/tests/azure/templates/pytest_tests.yml
@@ -18,6 +18,7 @@ jobs:
   timeoutInMinutes: 120
   variables:
   - template: variables.yaml
+  - template: variables_${{ parameters.scenario }}.yaml
   steps:
   - task: UsePythonVersion@0
     inputs:

--- a/tests/azure/templates/variables_c8s.yaml
+++ b/tests/azure/templates/variables_c8s.yaml
@@ -3,9 +3,6 @@
 # For easier management of items to enable/disable,
 # use one test/module on each line, followed by a comma.
 #
-# If no variable is to be set, add 'empty: true', as the
-# 'variables' dict cannot be empty.
-#
 # Example:
 #
 # disabled_modules: >-
@@ -16,7 +13,7 @@
 ---
 variables:
   empty: true
-  # ipa_enabled_modules: >-
-  # ipa_enabled_tests: >-
-  # ipa_disabled_modules: >-
-  # ipa_disabled_tests: >-
+#   ipa_enabled_modules: >-
+#   ipa_enabled_tests: >-
+#   ipa_disabled_modules: >-
+#   ipa_disabled_tests: >-

--- a/tests/azure/templates/variables_c9s.yaml
+++ b/tests/azure/templates/variables_c9s.yaml
@@ -3,9 +3,6 @@
 # For easier management of items to enable/disable,
 # use one test/module on each line, followed by a comma.
 #
-# If no variable is to be set, add 'empty: true', as the
-# 'variables' dict cannot be empty.
-#
 # Example:
 #
 # disabled_modules: >-
@@ -16,7 +13,7 @@
 ---
 variables:
   empty: true
-  # ipa_enabled_modules: >-
-  # ipa_enabled_tests: >-
-  # ipa_disabled_modules: >-
-  # ipa_disabled_tests: >-
+#   ipa_enabled_modules: >-
+#   ipa_enabled_tests: >-
+#   ipa_disabled_modules: >-
+#   ipa_disabled_tests: >-

--- a/tests/azure/templates/variables_centos-7.yaml
+++ b/tests/azure/templates/variables_centos-7.yaml
@@ -3,9 +3,6 @@
 # For easier management of items to enable/disable,
 # use one test/module on each line, followed by a comma.
 #
-# If no variable is to be set, add 'empty: true', as the
-# 'variables' dict cannot be empty.
-#
 # Example:
 #
 # disabled_modules: >-
@@ -16,7 +13,7 @@
 ---
 variables:
   empty: true
-  # ipa_enabled_modules: >-
-  # ipa_enabled_tests: >-
-  # ipa_disabled_modules: >-
-  # ipa_disabled_tests: >-
+#   ipa_enabled_modules: >-
+#   ipa_enabled_tests: >-
+#   ipa_disabled_modules: >-
+#   ipa_disabled_tests: >-

--- a/tests/azure/templates/variables_fedora-latest.yaml
+++ b/tests/azure/templates/variables_fedora-latest.yaml
@@ -3,9 +3,6 @@
 # For easier management of items to enable/disable,
 # use one test/module on each line, followed by a comma.
 #
-# If no variable is to be set, add 'empty: true', as the
-# 'variables' dict cannot be empty.
-#
 # Example:
 #
 # disabled_modules: >-
@@ -15,8 +12,9 @@
 #
 ---
 variables:
-  empty: true
   # ipa_enabled_modules: >-
   # ipa_enabled_tests: >-
-  # ipa_disabled_modules: >-
-  # ipa_disabled_tests: >-
+  ipa_disabled_modules: >-
+    dnsforwardzone,
+  ipa_disabled_tests: >-
+    test_dnsconfig_forwarders_ports

--- a/tests/azure/templates/variables_fedora-rawhide.yaml
+++ b/tests/azure/templates/variables_fedora-rawhide.yaml
@@ -3,9 +3,6 @@
 # For easier management of items to enable/disable,
 # use one test/module on each line, followed by a comma.
 #
-# If no variable is to be set, add 'empty: true', as the
-# 'variables' dict cannot be empty.
-#
 # Example:
 #
 # disabled_modules: >-

--- a/tests/sanity/ignore-2.12.txt
+++ b/tests/sanity/ignore-2.12.txt
@@ -50,6 +50,7 @@ utils/ansible-ipa-server-install shebang!skip
 utils/build-galaxy-release.sh shebang!skip
 utils/build-srpm.sh shebang!skip
 utils/changelog shebang!skip
+utils/check_test_configuration.py shebang!skip
 utils/galaxyfy-README.py shebang!skip
 utils/galaxyfy-module-EXAMPLES.py shebang!skip
 utils/galaxyfy-playbook.py shebang!skip

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -84,30 +84,6 @@ def get_enabled_test(group_name, test_name):
     return group_enabled or test_enabled
 
 
-def get_skip_conditions(group_name, test_name):
-    """
-    Check tests that need to be skipped.
-
-    The return is a dict containing `condition` and `reason`. For the test
-    to be skipped, `condition` must be True, if it is `False`, the test is
-    to be skipped. Although "reason" must be always provided, it can be
-    `None` if `condition` is True.
-    """
-    if not get_server_host():
-        return {
-            "condition": True,
-            "reason": "Environment variable IPA_SERVER_HOST must be set",
-        }
-
-    if not get_enabled_test(group_name, test_name):
-        return {"condition": True, "reason": "Test not configured to run"}
-
-    if get_disabled_test(group_name, test_name):
-        return {"condition": True, "reason": "Test configured to not run"}
-
-    return {"condition": False, "reason": "Test will run."}
-
-
 def get_inventory_content():
     """Create the content of an inventory file for a test run."""
     ipa_server_host = get_server_host()

--- a/utils/check_test_configuration.py
+++ b/utils/check_test_configuration.py
@@ -1,0 +1,110 @@
+#!/usr/bin/python
+
+"""Check which tests are scheduled to be executed."""
+
+import sys
+import re
+import os
+import yaml
+
+
+RE_IS_TEST = re.compile(r"(.*/)?test_.*\.yml")
+RE_IS_VARS = re.compile(r"(.*/)?variables(_.*)?\.yaml")
+REPO_ROOT = os.path.join(os.path.dirname(__file__), "..")
+
+
+def get_tests():
+    """Retrieve a list of modules and its tests."""
+    def get_module(root):
+        if root != _test_dir:
+            while True:
+                module = os.path.basename(root)
+                root = os.path.dirname(root)
+                if root == _test_dir:
+                    return module
+        return "."
+
+    _result = {}
+    _test_dir = os.path.join(REPO_ROOT, "tests")
+    for root, _dirs, files in os.walk(_test_dir):
+        module = get_module(root)
+        _result[module] = [
+            os.path.splitext(test)[0]
+            for test in files
+            if RE_IS_TEST.search(test)
+        ]
+
+    return _result
+
+
+def get_test_config(scenarios):
+    template_path = os.path.join(REPO_ROOT, "tests/azure/templates")
+    _result = {}
+    for _root, _dirs, files in os.walk(template_path):
+        for filename in [x for x in files if RE_IS_VARS.search(x)]:
+            _templates, *scenario = os.path.basename(
+                os.path.splitext(filename)[0]
+            ).split("_", 1)
+            scenario = scenario[0] if scenario else "All"
+            _result[scenario] = {}
+            # only process selected scenarios
+            if scenario not in scenarios and len(scenarios) > 1:
+                continue
+            with open(os.path.join(template_path, filename), "rt") as inp:
+                data = yaml.safe_load(inp)
+            if not data["variables"].get("empty", False):
+                variables = data["variables"]
+                for key, value in variables.items():
+                    variables[key] = [
+                        x.strip() for x in value.split(",") if x.strip()
+                    ]
+                _result[scenario] = variables
+
+    return _result
+
+
+def print_configuration(scenario, disabled, enabled):
+    """Print the test configuration for a scenario."""
+    print(f"\nScenario: {scenario}")
+    for test_cfg, title in [(disabled, "Disabled"), (enabled, "Enabled")]:
+        print(f"    {title} tests:")
+        if test_cfg:
+            for module, tests in test_cfg.items():
+                print(f"        {module}:")
+                for test in tests:
+                    print(f"            - {test}")
+        else:
+            print("        No custom configuration.")
+
+
+def main():
+    if any(item in sys.argv for item in ["-h", "--help"]):
+        print("usage: check_test_config.py [-h|--help] [SCENARIO...]")
+        return
+
+    scenarios = ["All"] + sys.argv[1:]
+    all_tests = get_tests()
+    test_config = get_test_config(scenarios)
+
+    print("Test configuration:")
+    for scenario in sorted(test_config.keys()):
+        if scenario not in scenarios and len(scenarios) > 1:
+            continue
+        # extract scenario configuration
+        config = test_config[scenario]
+        disabled = {}
+        enabled = {}
+        for res, state in [(disabled, "disabled"), (enabled, "enabled")]:
+            for module in config.get(f"ipa_{state}_modules", []):
+                res[module] = set(all_tests[module])
+            for test in config.get(f"ipa_{state}_tests", []):
+                for module, tests in all_tests.items():
+                    if test in tests:
+                        mod = res.setdefault(module, set())
+                        mod.add(test)
+                        tests.remove(test)
+        print_configuration(scenario, disabled, enabled)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This patch allows the configuration of enabled/disabled tests
in a per-test scenario way, allowing a test to be enabled or
disable depending on the Linux distribution used to run the
tests.

It also changes the 'skip' behavior of disabled tests to not
include the tests anymore, so that disabled tests are not
'skip'-ed, but are not even evaluated anymore.

Please, check individual commits for details.