### PR TITLE
ipaconfig: Do not require enable_sid for add_sids or netbios_name

### DIFF
--- a/README-config.md
+++ b/README-config.md
@@ -149,8 +149,8 @@ Variable | Description | Required
 `domain_resolution_order` \| `ipadomainresolutionorder` | Set list of domains used for short name qualification | no
 `ca_renewal_master_server` \| `ipacarenewalmasterserver`| Renewal master for IPA certificate authority. | no
 `enable_sid` | New users and groups automatically get a SID assigned. Cannot be deactivated once activated. Requires IPA 4.9.8+. (bool) | no
-`netbios_name` | NetBIOS name of the IPA domain. Requires IPA 4.9.8+ and 'enable_sid: yes'. | no
-`add_sids` | Add SIDs for existing users and groups. Requires IPA 4.9.8+ and 'enable_sid: yes'. (bool) | no
+`netbios_name` | NetBIOS name of the IPA domain. Requires IPA 4.9.8+ and SID generation to be activated. | no
+`add_sids` | Add SIDs for existing users and groups. Requires IPA 4.9.8+ and SID generation to be activated. (bool) | no
 
 
 Return Values

--- a/tests/config/test_config_sid.yml
+++ b/tests/config/test_config_sid.yml
@@ -19,6 +19,32 @@
 
   # TESTS
   - block:
+    - name: Check if SID is enabled.
+      ipaconfig:
+        ipaadmin_password: SomeADMINpassword
+        ipaapi_context: "{{ ipa_context | default(omit) }}"
+        enable_sid: yes
+      check_mode: yes
+      register: sid_disabled
+
+    - name: Ensure netbios_name can't be changed without SID enabled.
+      ipaconfig:
+        ipaadmin_password: SomeADMINpassword
+        ipaapi_context: "{{ ipa_context | default(omit) }}"
+        netbios_name: IPATESTPLAY
+      register: result
+      failed_when: not result.failed and "SID generation must be enabled" in result.msg
+      when: sid_disabled.changed
+
+    - name: Ensure SIDs can't be changed without SID enabled.
+      ipaconfig:
+        ipaadmin_password: SomeADMINpassword
+        ipaapi_context: "{{ ipa_context | default(omit) }}"
+        add_sids: yes
+      register: result
+      failed_when: not result.failed and "SID generation must be enabled" in result.msg
+      when: sid_disabled.changed
+
     - name: Ensure SID is enabled.
       ipaconfig:
         ipaadmin_password: SomeADMINpassword
@@ -56,10 +82,29 @@
       ipaconfig:
         ipaadmin_password: SomeADMINpassword
         ipaapi_context: "{{ ipa_context | default(omit) }}"
-        enable_sid: yes
         netbios_name: IPATESTPLAY
       register: result
       failed_when: result.failed or result.changed
+
+    - name: Ensure netbios_name cannot be set with lowercase characters
+      ipaconfig:
+        ipaadmin_password: SomeADMINpassword
+        ipaapi_context: "{{ ipa_context | default(omit) }}"
+        netbios_name: IPATESTplay
+      register: result
+      failed_when:
+        (not result.failed
+         and "Up to 15 characters and only uppercase ASCII letters, digits and dashes are allowed" not in result.message)
+
+    - name: Ensure netbios_name cannot be set different lowercase characters
+      ipaconfig:
+        ipaadmin_password: SomeADMINpassword
+        ipaapi_context: "{{ ipa_context | default(omit) }}"
+        netbios_name: otherPLAY
+      register: result
+      failed_when:
+        (not result.failed
+         and "Up to 15 characters and only uppercase ASCII letters, digits and dashes are allowed" not in result.message)
 
     # add_sids is not idempotent as it always tries to generate the missing
     # SIDs for users and groups.
@@ -67,7 +112,6 @@
       ipaconfig:
         ipaadmin_password: SomeADMINpassword
         ipaapi_context: "{{ ipa_context | default(omit) }}"
-        enable_sid: yes
         add_sids: yes
 
     # only run tests if version supports enable-sid


### PR DESCRIPTION
Current behavior of ipaconfig mimics FreeIPA CLI and requires that
'enable_sid' is set to True every time add_sids or netbios_name are
used. It is sufficient that SID generation is enabled to use add_sids
and netbios_name, but the IPA API requires 'enable_sid' so that the
operations are executed.

This patch allows ansible-freeipa plugin ipaconfig to run 'add_sids' or
set 'netbios_name without requiring 'enable_sid' to be set on the
playbook.

If SID generation is enabled, 'add_sids' and 'netbios_name' can be used
without 'enable_sid: yes'. If SID generation is not enabled, an error
message will be raised if 'enable_sid: yes' is not used.

Depends on PR #921 being merged (due to commit 3c7bd565ecfbca802110f85ef8ae679c053d8bdb).

Fixes [RHBZ#2134505](https://bugzilla.redhat.com/show_bug.cgi?id=2134505), [RHBZ#2134530](https://bugzilla.redhat.com/show_bug.cgi?id=2134530)