### PR TITLE
ipaservicedelegationtarget: Fix documentation sections and agument spec

### DIFF
--- a/plugins/modules/ipaservicedelegationtarget.py
+++ b/plugins/modules/ipaservicedelegationtarget.py
@@ -40,6 +40,8 @@ extends_documentation_fragment:
 options:
   name:
     description: The list of servicedelegationtarget name strings.
+    type: list
+    elements: str
     required: true
     aliases: ["cn"]
   principal:
@@ -49,17 +51,23 @@ options:
       host/fqdn@REALM, alias$, alias$@REALM, where fqdn and fqdn@REALM
       are host principals and the same as host/fqdn and host/fqdn@REALM.
       Host princpals are only usable with IPA versions 4.9.0 and up.
+    type: list
+    elements: str
     required: false
   action:
     description: Work on servicedelegationtarget or member level.
+    type: str
     choices: ["servicedelegationtarget", "member"]
     default: servicedelegationtarget
     required: false
   state:
     description: The state to ensure.
+    type: str
     choices: ["present", "absent"]
     default: present
-    required: true
+    required: false
+author:
+  - Thomas Woerner (@t-woerner)
 """
 
 EXAMPLES = """
@@ -121,10 +129,11 @@ def main():
     ansible_module = IPAAnsibleModule(
         argument_spec=dict(
             # general
-            name=dict(type="list", aliases=["cn"], default=None,
+            name=dict(type="list", elements="str", aliases=["cn"],
                       required=True),
             # present
-            principal=dict(required=False, type='list', default=None),
+            principal=dict(required=False, type='list', elements="str",
+                           default=None),
 
             action=dict(type="str", default="servicedelegationtarget",
                         choices=["member", "servicedelegationtarget"]),


### PR DESCRIPTION
ansible-test with ansible-2.14 is adding a lot of new tests to ensure that the documentation section and the agument spec is complete. Needed changes:

DOCUMENTATION section

- `type: str` needs to be set for string parameters
- `type: list` needs to be set for list parameters
- `elements: str` needs to be given for list of string parameters
- `required` tags need to be fixed according to the `argument_spec`
- `author` needs to be given with the github user also: `Name (@user)`

argument_spec

- `elements="str"` needs to be added to all list of string parameters

The `copyright` date is extended with `-2022`.