### PR TITLE
ipabackup_get_backup_dir: Fix documentation sections and agument spec

### DIFF
--- a/roles/ipabackup/library/ipabackup_get_backup_dir.py
+++ b/roles/ipabackup/library/ipabackup_get_backup_dir.py
@@ -3,7 +3,7 @@
 # Authors:
 #   Thomas Woerner <twoerner@redhat.com>
 #
-# Copyright (C) 2021  Red Hat
+# Copyright (C) 2021-2022  Red Hat
 # see file 'COPYING' for use and warranty information
 #
 # This program is free software; you can redistribute it and/or modify
@@ -36,9 +36,8 @@ short_description:
   Get IPA_BACKUP_DIR from ipaplatform
 description:
   Get IPA_BACKUP_DIR from ipaplatform
-options:
 author:
-    - Thomas Woerner
+    - Thomas Woerner (@t-woerner)
 '''
 
 EXAMPLES = '''


### PR DESCRIPTION
ansible-test with ansible-2.14 is adding a lot of new tests to ensure that the documentation section and the agument spec is complete. Needed changes:

DOCUMENTATION section

- `suboptions` needs to be removed without arguments
- `author` needs to be given with the github user also: `Name (@user)`

The `copyright` date is extended with `-2022`.