### PR TITLE
fedora rawhide: Temporarily disable failing DNS tests

### DIFF
--- a/tests/azure/templates/variables_fedora-rawhide.yaml
+++ b/tests/azure/templates/variables_fedora-rawhide.yaml
@@ -15,5 +15,7 @@ variables:
   empty: true
   # ipa_enabled_modules: >-
   # ipa_enabled_tests: >-
-  # ipa_disabled_modules: >-
-  # ipa_disabled_tests: >-
+  ipa_disabled_modules: >-
+    dnsforwardzone,
+  ipa_disabled_tests: >-
+    test_dnsconfig_forwarders_ports


### PR DESCRIPTION
Some DNS tests have been disabled for Fedora latest, but not for Fedora
Rawhide. Therefore these tests are filin still in nighty:

- dnsforwardzone
- test_dnsconfig_forwarders_ports