### PR TITLE
ipaserver: ipaclient part does not need to install packages

### DIFF
--- a/roles/ipaserver/tasks/install.yml
+++ b/roles/ipaserver/tasks/install.yml
@@ -428,7 +428,7 @@
         ipaclient_no_ntp:
           "{{ 'true' if result_ipaserver_test.ipa_python_version >= 40690
                else 'false' }}"
-        ipaclient_install_packages: "{{ ipaserver_install_packages }}"
+        ipaclient_install_packages: no
 
     - name: Install - Enable IPA
       ipaserver_enable_ipa:


### PR DESCRIPTION
The client part installation is checking for the client packages. These
packages are part of the server packages that have been installed with
the server role and therefore the task is not needed.

This is helping to reduce the deployment time of a server.