### PR TITLE
ipaselfservice: Fix documentation sections and agument spec

### DIFF
--- a/plugins/modules/ipaselfservice.py
+++ b/plugins/modules/ipaselfservice.py
@@ -3,7 +3,7 @@
 # Authors:
 #   Thomas Woerner <twoerner@redhat.com>
 #
-# Copyright (C) 2020 Red Hat
+# Copyright (C) 2020-2022 Red Hat
 # see file 'COPYING' for use and warranty information
 #
 # This program is free software; you can redistribute it and/or modify
@@ -39,26 +39,36 @@ extends_documentation_fragment:
 options:
   name:
     description: The list of selfservice name strings.
+    type: list
+    elements: str
     required: true
     aliases: ["aciname"]
   permission:
     description: Permissions to grant (read, write). Default is write.
+    type: list
+    elements: str
     required: false
     aliases: ["permissions"]
   attribute:
     description: Attribute list to which the selfservice applies
+    type: list
+    elements: str
     required: false
     aliases: ["attrs"]
   action:
     description: Work on selfservice or member level.
+    type: str
     choices: ["selfservice", "member"]
     default: selfservice
     required: false
   state:
     description: The state to ensure.
+    type: str
     choices: ["present", "absent"]
     default: present
-    required: true
+    required: false
+author:
+  - Thomas Woerner (@t-woerner)
 """
 
 EXAMPLES = """
@@ -130,13 +140,13 @@ def main():
     ansible_module = IPAAnsibleModule(
         argument_spec=dict(
             # general
-            name=dict(type="list", aliases=["aciname"], default=None,
+            name=dict(type="list", elements="str", aliases=["aciname"],
                       required=True),
             # present
-            permission=dict(required=False, type='list',
+            permission=dict(required=False, type='list', elements="str",
                             aliases=["permissions"], default=None),
-            attribute=dict(required=False, type='list', aliases=["attrs"],
-                           default=None),
+            attribute=dict(required=False, type='list', elements="str",
+                           aliases=["attrs"], default=None),
             action=dict(type="str", default="selfservice",
                         choices=["member", "selfservice"]),
             # state


### PR DESCRIPTION
ansible-test with ansible-2.14 is adding a lot of new tests to ensure that the documentation section and the agument spec is complete. Needed changes:

DOCUMENTATION section

- `type: str` needs to be set for string parameters
- `type: list` needs to be set for list parameters
- `elements: str` needs to be given for list of string parameters
- `required` tags need to be fixed according to the `argument_spec`
- `author` needs to be given with the github user also: `Name (@user)`

argument_spec

- `elements="str"` needs to be added to all list of string parameters

The `copyright` date is extended with `-2022`.