### PR TITLE
Fix ipasmartcard server role for ansible test

### DIFF
--- a/roles/ipasmartcard_server/library/ipasmartcard_server_get_vars.py
+++ b/roles/ipasmartcard_server/library/ipasmartcard_server_get_vars.py
@@ -36,9 +36,8 @@ short_description:
   Get variables from ipaplatform and ipaserver and python interpreter.
 description:
   Get variables from ipaplatform and ipaserver and python interpreter.
-options:
 author:
-    - Thomas Woerner
+    - Thomas Woerner (@t-woerner)
 '''
 
 EXAMPLES = '''

--- a/roles/ipasmartcard_server/library/ipasmartcard_server_validate_ca_certs.py
+++ b/roles/ipasmartcard_server/library/ipasmartcard_server_validate_ca_certs.py
@@ -41,9 +41,11 @@ options:
     description:
       List of files containing CA certificates for the service certificate
       files
-    required: yes
+    type: list
+    elements: str
+    required: no
 author:
-    - Thomas Woerner
+    - Thomas Woerner (@t-woerner)
 '''
 
 EXAMPLES = '''
@@ -63,7 +65,8 @@ except ImportError:
 def main():
     ansible_module = AnsibleModule(
         argument_spec=dict(
-            ca_cert_files=dict(required=False, type='list', default=[]),
+            ca_cert_files=dict(required=False, type='list', elements='str',
+                               default=[]),
         ),
         supports_check_mode=False,
     )


### PR DESCRIPTION
 **ipasmartcard_server_get_vars: Fix doc sections and agument spec**

ansible-test with ansible-2.14 is adding a lot of new tests to ensure
that the documentation section and the agument spec is complete. Needed
changes:

DOCUMENTATION section

- `suboptions` needs to be removed without arguments
- `author` needs to be given with the github user also: `Name (@user)`

 **ipasmartcard_server_validate_ca_certs: Fix doc sections and agument spec**

ansible-test with ansible-2.14 is adding a lot of new tests to ensure
that the documentation section and the agument spec is complete. Needed
changes:

DOCUMENTATION section

- `type: list` needs to be set for list parameters
- `elements: str` needs to be given for list of string parameters
- `required` tags need to be fixed according to the `argument_spec`
- `author` needs to be given with the github user also: `Name (@user)`

argument_spec

- `elements="str"` needs to be added to all list of string parameters