### PR TITLE
new_module: Modify new_module and templates for Ansible 2.14

### DIFF
--- a/utils/new_module
+++ b/utils/new_module
@@ -26,7 +26,7 @@ topdir="$(dirname "$0")"
 
 function usage() {
     cat <<EOF
-Usage: $prog [options] <module name> <author name> <author email address>
+Usage: $prog [options] <module name> <author name> <author email address> <github_user>
 
 Create new ansible-freeipa module using templates.
 
@@ -71,12 +71,14 @@ fi
 name=$1
 author=$2
 email=$3
+github_user=$4
 year=$(date +"%Y")
 
-if [ -z "$name" ] || [ -z "$author" ] || [ -z "$email" ]; then
+if [ -z "$name" ] || [ -z "$author" ] || [ -z "$email" ] || [ -z "$github_user" ]; then
     [ -z "$name" ] && echo "ERROR: name is not valid"
     [ -z "$author" ] && echo "ERROR: author is not valid"
     [ -z "$email" ] && echo "ERROR: email is not valid"
+    [ -z "$githubuser" ] && echo "ERROR: github_user is not valid"
     echo
     usage;
     exit 1;
@@ -143,6 +145,7 @@ function template() {
         -e "s/\${name^}/${name^}/g" \
         -e "s/\$author/$author/g" \
         -e "s/\$email/$email/" \
+        -e "s/\$github/$github_user/" \
         -e "s/\$year/$year/" \
         "$topdir/templates/$s" > "$d"
 }

--- a/utils/templates/README-module+member.md.in
+++ b/utils/templates/README-module+member.md.in
@@ -119,8 +119,8 @@ Variable | Description | Required
 `ipaapi_context` | The context in which the module will execute. Executing in a server context is preferred. If not provided context will be determined by the execution environment. Valid values are `server` and `client`. | no
 `ipaapi_ldap_cache` | Use LDAP cache for IPA connection. The bool setting defaults to yes. (bool) | no
 `name` \| `ALIAS` | The list of $name name strings. | yes
-`PARAMETER1` \| `API_PARAMETER_NAME` | DESCRIPTION | BOOL
-`PARAMETER2` \| `API_PARAMETER_NAME` | DESCRIPTION | BOOL
+`PARAMETER1` \| `API_PARAMETER_NAME` | DESCRIPTION | TYPE
+`PARAMETER2` \| `API_PARAMETER_NAME` | DESCRIPTION | TYPE
 `action` | Work on $name or member level. It can be on of `member` or `$name` and defaults to `$name`. | no
 `state` | The state to ensure. It can be one of `present`, `absent`, default: `present`. | no
 

--- a/utils/templates/README-module.md.in
+++ b/utils/templates/README-module.md.in
@@ -84,8 +84,8 @@ Variable | Description | Required
 `ipaapi_context` | The context in which the module will execute. Executing in a server context is preferred. If not provided context will be determined by the execution environment. Valid values are `server` and `client`. | no
 `ipaapi_ldap_cache` | Use LDAP cache for IPA connection. The bool setting defaults to yes. (bool) | no
 `name` \| `ALIAS` | The list of $name name strings. | yes
-`PARAMETER1` \| `API_PARAMETER_NAME` | DESCRIPTION | BOOL
-`PARAMETER2` \| `API_PARAMETER_NAME` | DESCRIPTION | BOOL
+`PARAMETER1` \| `API_PARAMETER_NAME` | DESCRIPTION | TYPE
+`PARAMETER2` \| `API_PARAMETER_NAME` | DESCRIPTION | TYPE
 `state` | The state to ensure. It can be one of `present`, `absent`, default: `present`. | no
 
 

--- a/utils/templates/ipamodule+member.py.in
+++ b/utils/templates/ipamodule+member.py.in
@@ -41,25 +41,35 @@ options:
   name:
     description: The list of $name name strings.
     required: true
+    type: list
+    elements: str
     aliases: ["API_PARAMETER_NAME"]
   PARAMETER1:
     description: DESCRIPTION
-    required: REQUIRED
+    required: false
+    default: None
+    type: TYPE
     aliases: ["API_PARAMETER_NAME"]
   PARAMETER2:
     description: member DESCRIPTION
-    required: REQUIRED
+    required: false
+    type: list
+    elements: str
+    default: None
+    type: TYPE
     aliases: ["API_PARAMETER_NAME"]
   action:
     description: Work on $name or member level.
     choices: ["$name", "member"]
     default: $name
-    required: false
+    type: str
   state:
     description: The state to ensure.
     choices: ["present", "absent"]
     default: present
-    required: true
+    type: str
+author:
+  - $author (@$github)
 """
 
 EXAMPLES = """
@@ -139,17 +149,18 @@ def main():
     ansible_module = IPAAnsibleModule(
         argument_spec=dict(
             # general
-            name=dict(type="list", aliases=["API_PARAMETER_NAME"],
-                      default=None, required=True),
+            name=dict(type="list", elements="str", required=True
+                      aliases=["API_PARAMETER_NAME"]),
             # present
-            PARAMETER1=dict(required=False, type='str',
-                            aliases=["API_PARAMETER_NAME"], default=None),
-            PARAMETER2=dict(required=False, type='list',
-                            aliases=["API_PARAMETER_NAME"], default=None),
-            action=dict(type="str", default="$name",
+            PARAMETER1=dict(required=False, type="str",
+                            default=None, aliases=["API_PARAMETER_NAME"]),
+            PARAMETER2=dict(required=False, type='list', elements='str',
+                            default=None, aliases=["API_PARAMETER_NAME"]),
+            # action
+            action=dict(type="str", default="$name", type="str",
                         choices=["member", "$name"]),
             # state
-            state=dict(type="str", default="present",
+            state=dict(type="str", default="present", type="str",
                        choices=["present", "absent"]),
         ),
         supports_check_mode=True,

--- a/utils/templates/ipamodule.py.in
+++ b/utils/templates/ipamodule.py.in
@@ -41,20 +41,27 @@ options:
   name:
     description: The list of $name name strings.
     required: true
+    type: list
+    elements: str
     aliases: ["API_PARAMETER_NAME"]
   PARAMETER1:
     description: DESCRIPTION
     required: REQUIRED
+    type: str
     aliases: ["API_PARAMETER_NAME"]
   PARAMETER2:
     description: DESCRIPTION
     required: REQUIRED
+    type: list
+    elements: str
     aliases: ["API_PARAMETER_NAME"]
   state:
     description: The state to ensure.
     choices: ["present", "absent"]
     default: present
-    required: true
+    type: str
+author:
+  - $author (@$github)
 """
 
 EXAMPLES = """
@@ -113,15 +120,15 @@ def main():
     ansible_module = IPAAnsibleModule(
         argument_spec=dict(
             # general
-            name=dict(type="list", aliases=["API_PARAMETER_NAME"],
-                      default=None, required=True),
+            name=dict(type="list", elements="str", required=True,
+                      aliases=["API_PARAMETER_NAME"],
             # present
             PARAMETER1=dict(required=False, type='str',
                             aliases=["API_PARAMETER_NAME"], default=None),
-            PARAMETER2=dict(required=False, type='list',
+            PARAMETER2=dict(required=False, type='list', elements='str',
                             aliases=["API_PARAMETER_NAME"], default=None),
             # state
-            state=dict(type="str", default="present",
+            state=dict(type="str", default="present", type="str",
                        choices=["present", "absent"]),
         ),
         supports_check_mode=True,


### PR DESCRIPTION
ansible-test with ansible-2.14 is adding a lot of new tests to ensure that the documentation section and the agument spec is complete.

To aid the creation of new_modules that follow these rules, the 'new_module' script and its templates were modified to use the new ansible-test rules. The 'new_module' script now requires a new argument, github_user, and the code templates provide the required fields (like 'type' and 'elements') to the provide examples.