### PR TITLE
Re-enable dnsforwardzone tests

### DIFF
--- a/tests/azure/templates/variables_c8s.yaml
+++ b/tests/azure/templates/variables_c8s.yaml
@@ -5,11 +5,13 @@
 #
 # Example:
 #
-# disabled_modules: >-
+# ipa_disabled_modules: >-
 #   dnsconfig,
 #   group,
 #   hostgroup
 #
+# If no variables are set, set "empty: true" as at least
+# one item is needed in the set.
 ---
 variables:
   empty: true

--- a/tests/azure/templates/variables_c9s.yaml
+++ b/tests/azure/templates/variables_c9s.yaml
@@ -5,11 +5,13 @@
 #
 # Example:
 #
-# disabled_modules: >-
+# ipa_disabled_modules: >-
 #   dnsconfig,
 #   group,
 #   hostgroup
 #
+# If no variables are set, set "empty: true" as at least
+# one item is needed in the set.
 ---
 variables:
   empty: true

--- a/tests/azure/templates/variables_centos-7.yaml
+++ b/tests/azure/templates/variables_centos-7.yaml
@@ -5,11 +5,13 @@
 #
 # Example:
 #
-# disabled_modules: >-
+# ipa_disabled_modules: >-
 #   dnsconfig,
 #   group,
 #   hostgroup
 #
+# If no variables are set, set "empty: true" as at least
+# one item is needed in the set.
 ---
 variables:
   # ipa_enabled_modules: >-

--- a/tests/azure/templates/variables_fedora-latest.yaml
+++ b/tests/azure/templates/variables_fedora-latest.yaml
@@ -15,9 +15,8 @@
 # one item is needed in the set.
 ---
 variables:
+  empty: true
   # ipa_enabled_modules: >-
   # ipa_enabled_tests: >-
-  ipa_disabled_modules: >-
-    dnsforwardzone,
-  ipa_disabled_tests: >-
-    test_dnsconfig_forwarders_ports
+  # ipa_disabled_modules: >-
+  # ipa_disabled_tests: >-

--- a/tests/azure/templates/variables_fedora-latest.yaml
+++ b/tests/azure/templates/variables_fedora-latest.yaml
@@ -1,15 +1,18 @@
 #
+#
 # Variables must be defined as comma separated lists.
 # For easier management of items to enable/disable,
 # use one test/module on each line, followed by a comma.
 #
 # Example:
 #
-# disabled_modules: >-
+# ipa_disabled_modules: >-
 #   dnsconfig,
 #   group,
 #   hostgroup
 #
+# If no variables are set, set "empty: true" as at least
+# one item is needed in the set.
 ---
 variables:
   # ipa_enabled_modules: >-

--- a/tests/azure/templates/variables_fedora-rawhide.yaml
+++ b/tests/azure/templates/variables_fedora-rawhide.yaml
@@ -5,11 +5,13 @@
 #
 # Example:
 #
-# disabled_modules: >-
+# ipa_disabled_modules: >-
 #   dnsconfig,
 #   group,
 #   hostgroup
 #
+# If no variables are set, set "empty: true" as at least
+# one item is needed in the set.
 ---
 variables:
   empty: true

--- a/tests/azure/templates/variables_fedora-rawhide.yaml
+++ b/tests/azure/templates/variables_fedora-rawhide.yaml
@@ -17,7 +17,5 @@ variables:
   empty: true
   # ipa_enabled_modules: >-
   # ipa_enabled_tests: >-
-  ipa_disabled_modules: >-
-    dnsforwardzone,
-  ipa_disabled_tests: >-
-    test_dnsconfig_forwarders_ports
+  # ipa_disabled_modules: >-
+  # ipa_disabled_tests: >-


### PR DESCRIPTION
This PR re-enables upstream CI tests that include DNS forwarders with port specification.