### PR TITLE
ipabackup: Fix order of ipabackup_name parameter evaluation.

### DIFF
--- a/roles/ipabackup/tasks/main.yml
+++ b/roles/ipabackup/tasks/main.yml
@@ -26,18 +26,18 @@
   fail: msg="ipabackup_from_controller and ipabackup_to_controller are set"
   when: ipabackup_from_controller | bool and ipabackup_to_controller | bool
 
+- name: Fail for given ipabackup_name if state is not copied, restored or absent
+  fail: msg="ipabackup_name is given and state is not copied, restored or absent"
+  when: state is not defined or
+        (state != "copied" and state != "restored" and state != "absent") and
+        ipabackup_name is defined
+
 - name: Get ipabackup_dir from IPA installation
   include_tasks: "{{ role_path }}/tasks/get_ipabackup_dir.yml"
 
 - name: Backup IPA server
   include_tasks: "{{ role_path }}/tasks/backup.yml"
   when: state|default("present") == "present"
-
-- name: Fail for given ipabackup_name if state is not copied, restored or absent
-  fail: msg="ipabackup_name is given and state is not copied, restored or absent"
-  when: state is not defined or
-        (state != "copied" and state != "restored" and state != "absent") and
-        ipabackup_name is defined
 
 - name: Fail on missing ipabackup_name
   fail: msg="ipabackup_name is not set"

--- a/tests/backup_role/test_backup.yml
+++ b/tests/backup_role/test_backup.yml
@@ -383,6 +383,31 @@
       loop_var: server_backup_data
       label: server_backup_data.path
 
+  # Test issue #900
+  - name: Remove all backup from server.
+    ansible.builtin.include_role:
+      name: ipabackup
+    vars:
+      state: absent
+      ipabackup_name: all
+
+  - name: Test issue 900 fix.
+    block:
+      - name: Invalid role configuration that should not produce a backup on the server.
+        ansible.builtin.include_role:
+          name: ipabackup
+        vars:
+          state: present
+          ipabackup_name: this_must_fail
+    rescue:
+      - name: List all existing backups on server
+        ansible.builtin.find:
+          path: /var/lib/ipa/backup
+          recurse: no
+          file_type: directory
+        register: server_backups
+        failed_when: server_backups.files
+
   # CLEANUP
 
   - name: List all existing backups on controller

--- a/utils/set_test_modules
+++ b/utils/set_test_modules
@@ -18,13 +18,11 @@ pushd "${TOPDIR}" >/dev/null 2>&1 || die "Failed to change directory."
 
 files_list=$(mktemp)
 
-if [ -z "$BASE_BRANCH" ]
-then
-    git remote add  _temp https://github.com/freeipa/ansible-freeipa
-    git fetch --prune --no-tags --quiet _temp
-    BASE_BRANCH="master"
-fi
-git diff "${BASE_BRANCH}" --name-only > "${files_list}"
+remote="$(basename $(mktemp -u remote_XXXXXX))"
+git remote add ${remote} https://github.com/freeipa/ansible-freeipa
+git fetch --prune --no-tags --quiet ${remote}
+git diff "${remote}/master" --name-only > "${files_list}"
+git remote remove ${remote}
 
 # Get all modules that should have tests executed
 enabled_modules="$(python utils/get_test_modules.py $(cat "${files_list}"))"


### PR DESCRIPTION
When performing a backup with 'state:present', if 'ipabackup_name' is
provided, the backup will be performed, but the role with return an
error since 'ipabackup_name' should not be set for this state.

This patch moves the parameter evaluation to be performed before the
actual backup is performed, so that the backup is not performed and an
error is reported.

FIxes #900 