### PR TITLE
ipaserver: Add missing idstart check

### DIFF
--- a/roles/ipaserver/library/ipaserver_test.py
+++ b/roles/ipaserver/library/ipaserver_test.py
@@ -225,7 +225,8 @@ from ansible.module_utils.ansible_ipa_server import (
     read_cache, ca, tasks, check_ldap_conf, timeconf, httpinstance,
     check_dirsrv, ScriptError, get_fqdn, verify_fqdn, BadHostError,
     validate_domain_name, load_pkcs12, IPA_PYTHON_VERSION,
-    encode_certificate, check_available_memory, getargspec, adtrustinstance
+    encode_certificate, check_available_memory, getargspec, adtrustinstance,
+    get_min_idstart
 )
 from ansible.module_utils import six
 
@@ -578,6 +579,16 @@ def main():
                 raise RuntimeError(
                     "'--ignore-topology-disconnect/--ignore-last-of-role' "
                     "options can be used only during uninstallation")
+
+            if get_min_idstart is not None:
+                min_idstart = get_min_idstart()
+                if self.idstart < min_idstart:
+                    raise RuntimeError(
+                        "idstart (%i) must be larger than UID_MAX/GID_MAX "
+                        "(%i) setting in /etc/login.defs." % (
+                            self.idstart, min_idstart
+                        )
+                    )
 
             if self.idmax < self.idstart:
                 raise RuntimeError(

--- a/roles/ipaserver/module_utils/ansible_ipa_server.py
+++ b/roles/ipaserver/module_utils/ansible_ipa_server.py
@@ -41,7 +41,7 @@ __all__ = ["IPAChangeConf", "certmonger", "sysrestore", "root_logger",
            "adtrustinstance", "IPAAPI_USER", "sync_time", "PKIIniLoader",
            "default_subject_base", "default_ca_subject_dn",
            "check_ldap_conf", "encode_certificate", "decode_certificate",
-           "check_available_memory", "getargspec"]
+           "check_available_memory", "getargspec", "get_min_idstart"]
 
 import sys
 
@@ -199,6 +199,11 @@ else:
         except ImportError:
             from ipalib.x509 import load_certificate
             load_pem_x509_certificate = None
+
+        try:
+            from ipaserver.install.server.install import get_min_idstart
+        except ImportError:
+            get_min_idstart = None
 
     else:
         # IPA version < 4.5


### PR DESCRIPTION
The idstart needs to be larger than UID_MAX or GID_MAX from /etc/login.defs.
This is "Require idstart to be larger than UID_MAX" for freeipa.

Fixes: #896 (Invalid RID/SID SSSD backtrace after deployment)