### PR TITLE
ipadnsconfig: Fix documentation sections and agument spec

### DIFF
--- a/plugins/modules/ipadnsconfig.py
+++ b/plugins/modules/ipadnsconfig.py
@@ -2,8 +2,9 @@
 
 # Authors:
 #   Rafael Guterres Jeffman <rjeffman@redhat.com>
+#   Thomas Woerner <twoerner@redhat.com>
 #
-# Copyright (C) 2019 Red Hat
+# Copyright (C) 2019-2022 Red Hat
 # see file 'COPYING' for use and warranty information
 #
 # This program is free software; you can redistribute it and/or modify
@@ -41,20 +42,25 @@ options:
   forwarders:
     description: The list of global DNS forwarders.
     required: false
-    options:
+    type: list
+    elements: dict
+    suboptions:
       ip_address:
         description: The forwarder nameserver IP address list (IPv4 and IPv6).
+        type: str
         required: true
       port:
         description: The port to forward requests to.
+        type: int
         required: false
   forward_policy:
     description:
       Global forwarding policy. Set to "none" to disable any configured
       global forwarders.
+    type: str
     required: false
     choices: ['only', 'first', 'none']
-    alias: ["forwardpolicy"]
+    aliases: ["forwardpolicy"]
   allow_sync_ptr:
     description:
       Allow synchronization of forward (A, AAAA) and reverse (PTR) records.
@@ -64,14 +70,19 @@ options:
     description: |
       Work on dnsconfig or member level. It can be one of `member` or
       `dnsconfig`. Only `forwarders` can be managed with `action: member`.
+    type: str
     default: "dnsconfig"
     choices: ["member", "dnsconfig"]
   state:
     description: |
       The state to ensure. It can be one of `present` or `absent`.
       `absent` can only be used with `action: member` and `forwarders`.
+    type: str
     default: present
     choices: ["present", "absent"]
+author:
+  - Rafael Guterres Jeffman (@rjeffman)
+  - Thomas Woerner (@t-woerner)
 """
 
 EXAMPLES = """
@@ -183,14 +194,15 @@ def gen_args(module, state, action, dnsconfig, forwarders, forward_policy,
 
 def main():
     forwarder_spec = dict(
-        ip_address=dict(type=str, required=True),
-        port=dict(type=int, required=False, default=None)
+        ip_address=dict(type="str", required=True),
+        port=dict(type="int", required=False, default=None)
     )
 
     ansible_module = IPAAnsibleModule(
         argument_spec=dict(
             # dnsconfig
-            forwarders=dict(type='list', default=None, required=False,
+            forwarders=dict(type='list', elements="dict", default=None,
+                            required=False,
                             options=dict(**forwarder_spec)),
             forward_policy=dict(type='str', required=False, default=None,
                                 choices=['only', 'first', 'none'],


### PR DESCRIPTION
ansible-test with ansible-2.14 is adding a lot of new tests to ensure that the documentation section and the agument spec is complete. Needed changes:

DOCUMENTATION section

- `type: str` needs to be set for string parameters
- `type: int` needs to be set for integer parameters
- `type: list` needs to be set for list parameters
- `elements: str` needs to be given for list of string parameters
- `aliases` tag need to be consistent to `argument_spec`
- `authors` needs to be given with the github user also: `Name (@user)`

argument_spec

- `elements="str"` needs to be added to all list of string parameters
- `type=str` and `type=int` need to be replaced by `type="str"` and `type="int"`

The `copyright` date is extended with `-2022`.