### PR TITLE
pwpolicy: Add support for password check and grace limit.

### DIFF
--- a/README-pwpolicy.md
+++ b/README-pwpolicy.md
@@ -87,6 +87,36 @@ Example playbook to ensure maxlife is set to 49 in global policy:
       maxlife: 49
 ```
 
+Example playbook to ensure password grace period is set to 3 in global policy:
+
+```yaml
+---
+- name: Playbook to handle pwpolicies
+  hosts: ipaserver
+  become: true
+
+  tasks:
+  # Ensure maxlife is set to 49 in global policy
+  - ipapwpolicy:
+      ipaadmin_password: SomeADMINpassword
+      gracelimit: 3
+```
+
+Example playbook to ensure password grace period is set to unlimited in global policy:
+
+```yaml
+---
+- name: Playbook to handle pwpolicies
+  hosts: ipaserver
+  become: true
+
+  tasks:
+  # Ensure maxlife is set to 49 in global policy
+  - ipapwpolicy:
+      ipaadmin_password: SomeADMINpassword
+      gracelimit: -1
+```
+
 
 Variables
 =========
@@ -107,6 +137,11 @@ Variable | Description | Required
 `maxfail` \| `krbpwdmaxfailure` | Consecutive failures before lockout. (int) | no
 `failinterval` \| `krbpwdfailurecountinterval` | Period after which failure count will be reset in seconds. (int) | no
 `lockouttime` \| `krbpwdlockoutduration` | Period for which lockout is enforced in seconds. (int) | no
+`maxrepeat` \| `ipapwdmaxrepeat` | Maximum number of same consecutive characters. Requires IPA 4.9+ (int) | no
+`maxsequence` \| `ipapwdmaxsequence` |  The maximum length of monotonic character sequences (abcd). Requires IPA 4.9+ (int) | no
+`dictcheck` \| `ipapwdictcheck` | Check if the password is a dictionary word. Requires IPA 4.9+ (int) | no
+`usercheck` \| `ipapwdusercheck` | Check if the password contains the username. Requires IPA 4.9+ (int) | no
+`gracelimit` \| `passwordgracelimit` |  Number of LDAP authentications allowed after expiration. Requires IPA 4.9.10 (int) | no
 `state` | The state to ensure. It can be one of `present` or `absent`, default: `present`. | yes
 
 

--- a/playbooks/pwpolicy/pwpolicy_grace_limit.yml
+++ b/playbooks/pwpolicy/pwpolicy_grace_limit.yml
@@ -1,0 +1,11 @@
+---
+- name: Playbook to manage password policy
+  hosts: ipaserver
+  become: no
+  gather_facts: no
+
+  tasks:
+  - name: Set password policy grace limit.
+    ipapwpolicy:
+      ipaadmin_password: SomeADMINpassword
+      gracelimit: 3

--- a/playbooks/pwpolicy/pwpolicy_password_check.yml
+++ b/playbooks/pwpolicy/pwpolicy_password_check.yml
@@ -1,0 +1,14 @@
+---
+- name: Playbook to manage password policy
+  hosts: ipaserver
+  become: no
+  gather_facts: no
+
+  tasks:
+  - name: Set password checking parameters.
+    ipapwpolicy:
+      ipaadmin_password: SomeADMINpassword
+      maxrepeat: 2
+      maxsequence: 3
+      dictcheck: yes
+      usercheck: yes

--- a/tests/pwpolicy/test_pwpolicy.yml
+++ b/tests/pwpolicy/test_pwpolicy.yml
@@ -5,6 +5,9 @@
   gather_facts: false
 
   tasks:
+  - name: Setup FreeIPA test facts.
+    import_tasks: ../env_freeipa_facts.yml
+
   - name: Ensure maxlife of 90 for global_policy
     ipapwpolicy:
       ipaadmin_password: SomeADMINpassword
@@ -117,3 +120,145 @@
       state: absent
     register: result
     failed_when: result.changed or result.failed
+
+  - block:
+    - name: Ensure maxrepeat of 2 for global_policy
+      ipapwpolicy:
+        ipaadmin_password: SomeADMINpassword
+        ipaapi_context: "{{ ipa_context | default(omit) }}"
+        maxrepeat: 2
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: Ensure maxrepeat of 2 for global_policy, again
+      ipapwpolicy:
+        ipaadmin_password: SomeADMINpassword
+        ipaapi_context: "{{ ipa_context | default(omit) }}"
+        maxrepeat: 2
+      register: result
+      failed_when: result.changed or result.failed
+
+    - name: Ensure maxrepeat of 0 for global_policy
+      ipapwpolicy:
+        ipaadmin_password: SomeADMINpassword
+        ipaapi_context: "{{ ipa_context | default(omit) }}"
+        maxrepeat: 0
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: Ensure maxsequence of 4 for global_policy
+      ipapwpolicy:
+        ipaadmin_password: SomeADMINpassword
+        ipaapi_context: "{{ ipa_context | default(omit) }}"
+        maxrepeat: 4
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: Ensure maxsequence of 4 for global_policy, again
+      ipapwpolicy:
+        ipaadmin_password: SomeADMINpassword
+        ipaapi_context: "{{ ipa_context | default(omit) }}"
+        maxrepeat: 4
+      register: result
+      failed_when: result.changed or result.failed
+
+    - name: Ensure maxsequence of 0 for global_policy
+      ipapwpolicy:
+        ipaadmin_password: SomeADMINpassword
+        ipaapi_context: "{{ ipa_context | default(omit) }}"
+        maxrepeat: 0
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: Ensure dictcheck is set for global_policy
+      ipapwpolicy:
+        ipaadmin_password: SomeADMINpassword
+        ipaapi_context: "{{ ipa_context | default(omit) }}"
+        dictcheck: yes
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: Ensure dictcheck is set for global_policy, again
+      ipapwpolicy:
+        ipaadmin_password: SomeADMINpassword
+        ipaapi_context: "{{ ipa_context | default(omit) }}"
+        dictcheck: yes
+      register: result
+      failed_when: result.changed or result.failed
+
+    - name: Ensure dictcheck is not set for global_policy
+      ipapwpolicy:
+        ipaadmin_password: SomeADMINpassword
+        ipaapi_context: "{{ ipa_context | default(omit) }}"
+        dictcheck: no
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: Ensure usercheck is set for global_policy
+      ipapwpolicy:
+        ipaadmin_password: SomeADMINpassword
+        ipaapi_context: "{{ ipa_context | default(omit) }}"
+        usercheck: yes
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: Ensure usercheck is set for global_policy, again
+      ipapwpolicy:
+        ipaadmin_password: SomeADMINpassword
+        ipaapi_context: "{{ ipa_context | default(omit) }}"
+        usercheck: yes
+      register: result
+      failed_when: result.changed or result.failed
+
+    - name: Ensure usercheck is not set for global_policy
+      ipapwpolicy:
+        ipaadmin_password: SomeADMINpassword
+        ipaapi_context: "{{ ipa_context | default(omit) }}"
+        usercheck: no
+      register: result
+      failed_when: not result.changed or result.failed
+
+    when: ipa_version is version("4.9", ">=")
+
+  - block:
+    - name: Ensure grace limit is set to 10 for global_policy
+      ipapwpolicy:
+        ipaadmin_password: SomeADMINpassword
+        ipaapi_context: "{{ ipa_context | default(omit) }}"
+        gracelimit: 10
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: Ensure grace limit is set to 0 for global_policy
+      ipapwpolicy:
+        ipaadmin_password: SomeADMINpassword
+        ipaapi_context: "{{ ipa_context | default(omit) }}"
+        gracelimit: 0
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: Ensure grace limit is set to 0 for global_policy
+      ipapwpolicy:
+        ipaadmin_password: SomeADMINpassword
+        ipaapi_context: "{{ ipa_context | default(omit) }}"
+        gracelimit: 0
+      register: result
+      failed_when: result.changed or result.failed
+
+    - name: Ensure grace limit is set to 0 for global_policy
+      ipapwpolicy:
+        ipaadmin_password: SomeADMINpassword
+        ipaapi_context: "{{ ipa_context | default(omit) }}"
+        gracelimit: -1
+      register: result
+      failed_when: not result.changed or result.failed
+
+    - name: Ensure grace limit is not set to -2 for global_policy
+      ipapwpolicy:
+        ipaadmin_password: SomeADMINpassword
+        ipaapi_context: "{{ ipa_context | default(omit) }}"
+        gracelimit: -2
+      register: result
+      failed_when: not result.failed and "must be at least -1" not in result.msg
+
+    when: ipa_version is version("4.9.10", ">=")


### PR DESCRIPTION
On recent version of FreeIPA options to verify passwords and for controlling a password grace period have been added to IPA API.

This patch adds support for the parameters maxrepeat, maxsequence, dictcheck and usercheck, available since FreeIPA, 4.9 and gracelimit, available since FreeIPA 4.9.10.

Test playbooks for the module have been updated with the new supported parameters.

New example playbooks can be found at:

    playbooks/pwpolicy/pwpolicy_grace_limit.yml
    playbooks/pwpolicy/pwpolicy_password_check.yml