### PR TITLE
ipasmartcard_client_get_vars: Fix for ansible-test fake execution test

### DIFF
--- a/roles/ipasmartcard_client/library/ipasmartcard_client_get_vars.py
+++ b/roles/ipasmartcard_client/library/ipasmartcard_client_get_vars.py
@@ -64,7 +64,13 @@ python_interpreter:
 
 import sys
 from ansible.module_utils.basic import AnsibleModule
-from ipaplatform.paths import paths
+try:
+    from ipaplatform.paths import paths
+except ImportError as _err:
+    MODULE_IMPORT_ERROR = str(_err)
+    paths = None
+else:
+    MODULE_IMPORT_ERROR = None
 
 
 def main():
@@ -72,6 +78,9 @@ def main():
         argument_spec={},
         supports_check_mode=False,
     )
+
+    if MODULE_IMPORT_ERROR is not None:
+        ansible_module.fail_json(msg=MODULE_IMPORT_ERROR)
 
     ansible_module.exit_json(changed=False,
                              NSS_DB_DIR=paths.NSS_DB_DIR,


### PR DESCRIPTION
All imports that are only available after installing IPA need to be in a try exception clause to be able to pass the fake execution test.

If the imports can not be done, all used and needed attributes are defined with the value None, MODULE_IMPORT_ERROR is set to the import error and fail_json is called.