### PR TITLE
sudorule: Add support for 'hostmask' parameter

### DIFF
--- a/README-sudorule.md
+++ b/README-sudorule.md
@@ -129,6 +129,7 @@ Variable | Description | Required
 `nomembers` | Suppress processing of membership attributes. (bool) | no
 `host` | List of host name strings assigned to this sudorule. | no
 `hostgroup` | List of host group name strings assigned to this sudorule. | no
+`hostmask` | List of host masks of allowed hosts | no
 `user` | List of user name strings assigned to this sudorule. | no
 `group` | List of user group name strings assigned to this sudorule. | no
 `allow_sudocmd` | List of sudocmd name strings assigned to the allow group of this sudorule. | no

--- a/playbooks/sudorule/ensure-sudorule-hostmask-member-is-absent.yml
+++ b/playbooks/sudorule/ensure-sudorule-hostmask-member-is-absent.yml
@@ -1,0 +1,14 @@
+---
+- name: Playbook to manage sudorule
+  hosts: ipaserver
+  become: no
+  gather_facts: no
+
+  tasks:
+  - name: Ensure hostmask network is absent in sudorule
+    ipasudorule:
+      ipaadmin_password: SomeADMINpassword
+      name: testrule1
+      hostmask: 192.168.122.37/24
+      action: member
+      state: absent

--- a/playbooks/sudorule/ensure-sudorule-hostmask-member-is-present.yml
+++ b/playbooks/sudorule/ensure-sudorule-hostmask-member-is-present.yml
@@ -1,0 +1,13 @@
+---
+- name: Playbook to manage sudorule
+  hosts: ipaserver
+  become: no
+  gather_facts: no
+
+  tasks:
+  - name: Ensure hostmask network is present in sudorule
+    ipasudorule:
+      ipaadmin_password: SomeADMINpassword
+      name: testrule1
+      hostmask: 192.168.122.37/24
+      action: member

--- a/tests/sudorule/test_sudorule.yml
+++ b/tests/sudorule/test_sudorule.yml
@@ -83,6 +83,7 @@
       ipaapi_context: "{{ ipa_context | default(omit) }}"
       name:
       - test_upstream_issue_664
+      - testrule_hostmask
       - testrule1
       - allusers
       - allhosts
@@ -1005,6 +1006,116 @@
     register: result
     failed_when: not result.changed or result.failed
 
+  - name: Ensure sudorule is present with hostmask
+    ipasudorule:
+      ipaadmin_password: SomeADMINpassword
+      name: testrule_hostmask
+      hostmask:
+      - 192.168.122.1/24
+      - 192.168.120.1/24
+    register: result
+    failed_when: not result.changed or result.failed
+
+  - name: Ensure sudorule is present with hostmask, again
+    ipasudorule:
+      ipaadmin_password: SomeADMINpassword
+      name: testrule_hostmask
+      hostmask:
+      - 192.168.122.1/24
+      - 192.168.120.1/24
+    register: result
+    failed_when: result.changed or result.failed
+
+  - name: Ensure sudorule hostmask member is absent
+    ipasudorule:
+      ipaadmin_password: SomeADMINpassword
+      name: testrule_hostmask
+      hostmask: 192.168.122.0/24
+      action: member
+      state: absent
+    register: result
+    failed_when: not result.changed or result.failed
+
+  - name: Ensure sudorule hostmask member is absent, again
+    ipasudorule:
+      ipaadmin_password: SomeADMINpassword
+      name: testrule_hostmask
+      hostmask: 192.168.122.0/24
+      action: member
+      state: absent
+    register: result
+    failed_when: result.changed or result.failed
+
+  - name: Ensure sudorule is present with another hostmask
+    ipasudorule:
+      ipaadmin_password: SomeADMINpassword
+      name: testrule_hostmask
+      hostmask: 192.168.122.0/24
+    register: result
+    failed_when: not result.changed or result.failed
+
+  - name: Ensure sudorule is present with another hostmask, again
+    ipasudorule:
+      ipaadmin_password: SomeADMINpassword
+      ipaapi_context: "{{ ipa_context | default(omit) }}"
+      name: testrule_hostmask
+      hostmask: 192.168.122.0/24
+    register: result
+    failed_when: result.changed
+
+  - name: Check sudorule with hostmask is absent
+    ipasudorule:
+      ipaadmin_password: SomeADMINpassword
+      ipaapi_context: "{{ ipa_context | default(omit) }}"
+      name: testrule_hostmask
+      hostmask: 192.168.120.0/24
+      action: member
+    register: result
+    check_mode: yes
+    failed_when: not result.changed or result.failed
+
+  - name: Ensure sudorule hostmask member is present
+    ipasudorule:
+      ipaadmin_password: SomeADMINpassword
+      ipaapi_context: "{{ ipa_context | default(omit) }}"
+      name: testrule_hostmask
+      hostmask: 192.168.120.0/24
+      action: member
+    register: result
+    failed_when: not result.changed or result.failed
+
+  - name: Ensure sudorule hostmask member is present, again
+    ipasudorule:
+      ipaadmin_password: SomeADMINpassword
+      ipaapi_context: "{{ ipa_context | default(omit) }}"
+      name: testrule_hostmask
+      hostmask: 192.168.120.0/24
+      action: member
+    register: result
+    failed_when: result.changed or result.failed
+
+  - name: Ensure sudorule hostmask member is absent
+    ipasudorule:
+      ipaadmin_password: SomeADMINpassword
+      ipaapi_context: "{{ ipa_context | default(omit) }}"
+      name: testrule_hostmask
+      hostmask: 192.168.120.0/24
+      action: member
+      state: absent
+    register: result
+    failed_when: not result.changed or result.failed
+
+  - name: Ensure sudorule hostmask member is absent, again
+    ipasudorule:
+      ipaadmin_password: SomeADMINpassword
+      ipaapi_context: "{{ ipa_context | default(omit) }}"
+      name: testrule_hostmask
+      hostmask: 192.168.120.0/24
+      action: member
+      state: absent
+    register: result
+    failed_when: result.changed or result.failed
+
   # cleanup
   - name: Ensure sudocmdgroup is absent
     ipasudocmdgroup:
@@ -1013,6 +1124,7 @@
       name:
       - test_sudorule
       - test_sudorule2
+      - testrule_hostmask
       state: absent
 
   - name: Ensure sudocmds are absent


### PR DESCRIPTION
The hostmask parameter allows matching a sudorule against a network address, and was missing from ipasudorule module.

Documentation and tests were updated to reflect changes.

Two new example playbooks are available:

    playbooks/sudorule/ensure-sudorule-hostmask-member-is-absent.yml
    playbooks/sudorule/ensure-sudorule-hostmask-member-is-present.yml

Fixes #676