### PR TITLE
ipaconfig: Fix example playbook titles.

### DIFF
--- a/playbooks/config/retrieve-config.yml
+++ b/playbooks/config/retrieve-config.yml
@@ -1,5 +1,5 @@
 ---
-- name: Playbook to handle global DNS configuration
+- name: Playbook to handle global IPA configuration
   hosts: ipaserver
   become: no
   gather_facts: no

--- a/playbooks/config/set-ca-renewal-master-server.yml
+++ b/playbooks/config/set-ca-renewal-master-server.yml
@@ -1,5 +1,5 @@
 ---
-- name: Playbook to handle global DNS configuration
+- name: Playbook to handle global IPA configuration
   hosts: ipaserver
   become: no
   gather_facts: no


### PR DESCRIPTION
`ipaconfig` playbooks had "DNS configuration" on the titles, but they manage global IPA configuration.