### PR TITLE
ipamodule_base_docs: Fix documentation sections

### DIFF
--- a/plugins/doc_fragments/ipamodule_base_docs.py
+++ b/plugins/doc_fragments/ipamodule_base_docs.py
@@ -30,15 +30,18 @@ options:
   ipaadmin_principal:
     description: The admin principal.
     default: admin
+    type: str
   ipaadmin_password:
     description: The admin password.
     required: false
+    type: str
   ipaapi_context:
     description: |
       The context in which the module will execute. Executing in a
       server context is preferred. If not provided context will be
       determined by the execution environment.
     choices: ["server", "client"]
+    type: str
     required: false
   ipaapi_ldap_cache:
     description: Use LDAP cache for IPA connection.


### PR DESCRIPTION
ansible-test with ansible-2.14 is adding a lot of new tests to ensure that the documentation section and the agument spec is complete. Needed changes:

DOCUMENTATION section

- `type: str` needs to be set for string parameters