### PR TITLE
ipadelegation: : Fix documentation sections and agument spec

### DIFF
--- a/plugins/modules/ipadelegation.py
+++ b/plugins/modules/ipadelegation.py
@@ -3,7 +3,7 @@
 # Authors:
 #   Thomas Woerner <twoerner@redhat.com>
 #
-# Copyright (C) 2020 Red Hat
+# Copyright (C) 2020-2022 Red Hat
 # see file 'COPYING' for use and warranty information
 #
 # This program is free software; you can redistribute it and/or modify
@@ -39,33 +39,45 @@ extends_documentation_fragment:
 options:
   name:
     description: The list of delegation name strings.
+    type: list
+    elements: str
     required: true
     aliases: ["aciname"]
   permission:
     description: Permissions to grant (read, write). Default is write.
+    type: list
+    elements: str
     required: false
     aliases: ["permissions"]
   attribute:
     description: Attribute list to which the delegation applies
+    type: list
+    elements: str
     required: false
     aliases: ["attrs"]
   membergroup:
     description: User group to apply delegation to
+    type: str
     required: false
     aliases: ["memberof"]
   group:
     description: User group ACI grants access to
+    type: str
     required: false
   action:
     description: Work on delegation or member level.
+    type: str
     choices: ["delegation", "member"]
     default: delegation
     required: false
   state:
     description: The state to ensure.
+    type: str
     choices: ["present", "absent"]
     default: present
-    required: true
+    required: false
+author:
+  - Thomas Woerner (@t-woerner)
 """
 
 EXAMPLES = """
@@ -143,13 +155,13 @@ def main():
     ansible_module = IPAAnsibleModule(
         argument_spec=dict(
             # general
-            name=dict(type="list", aliases=["aciname"], default=None,
+            name=dict(type="list", elements="str", aliases=["aciname"],
                       required=True),
             # present
-            permission=dict(required=False, type='list',
+            permission=dict(required=False, type='list', elements="str",
                             aliases=["permissions"], default=None),
-            attribute=dict(required=False, type='list', aliases=["attrs"],
-                           default=None),
+            attribute=dict(required=False, type='list', elements="str",
+                           aliases=["attrs"], default=None),
             membergroup=dict(type="str", aliases=["memberof"], default=None),
             group=dict(type="str", default=None),
             action=dict(type="str", default="delegation",


### PR DESCRIPTION
ansible-test with ansible-2.14 is adding a lot of new tests to ensure that the documentation section and the agument spec is complete. Needed changes:

DOCUMENTATION section

- `type: str` needs to be set for string parameters
- `type: list` needs to be set for list parameters
- `elements: str` needs to be given for list of string parameters
- `required` tags need to be fixed according to the `argument_spec`
- `authors` needs to be given with the github user also: `Name (@user)`

argument_spec

- `elements="str"` needs to be added to all list of string parameters

The `copyright` date is extended with `-2022`.