### PR TITLE
ipaconfig: Add support for SID related attributes.

### DIFF
--- a/README-config.md
+++ b/README-config.md
@@ -65,6 +65,9 @@ Example playbook to read config options:
         maxusername: 64
 ```
 
+
+Example playbook to set global configuration options:
+
 ```yaml
 ---
 - name: Playbook to ensure some config options are set
@@ -78,6 +81,40 @@ Example playbook to read config options:
         maxusername: 64
 ```
 
+
+Example playbook to enable SID and generate users and groups SIDs:
+
+```yaml
+---
+- name: Playbook to ensure SIDs are enabled and users and groups have SIDs
+  hosts: ipaserver
+  become: no
+  gather_facts: no
+
+  tasks:
+    - name: Enable SID and generate users and groups SIDS
+      ipaconfig:
+        ipaadmin_password: SomeADMINpassword
+        enable_sid: yes
+        add_sids: yes
+```
+
+Example playbook to change IPA domain NetBIOS name:
+
+```yaml
+---
+- name: Playbook to change IPA domain netbios name
+  hosts: ipaserver
+  become: no
+  gather_facts: no
+
+  tasks:
+    - name: Set IPA domain netbios name
+      ipaconfig:
+        ipaadmin_password: SomeADMINpassword
+        enable_sid: yes
+        netbios_name: IPADOM
+```
 
 Variables
 =========
@@ -111,6 +148,9 @@ Variable | Description | Required
 `user_auth_type` \| `ipauserauthtype` |  set default types of supported user authentication (choices: `password`, `radius`, `otp`, `disabled`). Use `""` to clear this variable. | no
 `domain_resolution_order` \| `ipadomainresolutionorder` | Set list of domains used for short name qualification | no
 `ca_renewal_master_server` \| `ipacarenewalmasterserver`| Renewal master for IPA certificate authority. | no
+`enable_sid` | New users and groups automatically get a SID assigned. Requires IPA 4.9.8+. (bool) | no
+`netbios_name` | NetBIOS name of the IPA domain. Requires IPA 4.9.8+ and 'enable_sid: yes'. | no
+`add_sids` | Add SIDs for existing users and groups. Requires IPA 4.9.8+ and 'enable_sid: yes'. (bool) | no
 
 
 Return Values
@@ -140,6 +180,8 @@ Variable | Description | Returned When
 &nbsp; | `user_auth_type` | &nbsp;
 &nbsp; | `domain_resolution_order` | &nbsp;
 &nbsp; | `ca_renewal_master_server` | &nbsp;
+&nbsp; | `enable_sid` | &nbsp;
+&nbsp; | `netbios_name` | &nbsp;
 
 All returned fields take the same form as their namesake input parameters
 

--- a/playbooks/config/change-ipa-domain-netbios-name.yml
+++ b/playbooks/config/change-ipa-domain-netbios-name.yml
@@ -1,0 +1,12 @@
+---
+- name: Playbook to change IPA domain netbios name
+  hosts: ipaserver
+  become: no
+  gather_facts: no
+
+  tasks:
+    - name: Set IPA domain netbios name
+      ipaconfig:
+        ipaadmin_password: SomeADMINpassword
+        enable_sid: yes
+        netbios_name: IPADOM

--- a/playbooks/config/generate-users-groups-sids.yml
+++ b/playbooks/config/generate-users-groups-sids.yml
@@ -1,0 +1,12 @@
+---
+- name: Playbook to ensure SIDs are enabled and users and groups have SIDs
+  hosts: ipaserver
+  become: no
+  gather_facts: no
+
+  tasks:
+    - name: Enable SID and generate users and groups SIDS
+      ipaconfig:
+        ipaadmin_password: SomeADMINpassword
+        enable_sid: yes
+        add_sids: yes

--- a/tests/azure/templates/variables_centos-7.yaml
+++ b/tests/azure/templates/variables_centos-7.yaml
@@ -12,8 +12,7 @@
 #
 ---
 variables:
-  empty: true
-#   ipa_enabled_modules: >-
-#   ipa_enabled_tests: >-
-#   ipa_disabled_modules: >-
-#   ipa_disabled_tests: >-
+  # ipa_enabled_modules: >-
+  # ipa_enabled_tests: >-
+  # ipa_disabled_modules: >-
+  ipa_disabled_tests: test_config_sid

--- a/tests/config/test_config_sid.yml
+++ b/tests/config/test_config_sid.yml
@@ -1,0 +1,70 @@
+---
+- name: Test config
+  hosts: "{{ ipa_test_host | default('ipaserver') }}"
+  become: no
+  gather_facts: no
+
+  tasks:
+
+  # GET CURRENT CONFIG
+
+  - name: Return current values of the global configuration options
+    ipaconfig:
+      ipaadmin_password: SomeADMINpassword
+      ipaapi_context: "{{ ipa_context | default(omit) }}"
+    register: previous
+
+  # TESTS
+  - block:
+    - name: Ensure SID is enabled.
+      ipaconfig:
+        ipaadmin_password: SomeADMINpassword
+        ipaapi_context: "{{ ipa_context | default(omit) }}"
+        enable_sid: yes
+      register: result
+      failed_when: result.failed or previous.config.enable_sid == result.changed
+
+    - name: Ensure SID is enabled, again.
+      ipaconfig:
+        ipaadmin_password: SomeADMINpassword
+        ipaapi_context: "{{ ipa_context | default(omit) }}"
+        enable_sid: yes
+      register: result
+      failed_when: result.failed or result.changed
+
+    - name: Ensure netbios_name is "IPATESTPLAY"
+      ipaconfig:
+        ipaadmin_password: SomeADMINpassword
+        ipaapi_context: "{{ ipa_context | default(omit) }}"
+        enable_sid: yes
+        netbios_name: IPATESTPLAY
+      register: result
+      failed_when: result.failed or not result.changed
+
+    - name: Ensure netbios_name is "IPATESTPLAY", again
+      ipaconfig:
+        ipaadmin_password: SomeADMINpassword
+        ipaapi_context: "{{ ipa_context | default(omit) }}"
+        enable_sid: yes
+        netbios_name: IPATESTPLAY
+      register: result
+      failed_when: result.failed or result.changed
+
+    # add_sids is not idempotent as it always tries to generate the missing
+    # SIDs for users and groups.
+    - name: Add SIDs to users and groups.
+      ipaconfig:
+        ipaadmin_password: SomeADMINpassword
+        ipaapi_context: "{{ ipa_context | default(omit) }}"
+        enable_sid: yes
+        add_sids: yes
+
+    # REVERT TO PREVIOUS CONFIG
+    always:
+    # Once SID is enabled, it cannot be reverted.
+    - name: Revert netbios_name to original configuration
+      ipaconfig:
+        ipaadmin_password: SomeADMINpassword
+        ipaapi_context: "{{ ipa_context | default(omit) }}"
+        netbios_name: "{{ previous.config.netbios_name | default(omit) }}"
+        enable_sid: yes


### PR DESCRIPTION
Since FreeIPA 4.9.8 the 'config_mod' command has parameters to enable
and configure SIDs, and set the Netbios name.

This patch adds the following parameters to ipaconfig plugin:
    enable_sids: New users and groups automatically get a SID assigned
    add_sids: Add SIDs for existing users and groups
    netbios_name: NetBIOS name of the IPA domain

Both add_sids and netbios_name requires 'enable_sid: yes'.

'enable_sid' and 'netbios_name' are returned when querying IPA
configuration.

'add_sids' always generate SIDs for users and groups, so, muiltiple
executions of the playbook with 'add_sids: yes' will return 'changed',
even if users and groups SIDs are not modified.

Fixes: #781
Related: https://bugzilla.redhat.com/show_bug.cgi?id=2069174
Related: https://bugzilla.redhat.com/show_bug.cgi?id=2069184