### PR TITLE
documentation: Change occurences of whitelist to allowlist.

### DIFF
--- a/plugins/modules/ipahost.py
+++ b/plugins/modules/ipahost.py
@@ -143,10 +143,11 @@ options:
         required: false
       auth_ind:
         description:
-          Defines a whitelist for Authentication Indicators. Use 'otp' to allow
-          OTP-based 2FA authentications. Use 'radius' to allow RADIUS-based 2FA
-          authentications. Other values may be used for custom configurations.
-          Use empty string to reset auth_ind to the initial value.
+          Defines an allow list for Authentication Indicators. Use 'otp'
+          to allow OTP-based 2FA authentications. Use 'radius' to allow
+          RADIUS-based 2FA authentications. Other values may be used
+          for custom configurations. Use empty string to reset auth_ind
+          to the initial value.
         type: list
         aliases: ["krbprincipalauthind"]
         choices: ["radius", "otp", "pkinit", "hardened", ""]
@@ -279,10 +280,11 @@ options:
     required: false
   auth_ind:
     description:
-      Defines a whitelist for Authentication Indicators. Use 'otp' to allow
-      OTP-based 2FA authentications. Use 'radius' to allow RADIUS-based 2FA
-      authentications. Other values may be used for custom configurations.
-      Use empty string to reset auth_ind to the initial value.
+      Defines an allow list for Authentication Indicators. Use 'otp'
+      to allow OTP-based 2FA authentications. Use 'radius' to allow
+      RADIUS-based 2FA authentications. Other values may be used
+      for custom configurations. Use empty string to reset auth_ind
+      to the initial value.
     type: list
     aliases: ["krbprincipalauthind"]
     choices: ["radius", "otp", "pkinit", "hardened", ""]

--- a/plugins/modules/ipaservice.py
+++ b/plugins/modules/ipaservice.py
@@ -59,7 +59,7 @@ options:
     elements: str
     aliases: ["pac_type", "ipakrbauthzdata"]
   auth_ind:
-    description: Defines a whitelist for Authentication Indicators.
+    description: Defines an allow list for Authentication Indicators.
     type: list
     elements: str
     required: false


### PR DESCRIPTION
This change follows language use recomendation from NISTIR 8366, "Guidance for NIST Staff on Using Inclusive Language in Documentary Standards", accessible from

    https://nvlpubs.nist.gov/nistpubs/ir/2021/NIST.IR.8366.pdf