### PR TITLE
ipasudorule: Fix usage of 'action' and 'state' in examples.

### DIFF
--- a/plugins/modules/ipasudorule.py
+++ b/plugins/modules/ipasudorule.py
@@ -162,19 +162,19 @@ EXAMPLES = """
     hostgroup: cluster
     action: member
 
-# Ensure sudo rule for usercategory "all"
+# Ensure sudo rule for usercategory "all" is enabled
 - ipasudorule:
     ipaadmin_password: SomeADMINpassword
     name: allusers
     usercategory: all
-    action: enabled
+    state: enabled
 
-# Ensure sudo rule for hostcategory "all"
+# Ensure sudo rule for hostcategory "all" is enabled
 - ipasudorule:
     ipaadmin_password: SomeADMINpassword
     name: allhosts
     hostcategory: all
-    action: enabled
+    state: enabled
 
 # Ensure Sudo Rule tesrule1 is absent
 - ipasudorule:


### PR DESCRIPTION
Some examples in ipasudorule were using `action: enabled` when it
should've been `state: enabled`. The examples were fixed.

Fixes #885