### PR TITLE
upstream CI: Fix list evaluation in IPA_ENABLED/IPA_DISABLED tests

### DIFF
--- a/tests/utils.py
+++ b/tests/utils.py
@@ -66,12 +66,12 @@ def get_disabled_test(group_name, test_name):
 def get_enabled_test(group_name, test_name):
     enabled_modules = [
         enabled.strip()
-        for enabled in os.environ.get("IPA_ENABLED_MODULES", "").split(":")
+        for enabled in os.environ.get("IPA_ENABLED_MODULES", "").split(",")
         if enabled.strip()
     ]
     enabled_tests = [
         enabled.strip()
-        for enabled in os.environ.get("IPA_ENABLED_TESTS", "").split(":")
+        for enabled in os.environ.get("IPA_ENABLED_TESTS", "").split(",")
         if enabled.strip()
     ]
 


### PR DESCRIPTION
When enabling or disabling multiple tests, a comma separated list must
be used, but current code is using a colon to split the list.

This patch fixes this behavior.