### PR TITLE
Fix short_description flag in plugins, role modules and templates

### DIFF
--- a/plugins/modules/ipaautomember.py
+++ b/plugins/modules/ipaautomember.py
@@ -34,7 +34,7 @@ ANSIBLE_METADATA = {
 DOCUMENTATION = """
 ---
 module: ipaautomember
-short description: Add and delete FreeIPA Auto Membership Rules.
+short_description: Add and delete FreeIPA Auto Membership Rules.
 description: Add, modify and delete an IPA Auto Membership Rules.
 extends_documentation_fragment:
   - ipamodule_base_docs

--- a/plugins/modules/ipadelegation.py
+++ b/plugins/modules/ipadelegation.py
@@ -32,7 +32,7 @@ ANSIBLE_METADATA = {
 DOCUMENTATION = """
 ---
 module: ipadelegation
-short description: Manage FreeIPA delegations
+short_description: Manage FreeIPA delegations
 description: Manage FreeIPA delegations and delegation attributes
 extends_documentation_fragment:
   - ipamodule_base_docs

--- a/plugins/modules/ipadnsconfig.py
+++ b/plugins/modules/ipadnsconfig.py
@@ -33,7 +33,7 @@ ANSIBLE_METADATA = {
 DOCUMENTATION = """
 ---
 module: ipadnsconfig
-short description: Manage FreeIPA dnsconfig
+short_description: Manage FreeIPA dnsconfig
 description: Manage FreeIPA dnsconfig
 extends_documentation_fragment:
   - ipamodule_base_docs

--- a/plugins/modules/ipadnsrecord.py
+++ b/plugins/modules/ipadnsrecord.py
@@ -34,7 +34,7 @@ ANSIBLE_METADATA = {
 DOCUMENTATION = """
 ---
 module: ipadnsrecord
-short description: Manage FreeIPA DNS records
+short_description: Manage FreeIPA DNS records
 description: Manage FreeIPA DNS records
 extends_documentation_fragment:
   - ipamodule_base_docs

--- a/plugins/modules/ipadnszone.py
+++ b/plugins/modules/ipadnszone.py
@@ -32,7 +32,7 @@ ANSIBLE_METADATA = {
 DOCUMENTATION = """
 ---
 module: ipadnszone
-short description: Manage FreeIPA dnszone
+short_description: Manage FreeIPA dnszone
 description: Manage FreeIPA dnszone
 extends_documentation_fragment:
   - ipamodule_base_docs

--- a/plugins/modules/ipagroup.py
+++ b/plugins/modules/ipagroup.py
@@ -32,7 +32,7 @@ ANSIBLE_METADATA = {
 DOCUMENTATION = """
 ---
 module: ipagroup
-short description: Manage FreeIPA groups
+short_description: Manage FreeIPA groups
 description: Manage FreeIPA groups
 extends_documentation_fragment:
   - ipamodule_base_docs

--- a/plugins/modules/ipahbacrule.py
+++ b/plugins/modules/ipahbacrule.py
@@ -32,7 +32,7 @@ ANSIBLE_METADATA = {
 DOCUMENTATION = """
 ---
 module: ipahbacrule
-short description: Manage FreeIPA HBAC rules
+short_description: Manage FreeIPA HBAC rules
 description: Manage FreeIPA HBAC rules
 extends_documentation_fragment:
   - ipamodule_base_docs

--- a/plugins/modules/ipahbacsvc.py
+++ b/plugins/modules/ipahbacsvc.py
@@ -32,7 +32,7 @@ ANSIBLE_METADATA = {
 DOCUMENTATION = """
 ---
 module: ipahbacsvc
-short description: Manage FreeIPA HBAC Services
+short_description: Manage FreeIPA HBAC Services
 description: Manage FreeIPA HBAC Services
 extends_documentation_fragment:
   - ipamodule_base_docs

--- a/plugins/modules/ipahbacsvcgroup.py
+++ b/plugins/modules/ipahbacsvcgroup.py
@@ -33,7 +33,7 @@ ANSIBLE_METADATA = {
 DOCUMENTATION = """
 ---
 module: ipahbacsvcgroup
-short description: Manage FreeIPA hbacsvcgroups
+short_description: Manage FreeIPA hbacsvcgroups
 description: Manage FreeIPA hbacsvcgroups
 extends_documentation_fragment:
   - ipamodule_base_docs

--- a/plugins/modules/ipahost.py
+++ b/plugins/modules/ipahost.py
@@ -32,7 +32,7 @@ ANSIBLE_METADATA = {
 DOCUMENTATION = """
 ---
 module: ipahost
-short description: Manage FreeIPA hosts
+short_description: Manage FreeIPA hosts
 description: Manage FreeIPA hosts
 extends_documentation_fragment:
   - ipamodule_base_docs

--- a/plugins/modules/ipahostgroup.py
+++ b/plugins/modules/ipahostgroup.py
@@ -33,7 +33,7 @@ ANSIBLE_METADATA = {
 DOCUMENTATION = """
 ---
 module: ipahostgroup
-short description: Manage FreeIPA hostgroups
+short_description: Manage FreeIPA hostgroups
 description: Manage FreeIPA hostgroups
 extends_documentation_fragment:
   - ipamodule_base_docs

--- a/plugins/modules/ipaidrange.py
+++ b/plugins/modules/ipaidrange.py
@@ -32,7 +32,7 @@ ANSIBLE_METADATA = {
 DOCUMENTATION = """
 ---
 module: ipaidrange
-short description: Manage FreeIPA idrange
+short_description: Manage FreeIPA idrange
 description: Manage FreeIPA idrange
 extends_documentation_fragment:
   - ipamodule_base_docs

--- a/plugins/modules/ipalocation.py
+++ b/plugins/modules/ipalocation.py
@@ -32,7 +32,7 @@ ANSIBLE_METADATA = {
 DOCUMENTATION = """
 ---
 module: ipalocation
-short description: Manage FreeIPA location
+short_description: Manage FreeIPA location
 description: Manage FreeIPA location
 extends_documentation_fragment:
   - ipamodule_base_docs

--- a/plugins/modules/ipapermission.py
+++ b/plugins/modules/ipapermission.py
@@ -32,7 +32,7 @@ ANSIBLE_METADATA = {
 DOCUMENTATION = """
 ---
 module: ipapermission
-short description: Manage FreeIPA permission
+short_description: Manage FreeIPA permission
 description: Manage FreeIPA permission and permission members
 extends_documentation_fragment:
   - ipamodule_base_docs

--- a/plugins/modules/ipaprivilege.py
+++ b/plugins/modules/ipaprivilege.py
@@ -35,7 +35,7 @@ ANSIBLE_METADATA = {
 DOCUMENTATION = """
 ---
 module: ipaprivilege
-short description: Manage FreeIPA privilege
+short_description: Manage FreeIPA privilege
 description: Manage FreeIPA privilege and privilege members
 extends_documentation_fragment:
   - ipamodule_base_docs

--- a/plugins/modules/ipapwpolicy.py
+++ b/plugins/modules/ipapwpolicy.py
@@ -32,7 +32,7 @@ ANSIBLE_METADATA = {
 DOCUMENTATION = """
 ---
 module: ipapwpolicy
-short description: Manage FreeIPA pwpolicies
+short_description: Manage FreeIPA pwpolicies
 description: Manage FreeIPA pwpolicies
 options:
   ipaadmin_principal:

--- a/plugins/modules/iparole.py
+++ b/plugins/modules/iparole.py
@@ -34,7 +34,7 @@ ANSIBLE_METADATA = {
 DOCUMENTATION = """
 ---
 module: iparole
-short description: Manage FreeIPA role
+short_description: Manage FreeIPA role
 description: Manage FreeIPA role
 extends_documentation_fragment:
   - ipamodule_base_docs

--- a/plugins/modules/ipaselfservice.py
+++ b/plugins/modules/ipaselfservice.py
@@ -32,7 +32,7 @@ ANSIBLE_METADATA = {
 DOCUMENTATION = """
 ---
 module: ipaselfservice
-short description: Manage FreeIPA selfservices
+short_description: Manage FreeIPA selfservices
 description: Manage FreeIPA selfservices and selfservice attributes
 extends_documentation_fragment:
   - ipamodule_base_docs

--- a/plugins/modules/ipaserver.py
+++ b/plugins/modules/ipaserver.py
@@ -32,7 +32,7 @@ ANSIBLE_METADATA = {
 DOCUMENTATION = """
 ---
 module: ipaserver
-short description: Manage FreeIPA server
+short_description: Manage FreeIPA server
 description: Manage FreeIPA server
 extends_documentation_fragment:
   - ipamodule_base_docs

--- a/plugins/modules/ipaservice.py
+++ b/plugins/modules/ipaservice.py
@@ -33,7 +33,7 @@ ANSIBLE_METADATA = {
 DOCUMENTATION = """
 ---
 module: ipaservice
-short description: Manage FreeIPA service
+short_description: Manage FreeIPA service
 description: Manage FreeIPA service
 extends_documentation_fragment:
   - ipamodule_base_docs

--- a/plugins/modules/ipaservicedelegationrule.py
+++ b/plugins/modules/ipaservicedelegationrule.py
@@ -32,7 +32,7 @@ ANSIBLE_METADATA = {
 DOCUMENTATION = """
 ---
 module: ipaservicedelegationrule
-short description: Manage FreeIPA servicedelegationrule
+short_description: Manage FreeIPA servicedelegationrule
 description: |
   Manage FreeIPA servicedelegationrule and servicedelegationrule members
 extends_documentation_fragment:

--- a/plugins/modules/ipaservicedelegationtarget.py
+++ b/plugins/modules/ipaservicedelegationtarget.py
@@ -32,7 +32,7 @@ ANSIBLE_METADATA = {
 DOCUMENTATION = """
 ---
 module: ipaservicedelegationtarget
-short description: Manage FreeIPA servicedelegationtarget
+short_description: Manage FreeIPA servicedelegationtarget
 description: |
   Manage FreeIPA servicedelegationtarget and servicedelegationtarget members
 extends_documentation_fragment:

--- a/plugins/modules/ipasudocmd.py
+++ b/plugins/modules/ipasudocmd.py
@@ -33,7 +33,7 @@ ANSIBLE_METADATA = {
 DOCUMENTATION = """
 ---
 module: ipasudocmd
-short description: Manage FreeIPA sudo command
+short_description: Manage FreeIPA sudo command
 description: Manage FreeIPA sudo command
 extends_documentation_fragment:
   - ipamodule_base_docs

--- a/plugins/modules/ipasudocmdgroup.py
+++ b/plugins/modules/ipasudocmdgroup.py
@@ -33,7 +33,7 @@ ANSIBLE_METADATA = {
 DOCUMENTATION = """
 ---
 module: ipasudocmdgroup
-short description: Manage FreeIPA sudocmd groups
+short_description: Manage FreeIPA sudocmd groups
 description: Manage FreeIPA sudocmd groups
 extends_documentation_fragment:
   - ipamodule_base_docs

--- a/plugins/modules/ipasudorule.py
+++ b/plugins/modules/ipasudorule.py
@@ -32,7 +32,7 @@ ANSIBLE_METADATA = {
 DOCUMENTATION = """
 ---
 module: ipasudorule
-short description: Manage FreeIPA sudo rules
+short_description: Manage FreeIPA sudo rules
 description: Manage FreeIPA sudo rules
 extends_documentation_fragment:
   - ipamodule_base_docs

--- a/plugins/modules/ipatopologysegment.py
+++ b/plugins/modules/ipatopologysegment.py
@@ -32,7 +32,7 @@ ANSIBLE_METADATA = {
 DOCUMENTATION = """
 ---
 module: ipatopologysegment
-short description: Manage FreeIPA topology segments
+short_description: Manage FreeIPA topology segments
 description: Manage FreeIPA topology segments
 extends_documentation_fragment:
   - ipamodule_base_docs

--- a/plugins/modules/ipatopologysuffix.py
+++ b/plugins/modules/ipatopologysuffix.py
@@ -32,7 +32,7 @@ ANSIBLE_METADATA = {
 DOCUMENTATION = """
 ---
 module: ipatopologysuffix
-short description: Verify FreeIPA topology suffix
+short_description: Verify FreeIPA topology suffix
 description: Verify FreeIPA topology suffix
 extends_documentation_fragment:
   - ipamodule_base_docs

--- a/plugins/modules/ipauser.py
+++ b/plugins/modules/ipauser.py
@@ -32,7 +32,7 @@ ANSIBLE_METADATA = {
 DOCUMENTATION = """
 ---
 module: ipauser
-short description: Manage FreeIPA users
+short_description: Manage FreeIPA users
 description: Manage FreeIPA users
 extends_documentation_fragment:
   - ipamodule_base_docs

--- a/plugins/modules/ipavault.py
+++ b/plugins/modules/ipavault.py
@@ -32,7 +32,7 @@ ANSIBLE_METADATA = {
 DOCUMENTATION = """
 ---
 module: ipavault
-short description: Manage vaults and secret vaults.
+short_description: Manage vaults and secret vaults.
 description: Manage vaults and secret vaults. KRA service must be enabled.
 extends_documentation_fragment:
   - ipamodule_base_docs

--- a/roles/ipabackup/library/ipabackup_get_backup_dir.py
+++ b/roles/ipabackup/library/ipabackup_get_backup_dir.py
@@ -32,7 +32,7 @@ ANSIBLE_METADATA = {
 DOCUMENTATION = '''
 ---
 module: ipabackup_get_backup_dir
-short description:
+short_description:
   Get IPA_BACKUP_DIR from ipaplatform
 description:
   Get IPA_BACKUP_DIR from ipaplatform

--- a/roles/ipaclient/library/ipaclient_api.py
+++ b/roles/ipaclient/library/ipaclient_api.py
@@ -32,7 +32,7 @@ ANSIBLE_METADATA = {'metadata_version': '1.0',
 DOCUMENTATION = '''
 ---
 module: ipaclient_api
-short description:
+short_description:
   Create temporary NSS database, call IPA API for remaining enrollment parts
 description:
   Create temporary NSS database, call IPA API for remaining enrollment parts

--- a/roles/ipaclient/library/ipaclient_fix_ca.py
+++ b/roles/ipaclient/library/ipaclient_fix_ca.py
@@ -32,7 +32,7 @@ ANSIBLE_METADATA = {'metadata_version': '1.0',
 DOCUMENTATION = '''
 ---
 module: ipaclient_fix_ca
-short description: Fix IPA ca certificate
+short_description: Fix IPA ca certificate
 description: Repair Fix IPA ca certificate
 options:
   servers:

--- a/roles/ipaclient/library/ipaclient_fstore.py
+++ b/roles/ipaclient/library/ipaclient_fstore.py
@@ -34,7 +34,7 @@ ANSIBLE_METADATA = {
 DOCUMENTATION = '''
 ---
 module: ipaclient_fstore
-short description: Backup files using IPA client sysrestore
+short_description: Backup files using IPA client sysrestore
 description: Backup files using IPA client sysrestore
 options:
   backup:

--- a/roles/ipaclient/library/ipaclient_get_facts.py
+++ b/roles/ipaclient/library/ipaclient_get_facts.py
@@ -7,7 +7,7 @@ __metaclass__ = type
 DOCUMENTATION = """
 ---
 module: ipaclient_get_facts
-short description: Get facts about IPA client and server configuration.
+short_description: Get facts about IPA client and server configuration.
 description: Get facts about IPA client and server configuration.
 author:
     - Thomas Woerner

--- a/roles/ipaclient/library/ipaclient_get_otp.py
+++ b/roles/ipaclient/library/ipaclient_get_otp.py
@@ -30,7 +30,7 @@ ANSIBLE_METADATA = {'metadata_version': '1.0',
 DOCUMENTATION = '''
 ---
 module: ipaclient_get_otp
-short description: Manage IPA hosts
+short_description: Manage IPA hosts
 description:
   Manage hosts in a IPA domain.
   The operation needs to be authenticated with Kerberos either by providing

--- a/roles/ipaclient/library/ipaclient_ipa_conf.py
+++ b/roles/ipaclient/library/ipaclient_ipa_conf.py
@@ -34,7 +34,7 @@ ANSIBLE_METADATA = {
 DOCUMENTATION = '''
 ---
 module: ipaclient_ipa_conf
-short description: Configure ipa.conf
+short_description: Configure ipa.conf
 description:
   Configure ipa.conf
 options:

--- a/roles/ipaclient/library/ipaclient_join.py
+++ b/roles/ipaclient/library/ipaclient_join.py
@@ -34,7 +34,7 @@ ANSIBLE_METADATA = {
 DOCUMENTATION = '''
 ---
 module: ipaclient_join
-short description:
+short_description:
   Join a machine to an IPA realm and get a keytab for the host service
   principal
 description:

--- a/roles/ipaclient/library/ipaclient_set_hostname.py
+++ b/roles/ipaclient/library/ipaclient_set_hostname.py
@@ -34,7 +34,7 @@ ANSIBLE_METADATA = {
 DOCUMENTATION = '''
 ---
 module: ipaclient_set_hostname
-short description: Backup and set hostname
+short_description: Backup and set hostname
 description:
   Backup and set hostname
 options:

--- a/roles/ipaclient/library/ipaclient_setup_automount.py
+++ b/roles/ipaclient/library/ipaclient_setup_automount.py
@@ -34,7 +34,7 @@ ANSIBLE_METADATA = {
 DOCUMENTATION = '''
 ---
 module: ipaclient_setup_automount
-short description: Setup automount for IPA client
+short_description: Setup automount for IPA client
 description:
   Setup automount for IPA client
 options:

--- a/roles/ipaclient/library/ipaclient_setup_firefox.py
+++ b/roles/ipaclient/library/ipaclient_setup_firefox.py
@@ -34,7 +34,7 @@ ANSIBLE_METADATA = {
 DOCUMENTATION = '''
 ---
 module: ipaclient_setup_firefox
-short description: Setup firefox for IPA client
+short_description: Setup firefox for IPA client
 description:
   Setup firefox for IPA client
 options:

--- a/roles/ipaclient/library/ipaclient_setup_krb5.py
+++ b/roles/ipaclient/library/ipaclient_setup_krb5.py
@@ -34,7 +34,7 @@ ANSIBLE_METADATA = {
 DOCUMENTATION = '''
 ---
 module: ipaclient_setup_krb5
-short description: Setup krb5 for IPA client
+short_description: Setup krb5 for IPA client
 description:
   Setup krb5 for IPA client
 options:

--- a/roles/ipaclient/library/ipaclient_setup_nis.py
+++ b/roles/ipaclient/library/ipaclient_setup_nis.py
@@ -34,7 +34,7 @@ ANSIBLE_METADATA = {
 DOCUMENTATION = '''
 ---
 module: ipaclient_setup_nis
-short description: Setup NIS for IPA client
+short_description: Setup NIS for IPA client
 description:
   Setup NIS for IPA client
 options:

--- a/roles/ipaclient/library/ipaclient_setup_nss.py
+++ b/roles/ipaclient/library/ipaclient_setup_nss.py
@@ -34,7 +34,7 @@ ANSIBLE_METADATA = {
 DOCUMENTATION = '''
 ---
 module: ipaclient_setup_nss
-short description: Create IPA client NSS database
+short_description: Create IPA client NSS database
 description: Create IPA NSS database
 options:
   servers:

--- a/roles/ipaclient/library/ipaclient_setup_ntp.py
+++ b/roles/ipaclient/library/ipaclient_setup_ntp.py
@@ -34,7 +34,7 @@ ANSIBLE_METADATA = {
 DOCUMENTATION = '''
 ---
 module: ipaclient_setup_ntp
-short description: Setup NTP for IPA client
+short_description: Setup NTP for IPA client
 description:
   Setup NTP for IPA client
 options:

--- a/roles/ipaclient/library/ipaclient_setup_ssh.py
+++ b/roles/ipaclient/library/ipaclient_setup_ssh.py
@@ -34,7 +34,7 @@ ANSIBLE_METADATA = {
 DOCUMENTATION = '''
 ---
 module: ipaclient_setup_ssh
-short description: Configure ssh and sshd for IPA client
+short_description: Configure ssh and sshd for IPA client
 description:
   Configure ssh and sshd for IPA client
 options:

--- a/roles/ipaclient/library/ipaclient_setup_sssd.py
+++ b/roles/ipaclient/library/ipaclient_setup_sssd.py
@@ -34,7 +34,7 @@ ANSIBLE_METADATA = {
 DOCUMENTATION = '''
 ---
 module: ipaclient_setup_ssd
-short description: Setup sssd for IPA client
+short_description: Setup sssd for IPA client
 description:
   Setup sssd for IPA client
 options:

--- a/roles/ipaclient/library/ipaclient_test.py
+++ b/roles/ipaclient/library/ipaclient_test.py
@@ -34,7 +34,7 @@ ANSIBLE_METADATA = {
 DOCUMENTATION = '''
 ---
 module: ipaclient_test
-short description: Tries to discover IPA server
+short_description: Tries to discover IPA server
 description:
   Tries to discover IPA server using DNS or host name
 options:

--- a/roles/ipaclient/library/ipaclient_test_keytab.py
+++ b/roles/ipaclient/library/ipaclient_test_keytab.py
@@ -34,7 +34,7 @@ ANSIBLE_METADATA = {
 DOCUMENTATION = '''
 ---
 module: ipaclient_test_keytab
-short description:
+short_description:
   Test if the krb5.keytab on the machine is valid and can be used.
 description:
   Test if the krb5.keytab on the machine is valid and can be used.

--- a/roles/ipareplica/library/ipareplica_add_to_ipaservers.py
+++ b/roles/ipareplica/library/ipareplica_add_to_ipaservers.py
@@ -34,7 +34,7 @@ ANSIBLE_METADATA = {
 DOCUMENTATION = '''
 ---
 module: ipareplica_add_to_ipaservers
-short description: Add to ipaservers
+short_description: Add to ipaservers
 description:
   Add to ipaservers
 options:

--- a/roles/ipareplica/library/ipareplica_create_ipa_conf.py
+++ b/roles/ipareplica/library/ipareplica_create_ipa_conf.py
@@ -34,7 +34,7 @@ ANSIBLE_METADATA = {
 DOCUMENTATION = '''
 ---
 module: ipareplica_create_ipa_conf
-short description: Create ipa.conf
+short_description: Create ipa.conf
 description:
   Create ipa.conf
 options:

--- a/roles/ipareplica/library/ipareplica_custodia_import_dm_password.py
+++ b/roles/ipareplica/library/ipareplica_custodia_import_dm_password.py
@@ -34,7 +34,7 @@ ANSIBLE_METADATA = {
 DOCUMENTATION = '''
 ---
 module: ipareplica_custodia_import_dm_password
-short description: Import dm password into custodia
+short_description: Import dm password into custodia
 description:
   Import dm password into custodia
 options:

--- a/roles/ipareplica/library/ipareplica_ds_apply_updates.py
+++ b/roles/ipareplica/library/ipareplica_ds_apply_updates.py
@@ -34,7 +34,7 @@ ANSIBLE_METADATA = {
 DOCUMENTATION = '''
 ---
 module: ipareplica_ds_apply_updates
-short description: DS apply updates
+short_description: DS apply updates
 description:
   DS apply updates
 options:

--- a/roles/ipareplica/library/ipareplica_ds_enable_ssl.py
+++ b/roles/ipareplica/library/ipareplica_ds_enable_ssl.py
@@ -34,7 +34,7 @@ ANSIBLE_METADATA = {
 DOCUMENTATION = '''
 ---
 module: ipareplica_ds_enable_ssl
-short description: DS enable SSL
+short_description: DS enable SSL
 description:
   DS enable SSL
 options:

--- a/roles/ipareplica/library/ipareplica_enable_ipa.py
+++ b/roles/ipareplica/library/ipareplica_enable_ipa.py
@@ -34,7 +34,7 @@ ANSIBLE_METADATA = {
 DOCUMENTATION = '''
 ---
 module: ipareplica_enable_ipa
-short description: Enable IPA
+short_description: Enable IPA
 description: Enable IPA
   Enable IPA
 options:

--- a/roles/ipareplica/library/ipareplica_install_ca_certs.py
+++ b/roles/ipareplica/library/ipareplica_install_ca_certs.py
@@ -34,7 +34,7 @@ ANSIBLE_METADATA = {
 DOCUMENTATION = '''
 ---
 module: ipareplica_install_ca_cert
-short description: Install CA certs
+short_description: Install CA certs
 description:
   Install CA certs
 options:

--- a/roles/ipareplica/library/ipareplica_krb_enable_ssl.py
+++ b/roles/ipareplica/library/ipareplica_krb_enable_ssl.py
@@ -34,7 +34,7 @@ ANSIBLE_METADATA = {
 DOCUMENTATION = '''
 ---
 module: ipareplica_krb_enable_ssl
-short description: KRB enable SSL
+short_description: KRB enable SSL
 description:
   KRB enable SSL
 options:

--- a/roles/ipareplica/library/ipareplica_master_password.py
+++ b/roles/ipareplica/library/ipareplica_master_password.py
@@ -34,7 +34,7 @@ ANSIBLE_METADATA = {
 DOCUMENTATION = '''
 ---
 module: ipareplica_master_password
-short description: Generate kerberos master password if not given
+short_description: Generate kerberos master password if not given
 description:
   Generate kerberos master password if not given
 options:

--- a/roles/ipareplica/library/ipareplica_prepare.py
+++ b/roles/ipareplica/library/ipareplica_prepare.py
@@ -34,7 +34,7 @@ ANSIBLE_METADATA = {
 DOCUMENTATION = '''
 ---
 module: ipareplica_prepare
-short description: Prepare ipa replica installation
+short_description: Prepare ipa replica installation
 description: |
   Prepare ipa replica installation: Create IPA configuration file, run install
   checks again and also update the host name and the hosts file if needed.

--- a/roles/ipareplica/library/ipareplica_promote_openldap_conf.py
+++ b/roles/ipareplica/library/ipareplica_promote_openldap_conf.py
@@ -34,7 +34,7 @@ ANSIBLE_METADATA = {
 DOCUMENTATION = '''
 ---
 module: ipareplica_promote_openldap_conf
-short description: Promote openldap.conf
+short_description: Promote openldap.conf
 description:
   Promote openldap.conf
 options:

--- a/roles/ipareplica/library/ipareplica_promote_sssd.py
+++ b/roles/ipareplica/library/ipareplica_promote_sssd.py
@@ -34,7 +34,7 @@ ANSIBLE_METADATA = {
 DOCUMENTATION = '''
 ---
 module: ipareplica_promote_sssd
-short description: Promote sssd
+short_description: Promote sssd
 description:
   Promote sssd
 options:

--- a/roles/ipareplica/library/ipareplica_restart_kdc.py
+++ b/roles/ipareplica/library/ipareplica_restart_kdc.py
@@ -34,7 +34,7 @@ ANSIBLE_METADATA = {
 DOCUMENTATION = '''
 ---
 module: ipareplica_restart_kdc
-short description: Restart KDC
+short_description: Restart KDC
 description:
   Restart KDC
 options:

--- a/roles/ipareplica/library/ipareplica_setup_adtrust.py
+++ b/roles/ipareplica/library/ipareplica_setup_adtrust.py
@@ -34,7 +34,7 @@ ANSIBLE_METADATA = {
 DOCUMENTATION = '''
 ---
 module: ipareplica_setup_adtrust
-short description: Setup adtrust
+short_description: Setup adtrust
 description:
   Setup adtrust
 options:

--- a/roles/ipareplica/library/ipareplica_setup_ca.py
+++ b/roles/ipareplica/library/ipareplica_setup_ca.py
@@ -34,7 +34,7 @@ ANSIBLE_METADATA = {
 DOCUMENTATION = '''
 ---
 module: ipareplica_setup_ca
-short description: Setup CA
+short_description: Setup CA
 description:
   Setup CA
 options:

--- a/roles/ipareplica/library/ipareplica_setup_certmonger.py
+++ b/roles/ipareplica/library/ipareplica_setup_certmonger.py
@@ -34,7 +34,7 @@ ANSIBLE_METADATA = {
 DOCUMENTATION = '''
 ---
 module: ipareplica_setup_certmonger
-short description: Setup certmonger
+short_description: Setup certmonger
 description:
   Setup certmonger
 options:

--- a/roles/ipareplica/library/ipareplica_setup_custodia.py
+++ b/roles/ipareplica/library/ipareplica_setup_custodia.py
@@ -34,7 +34,7 @@ ANSIBLE_METADATA = {
 DOCUMENTATION = '''
 ---
 module: ipareplica_setup_custodia
-short description: Setup custodia
+short_description: Setup custodia
 description:
   Setup custodia
 options:

--- a/roles/ipareplica/library/ipareplica_setup_dns.py
+++ b/roles/ipareplica/library/ipareplica_setup_dns.py
@@ -34,7 +34,7 @@ ANSIBLE_METADATA = {
 DOCUMENTATION = '''
 ---
 module: ipareplica_setup_dns
-short description: Setup DNS
+short_description: Setup DNS
 description:
   Setup DNS
 options:

--- a/roles/ipareplica/library/ipareplica_setup_ds.py
+++ b/roles/ipareplica/library/ipareplica_setup_ds.py
@@ -34,7 +34,7 @@ ANSIBLE_METADATA = {
 DOCUMENTATION = '''
 ---
 module: ipareplica_setup_ds
-short description: Setup DS
+short_description: Setup DS
 description:
   Setup DS
 options:

--- a/roles/ipareplica/library/ipareplica_setup_http.py
+++ b/roles/ipareplica/library/ipareplica_setup_http.py
@@ -34,7 +34,7 @@ ANSIBLE_METADATA = {
 DOCUMENTATION = '''
 ---
 module: ipareplica_setup_http
-short description: Setup HTTP
+short_description: Setup HTTP
 description:
   Setup HTTP
 options:

--- a/roles/ipareplica/library/ipareplica_setup_kra.py
+++ b/roles/ipareplica/library/ipareplica_setup_kra.py
@@ -34,7 +34,7 @@ ANSIBLE_METADATA = {
 DOCUMENTATION = '''
 ---
 module: ipareplica_setup_kra
-short description: Setup KRA
+short_description: Setup KRA
 description:
   Setup KRA
 options:

--- a/roles/ipareplica/library/ipareplica_setup_krb.py
+++ b/roles/ipareplica/library/ipareplica_setup_krb.py
@@ -34,7 +34,7 @@ ANSIBLE_METADATA = {
 DOCUMENTATION = '''
 ---
 module: ipareplica_setup_krb
-short description: Setup KRB
+short_description: Setup KRB
 description:
   Setup KRB
 options:

--- a/roles/ipareplica/library/ipareplica_setup_otpd.py
+++ b/roles/ipareplica/library/ipareplica_setup_otpd.py
@@ -34,7 +34,7 @@ ANSIBLE_METADATA = {
 DOCUMENTATION = '''
 ---
 module: ipareplica_setup_otpd
-short description: Setup OTPD
+short_description: Setup OTPD
 description:
   Setup OTPD
 options:

--- a/roles/ipareplica/library/ipareplica_test.py
+++ b/roles/ipareplica/library/ipareplica_test.py
@@ -34,7 +34,7 @@ ANSIBLE_METADATA = {
 DOCUMENTATION = '''
 ---
 module: ipareplica_test
-short description: IPA replica deployment tests
+short_description: IPA replica deployment tests
 description: IPA replica deployment tests
 options:
   ip_addresses:

--- a/roles/ipaserver/library/ipaserver_enable_ipa.py
+++ b/roles/ipaserver/library/ipaserver_enable_ipa.py
@@ -34,7 +34,7 @@ ANSIBLE_METADATA = {
 DOCUMENTATION = '''
 ---
 module: ipaserver_enable_ipa
-short description: Enable IPA
+short_description: Enable IPA
 description: Enable IPA
 options:
   hostname:

--- a/roles/ipaserver/library/ipaserver_load_cache.py
+++ b/roles/ipaserver/library/ipaserver_load_cache.py
@@ -34,7 +34,7 @@ ANSIBLE_METADATA = {
 DOCUMENTATION = '''
 ---
 module: ipaserver_load_cache
-short description: Load cache file
+short_description: Load cache file
 description: Load cache file
 options:
   dm_password:

--- a/roles/ipaserver/library/ipaserver_master_password.py
+++ b/roles/ipaserver/library/ipaserver_master_password.py
@@ -34,7 +34,7 @@ ANSIBLE_METADATA = {
 DOCUMENTATION = '''
 ---
 module: ipaserver_master_password
-short description: Generate kerberos master password if not given
+short_description: Generate kerberos master password if not given
 description:
   Generate kerberos master password if not given
 options:

--- a/roles/ipaserver/library/ipaserver_prepare.py
+++ b/roles/ipaserver/library/ipaserver_prepare.py
@@ -34,7 +34,7 @@ ANSIBLE_METADATA = {
 DOCUMENTATION = '''
 ---
 module: ipaserver_prepare
-short description: Prepare IPA server deployment
+short_description: Prepare IPA server deployment
 description: Prepare IPA server deployment
 options:
   force:

--- a/roles/ipaserver/library/ipaserver_set_ds_password.py
+++ b/roles/ipaserver/library/ipaserver_set_ds_password.py
@@ -34,7 +34,7 @@ ANSIBLE_METADATA = {
 DOCUMENTATION = '''
 ---
 module: ipaserver_set_ds_password
-short description: Set DS password
+short_description: Set DS password
 description: Set DS password
 options:
   dm_password:

--- a/roles/ipaserver/library/ipaserver_setup_adtrust.py
+++ b/roles/ipaserver/library/ipaserver_setup_adtrust.py
@@ -34,7 +34,7 @@ ANSIBLE_METADATA = {
 DOCUMENTATION = '''
 ---
 module: ipaserver_setup_adtrust
-short description: Setup trust ad
+short_description: Setup trust ad
 description: Setup trust ad
 options:
   hostname:

--- a/roles/ipaserver/library/ipaserver_setup_ca.py
+++ b/roles/ipaserver/library/ipaserver_setup_ca.py
@@ -34,7 +34,7 @@ ANSIBLE_METADATA = {
 DOCUMENTATION = '''
 ---
 module: ipaserver_setup_ca
-short description: Setup CA
+short_description: Setup CA
 description: Setup CA
 options:
   dm_password:

--- a/roles/ipaserver/library/ipaserver_setup_custodia.py
+++ b/roles/ipaserver/library/ipaserver_setup_custodia.py
@@ -34,7 +34,7 @@ ANSIBLE_METADATA = {
 DOCUMENTATION = '''
 ---
 module: ipaserver_setup_custodia
-short description: Setup custodia
+short_description: Setup custodia
 description: Setup custodia
 options:
   realm:

--- a/roles/ipaserver/library/ipaserver_setup_dns.py
+++ b/roles/ipaserver/library/ipaserver_setup_dns.py
@@ -34,7 +34,7 @@ ANSIBLE_METADATA = {
 DOCUMENTATION = '''
 ---
 module: ipaserver_setup_dns
-short description: Setup DNS
+short_description: Setup DNS
 description: Setup DNS
 options:
   ip_addresses:

--- a/roles/ipaserver/library/ipaserver_setup_ds.py
+++ b/roles/ipaserver/library/ipaserver_setup_ds.py
@@ -34,7 +34,7 @@ ANSIBLE_METADATA = {
 DOCUMENTATION = '''
 ---
 module: ipaserver_setup_ds
-short description: Configure directory server
+short_description: Configure directory server
 description: Configure directory server
 options:
   dm_password:

--- a/roles/ipaserver/library/ipaserver_setup_http.py
+++ b/roles/ipaserver/library/ipaserver_setup_http.py
@@ -34,7 +34,7 @@ ANSIBLE_METADATA = {
 DOCUMENTATION = '''
 ---
 module: ipaserver_setup_http
-short description: Setup HTTP
+short_description: Setup HTTP
 description: Setup HTTP
 options:
   dm_password:

--- a/roles/ipaserver/library/ipaserver_setup_kra.py
+++ b/roles/ipaserver/library/ipaserver_setup_kra.py
@@ -34,7 +34,7 @@ ANSIBLE_METADATA = {
 DOCUMENTATION = '''
 ---
 module: ipaserver_setup_kra
-short description: Setup KRA
+short_description: Setup KRA
 description: Setup KRA
 options:
   dm_password:

--- a/roles/ipaserver/library/ipaserver_setup_krb.py
+++ b/roles/ipaserver/library/ipaserver_setup_krb.py
@@ -34,7 +34,7 @@ ANSIBLE_METADATA = {
 DOCUMENTATION = '''
 ---
 module: ipaserver_setup_krb
-short description: Setup KRB
+short_description: Setup KRB
 description: Setup KRB
 options:
   dm_password:

--- a/roles/ipaserver/library/ipaserver_setup_ntp.py
+++ b/roles/ipaserver/library/ipaserver_setup_ntp.py
@@ -34,7 +34,7 @@ ANSIBLE_METADATA = {
 DOCUMENTATION = '''
 ---
 module: ipaserver_setup_ntp
-short description: Setup NTP
+short_description: Setup NTP
 description: Setup NTP
 options:
   ntp_servers:

--- a/roles/ipaserver/library/ipaserver_setup_otpd.py
+++ b/roles/ipaserver/library/ipaserver_setup_otpd.py
@@ -34,7 +34,7 @@ ANSIBLE_METADATA = {
 DOCUMENTATION = '''
 ---
 module: ipaserver_setup_otpd
-short description: Setup OTPD
+short_description: Setup OTPD
 description: Setup OTPD
 options:
   realm:

--- a/roles/ipaserver/library/ipaserver_test.py
+++ b/roles/ipaserver/library/ipaserver_test.py
@@ -34,7 +34,7 @@ ANSIBLE_METADATA = {
 DOCUMENTATION = '''
 ---
 module: ipaserver_test
-short description: IPA server test
+short_description: IPA server test
 description: IPA server test
 options:
   force:

--- a/roles/ipasmartcard_client/library/ipasmartcard_client_get_vars.py
+++ b/roles/ipasmartcard_client/library/ipasmartcard_client_get_vars.py
@@ -32,7 +32,7 @@ ANSIBLE_METADATA = {
 DOCUMENTATION = '''
 ---
 module: ipasmartcard_client_get_vars
-short description:
+short_description:
   Get variables from ipaplatform and python interpreter used for the module.
 description:
   Get variables from ipaplatform and python interpreter used for the module.

--- a/roles/ipasmartcard_client/library/ipasmartcard_client_validate_ca_certs.py
+++ b/roles/ipasmartcard_client/library/ipasmartcard_client_validate_ca_certs.py
@@ -34,7 +34,7 @@ ANSIBLE_METADATA = {
 DOCUMENTATION = '''
 ---
 module: ipasmartcard_server_validate_ca_certs
-short description: Validate CA certs
+short_description: Validate CA certs
 description: Validate CA certs
 options:
   ca_cert_files:

--- a/roles/ipasmartcard_server/library/ipasmartcard_server_get_vars.py
+++ b/roles/ipasmartcard_server/library/ipasmartcard_server_get_vars.py
@@ -32,7 +32,7 @@ ANSIBLE_METADATA = {
 DOCUMENTATION = '''
 ---
 module: ipasmartcard_server_get_vars
-short description:
+short_description:
   Get variables from ipaplatform and ipaserver and python interpreter.
 description:
   Get variables from ipaplatform and ipaserver and python interpreter.

--- a/roles/ipasmartcard_server/library/ipasmartcard_server_validate_ca_certs.py
+++ b/roles/ipasmartcard_server/library/ipasmartcard_server_validate_ca_certs.py
@@ -34,7 +34,7 @@ ANSIBLE_METADATA = {
 DOCUMENTATION = '''
 ---
 module: ipasmartcard_server_validate_ca_certs
-short description: Validate CA certs
+short_description: Validate CA certs
 description: Validate CA certs
 options:
   ca_cert_files:

--- a/utils/templates/ipamodule+member.py.in
+++ b/utils/templates/ipamodule+member.py.in
@@ -32,7 +32,7 @@ ANSIBLE_METADATA = {
 DOCUMENTATION = """
 ---
 module: ipa$name
-short description: Manage FreeIPA $name
+short_description: Manage FreeIPA $name
 description: Manage FreeIPA $name and $name members
 extends_documentation_fragment:
   - ipamodule_base_docs

--- a/utils/templates/ipamodule.py.in
+++ b/utils/templates/ipamodule.py.in
@@ -32,7 +32,7 @@ ANSIBLE_METADATA = {
 DOCUMENTATION = """
 ---
 module: ipa$name
-short description: Manage FreeIPA $name
+short_description: Manage FreeIPA $name
 description: Manage FreeIPA $name
 extends_documentation_fragment:
   - ipamodule_base_docs


### PR DESCRIPTION
Before "short description" was used in most plugins, modules and also
in the new module templates.

ansible-doc was therefore not showing the short description. To fix the
issue the flag was renamed to short_description instead.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=2121362
       'ansible-doc' -l lists most idm modules as 'UNDOCUMENTED'