### PR TITLE
ipaserver/ipareplica: Add isatty method to AnsibleModuleLog

### DIFF
--- a/roles/ipareplica/module_utils/ansible_ipa_replica.py
+++ b/roles/ipareplica/module_utils/ansible_ipa_replica.py
@@ -222,6 +222,10 @@ else:
         def info(self, msg):
             self.module.debug(msg)
 
+        @staticmethod
+        def isatty():
+            return False
+
         def write(self, msg):
             self.module.debug(msg)
             # self.module.warn(msg)

--- a/roles/ipaserver/module_utils/ansible_ipa_server.py
+++ b/roles/ipaserver/module_utils/ansible_ipa_server.py
@@ -255,6 +255,10 @@ else:
         def info(self, msg):
             self.module.debug(msg)
 
+        @staticmethod
+        def isatty():
+            return False
+
         def write(self, msg):
             self.module.debug(msg)
             # self.module.warn(msg)


### PR DESCRIPTION
In some cases ipa code is using sys.stdout.isatty. As stdout is mapped
to AnsibleModuleLog this call will lead in a traceback as it was not
defined.

The staticmethod isatty has been added to AnsibleModuleLog in ipaserver
role module_utils/ansible_ipa_server.py and in ipareplica role
module_utils/ansible_ipa_repica.py.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=2120415
       ansible-freeipa Replica Install Setup DNS fails
Fixes: #251 - 'AnsibleModuleLog' object has no attribute 'isatty'
Fixes: #117 - 'AnsibleModuleLog' object has no attribute 'isatty'