### PR TITLE
Fix ipasmartcard client role for ansible test

### DIFF
--- a/roles/ipasmartcard_client/library/ipasmartcard_client_get_vars.py
+++ b/roles/ipasmartcard_client/library/ipasmartcard_client_get_vars.py
@@ -36,9 +36,8 @@ short_description:
   Get variables from ipaplatform and python interpreter used for the module.
 description:
   Get variables from ipaplatform and python interpreter used for the module.
-options:
 author:
-    - Thomas Woerner
+    - Thomas Woerner (@t-woerner)
 '''
 
 EXAMPLES = '''

--- a/roles/ipasmartcard_client/library/ipasmartcard_client_validate_ca_certs.py
+++ b/roles/ipasmartcard_client/library/ipasmartcard_client_validate_ca_certs.py
@@ -33,7 +33,7 @@ ANSIBLE_METADATA = {
 
 DOCUMENTATION = '''
 ---
-module: ipasmartcard_server_validate_ca_certs
+module: ipasmartcard_client_validate_ca_certs
 short_description: Validate CA certs
 description: Validate CA certs
 options:
@@ -41,9 +41,11 @@ options:
     description:
       List of files containing CA certificates for the service certificate
       files
-    required: yes
+    type: list
+    elements: str
+    required: no
 author:
-    - Thomas Woerner
+    - Thomas Woerner (@t-woerner)
 '''
 
 EXAMPLES = '''
@@ -63,7 +65,8 @@ except ImportError:
 def main():
     ansible_module = AnsibleModule(
         argument_spec=dict(
-            ca_cert_files=dict(required=False, type='list', default=[]),
+            ca_cert_files=dict(required=False, type='list', elements='str',
+                               default=[]),
         ),
         supports_check_mode=False,
     )


### PR DESCRIPTION
 **ipasmartcard_client_get_vars: Fix doc sections and agument spec**

ansible-test with ansible-2.14 is adding a lot of new tests to ensure
that the documentation section and the agument spec is complete. Needed
changes:

DOCUMENTATION section

- `suboptions` needs to be removed without arguments
- `author` needs to be given with the github user also: `Name (@user)`

 **ipasmartcard_client_validate_ca_certs: Fix doc sections and agument spec**

ansible-test with ansible-2.14 is adding a lot of new tests to ensure
that the documentation section and the agument spec is complete. Needed
changes:

DOCUMENTATION section

- `module` needs to match module name
- `type: list` needs to be set for list parameters
- `required` tags need to be fixed according to the `argument_spec`

argument_spec

- `elements="str"` needs to be added to all list of string parameters