### PR TITLE
upstream CI: Ensure 'master' branch is available for set_test_modules

### DIFF
--- a/utils/set_test_modules
+++ b/utils/set_test_modules
@@ -18,7 +18,12 @@ pushd "${TOPDIR}" >/dev/null 2>&1 || die "Failed to change directory."
 
 files_list=$(mktemp)
 
-BASE_BRANCH=${BASE_BRANCH:-"master"}
+if [ -z "$BASE_BRANCH" ]
+then
+    git remote add  _temp https://github.com/freeipa/ansible-freeipa
+    git fetch --prune --no-tags --quiet _temp
+    BASE_BRANCH="master"
+fi
 git diff "${BASE_BRANCH}" --name-only > "${files_list}"
 
 # Get all modules that should have tests executed


### PR DESCRIPTION
If the repository is setup in a way that master branch is not available
for comparing the current HEAD against it, the comparison will fail and
not module/role will be scheduled for testing.

This patch forces fetching 'master' from ansible-freeipa repository,
allowing the comparison to be performed.