### PR TITLE
ipauser: Add note on attributes 'first' and 'last' requirements

### DIFF
--- a/README-user.md
+++ b/README-user.md
@@ -381,8 +381,8 @@ Variable | Description | Required
 
 Variable | Description | Required
 -------- | ----------- | --------
-`first` \| `givenname` | The first name string. | no
-`last` \| `sn` | The last name string. | no
+`first` \| `givenname` | The first name string. Required if user does not exist. | no
+`last` \| `sn` | The last name string. Required if user does not exist. | no
 `fullname` \| `cn` | The full name string. | no
 `displayname` | The display name string. | no
 `homedir` | The home directory string. | no

--- a/plugins/modules/ipauser.py
+++ b/plugins/modules/ipauser.py
@@ -47,11 +47,11 @@ options:
         description: The user (internally uid).
         required: true
       first:
-        description: The first name
+        description: The first name. Required if user does not exist.
         required: false
         aliases: ["givenname"]
       last:
-        description: The last name
+        description: The last name. Required if user doesnot exst.
         required: false
         aliases: ["sn"]
       fullname:
@@ -212,11 +212,11 @@ options:
         type: bool
     required: false
   first:
-    description: The first name
+    description: The first name. Required if user does not exist.
     required: false
     aliases: ["givenname"]
   last:
-    description: The last name
+    description: The last name. Required if user does not exist.
     required: false
     aliases: ["sn"]
   fullname:


### PR DESCRIPTION
Attributes 'first' and 'last' are required if user does not exist, but
current documentation doesn't make it clear. This patch adds a note on
both attributes to make clear the cases where the attribute is required.

Fixes #881