### PR TITLE
Fix ipaclient role for ansible test

### DIFF
--- a/roles/ipaclient/library/ipaclient_api.py
+++ b/roles/ipaclient/library/ipaclient_api.py
@@ -5,7 +5,7 @@
 #
 # Based on ipa-client-install code
 #
-# Copyright (C) 2017  Red Hat
+# Copyright (C) 2017-2022  Red Hat
 # see file 'COPYING' for use and warranty information
 #
 # This program is free software; you can redistribute it and/or modify
@@ -39,18 +39,24 @@ description:
 options:
   servers:
     description: Fully qualified name of IPA servers to enroll to
-    required: no
+    type: list
+    elements: str
+    required: yes
   realm:
     description: Kerberos realm name of the IPA deployment
-    required: no
+    type: str
+    required: yes
   hostname:
     description: Fully qualified name of this host
-    required: no
+    type: str
+    required: yes
   debug:
     description: Turn on extra debugging
-    required: yes
+    type: bool
+    required: no
+    default: no
 author:
-    - Thomas Woerner
+    - Thomas Woerner (@t-woerner)
 '''
 
 EXAMPLES = '''
@@ -70,7 +76,7 @@ ca_enabled:
 subject_base:
   description: The subject base, needed for certmonger
   returned: always
-  type: string
+  type: str
   sample: O=EXAMPLE.COM
 '''
 
@@ -78,7 +84,7 @@ import os
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.ansible_ipa_client import (
-    setup_logging,
+    setup_logging, check_imports,
     paths, x509, NUM_VERSION, serialization, certdb, api,
     delete_persistent_client_session_data, write_tmp_file,
     ipa_generate_password, CalledProcessError, errors, disable_ra, DN,
@@ -89,15 +95,16 @@ from ansible.module_utils.ansible_ipa_client import (
 def main():
     module = AnsibleModule(
         argument_spec=dict(
-            servers=dict(required=True, type='list'),
-            realm=dict(required=True),
-            hostname=dict(required=True),
+            servers=dict(required=True, type='list', elements='str'),
+            realm=dict(required=True, type='str'),
+            hostname=dict(required=True, type='str'),
             debug=dict(required=False, type='bool', default="false"),
         ),
-        supports_check_mode=True,
+        supports_check_mode=False,
     )
 
     module._ansible_debug = True
+    check_imports(module)
     setup_logging()
 
     realm = module.params.get('realm')

--- a/roles/ipaclient/library/ipaclient_fix_ca.py
+++ b/roles/ipaclient/library/ipaclient_fix_ca.py
@@ -5,7 +5,7 @@
 #
 # Based on ipa-client-install code
 #
-# Copyright (C) 2017  Red Hat
+# Copyright (C) 2017-2022  Red Hat
 # see file 'COPYING' for use and warranty information
 #
 # This program is free software; you can redistribute it and/or modify
@@ -33,24 +33,29 @@ DOCUMENTATION = '''
 ---
 module: ipaclient_fix_ca
 short_description: Fix IPA ca certificate
-description: Repair Fix IPA ca certificate
+description: Fix IPA ca certificate
 options:
   servers:
     description: Fully qualified name of IPA servers to enroll to
-    required: no
+    type: list
+    elements: str
+    required: yes
   realm:
     description: Kerberos realm name of the IPA deployment
-    required: no
+    type: str
+    required: yes
   basedn:
     description: The basedn of the IPA server (of the form dc=example,dc=com)
-    required: no
+    type: str
+    required: yes
   allow_repair:
     description: |
       Allow repair of already joined hosts. Contrary to ipaclient_force_join
       the host entry will not be changed on the server
-    required: no
+    type: bool
+    required: yes
 author:
-    - Thomas Woerner
+    - Thomas Woerner (@t-woerner)
 '''
 
 EXAMPLES = '''
@@ -69,7 +74,7 @@ import os
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.ansible_ipa_client import (
-    setup_logging,
+    setup_logging, check_imports,
     SECURE_PATH, paths, sysrestore, options, NUM_VERSION, get_ca_cert,
     get_ca_certs, errors
 )
@@ -78,14 +83,15 @@ from ansible.module_utils.ansible_ipa_client import (
 def main():
     module = AnsibleModule(
         argument_spec=dict(
-            servers=dict(required=True, type='list'),
-            realm=dict(required=True),
-            basedn=dict(required=True),
+            servers=dict(required=True, type='list', elements='str'),
+            realm=dict(required=True, type='str'),
+            basedn=dict(required=True, type='str'),
             allow_repair=dict(required=True, type='bool'),
         ),
     )
 
     module._ansible_debug = True
+    check_imports(module)
     setup_logging()
 
     servers = module.params.get('servers')

--- a/roles/ipaclient/library/ipaclient_fstore.py
+++ b/roles/ipaclient/library/ipaclient_fstore.py
@@ -5,7 +5,7 @@
 #
 # Based on ipa-client-install code
 #
-# Copyright (C) 2017  Red Hat
+# Copyright (C) 2017-2022  Red Hat
 # see file 'COPYING' for use and warranty information
 #
 # This program is free software; you can redistribute it and/or modify
@@ -39,9 +39,10 @@ description: Backup files using IPA client sysrestore
 options:
   backup:
     description: File to backup
-    required: no
+    type: str
+    required: yes
 author:
-    - Thomas Woerner
+    - Thomas Woerner (@t-woerner)
 '''
 
 EXAMPLES = '''
@@ -55,18 +56,19 @@ RETURN = '''
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.ansible_ipa_client import (
-    setup_logging, paths, sysrestore
+    setup_logging, check_imports, paths, sysrestore
 )
 
 
 def main():
     module = AnsibleModule(
         argument_spec=dict(
-            backup=dict(required=True),
+            backup=dict(required=True, type='str'),
         ),
     )
 
     module._ansible_debug = True
+    check_imports(module)
     setup_logging()
 
     backup = module.params.get('backup')

--- a/roles/ipaclient/library/ipaclient_get_facts.py
+++ b/roles/ipaclient/library/ipaclient_get_facts.py
@@ -1,5 +1,26 @@
 # -*- coding: utf-8 -*-
 
+# Authors:
+#   Thomas Woerner <twoerner@redhat.com>
+#
+# Based on ipa-client-install code
+#
+# Copyright (C) 2018-2022  Red Hat
+# see file 'COPYING' for use and warranty information
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 from __future__ import (absolute_import, division, print_function)
 
 __metaclass__ = type
@@ -10,7 +31,60 @@ module: ipaclient_get_facts
 short_description: Get facts about IPA client and server configuration.
 description: Get facts about IPA client and server configuration.
 author:
-    - Thomas Woerner
+    - Thomas Woerner (@t-woerner)
+"""
+
+EXAMPLES = """
+"""
+
+RETURN = """
+ipa:
+  description: IPA configuration
+  returned: always
+  type: complex
+  contains:
+    packages:
+      description: IPA lib and server bindings
+      type: dict
+      returned: always
+      contains:
+        ipalib:
+          description: Whether ipalib.api binding could be imported.
+          type: bool
+          returned: always
+        ipaserver:
+          description: Whether ipaserver binding could be imported.
+          type: bool
+          returned: always
+    configured:
+      description: IPA components
+      type: dict
+      returned: always
+      contains:
+        client:
+          description: Whether client is configured
+          type: bool
+          returned: always
+        server:
+          description: Whether server is configured
+          type: bool
+          returned: always
+        dns:
+          description: Whether dns is configured
+          type: bool
+          returned: always
+        ca:
+          description: Whether ca is configured
+          type: bool
+          returned: always
+        kra:
+          description: Whether kra is configured
+          type: bool
+          returned: always
+        ntpd:
+          description: Whether ntpd is configured
+          type: bool
+          returned: always
 """
 
 import os

--- a/roles/ipaclient/library/ipaclient_ipa_conf.py
+++ b/roles/ipaclient/library/ipaclient_ipa_conf.py
@@ -5,7 +5,7 @@
 #
 # Based on ipa-client-install code
 #
-# Copyright (C) 2018  Red Hat
+# Copyright (C) 2018-2022  Red Hat
 # see file 'COPYING' for use and warranty information
 #
 # This program is free software; you can redistribute it and/or modify
@@ -40,21 +40,27 @@ description:
 options:
   domain:
     description: Primary DNS domain of the IPA deployment
-    required: no
+    type: str
+    required: yes
   servers:
     description: Fully qualified name of IPA servers to enroll to
-    required: no
+    type: list
+    elements: str
+    required: yes
   realm:
     description: Kerberos realm name of the IPA deployment
-    required: no
+    type: str
+    required: yes
   hostname:
     description: Fully qualified name of this host
-    required: no
+    type: str
+    required: yes
   basedn:
     description: The basedn of the IPA server (of the form dc=example,dc=com)
-    required: no
+    type: str
+    required: yes
 author:
-    - Thomas Woerner
+    - Thomas Woerner (@t-woerner)
 '''
 
 EXAMPLES = '''
@@ -73,23 +79,24 @@ RETURN = '''
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.ansible_ipa_client import (
-    setup_logging, paths, sysrestore, configure_ipa_conf
+    setup_logging, check_imports, paths, sysrestore, configure_ipa_conf
 )
 
 
 def main():
     module = AnsibleModule(
         argument_spec=dict(
-            domain=dict(required=True, default=None),
-            servers=dict(required=True, type='list', default=None),
-            realm=dict(required=True, default=None),
-            hostname=dict(required=True, default=None),
-            basedn=dict(required=True),
+            domain=dict(required=True, type='str'),
+            servers=dict(required=True, type='list', elements='str'),
+            realm=dict(required=True, type='str'),
+            hostname=dict(required=True, type='str'),
+            basedn=dict(required=True, type='str'),
         ),
-        supports_check_mode=True,
+        supports_check_mode=False,
     )
 
     module._ansible_debug = True
+    check_imports(module)
     setup_logging()
 
     servers = module.params.get('servers')

--- a/roles/ipaclient/library/ipaclient_join.py
+++ b/roles/ipaclient/library/ipaclient_join.py
@@ -5,7 +5,7 @@
 #
 # Based on ipa-client-install code
 #
-# Copyright (C) 2017  Red Hat
+# Copyright (C) 2017-2022  Red Hat
 # see file 'COPYING' for use and warranty information
 #
 # This program is free software; you can redistribute it and/or modify
@@ -43,51 +43,67 @@ description:
 options:
   servers:
     description: Fully qualified name of IPA servers to enroll to
-    required: no
+    type: list
+    elements: str
+    required: yes
   domain:
     description: Primary DNS domain of the IPA deployment
-    required: no
+    type: str
+    required: yes
   realm:
     description: Kerberos realm name of the IPA deployment
-    required: no
+    type: str
+    required: yes
   hostname:
     description: Fully qualified name of this host
-    required: no
+    type: str
+    required: yes
   kdc:
     description: The name or address of the host running the KDC
-    required: no
+    type: str
+    required: yes
   basedn:
     description: The basedn of the IPA server (of the form dc=example,dc=com)
-    required: no
+    type: str
+    required: yes
   principal:
     description:
       User Principal allowed to promote replicas and join IPA realm
-    required: yes
+    type: str
+    required: no
   password:
     description: Admin user kerberos password
-    required: yes
+    type: str
+    required: no
   keytab:
     description: Path to backed up keytab from previous enrollment
-    required: yes
+    type: str
+    required: no
   admin_keytab:
     description: The path to a local admin keytab
-    required: yes
+    type: str
+    required: no
   ca_cert_file:
     description:
       A CA certificate to use. Do not acquire the IPA CA certificate via
       automated means
-    required: yes
+    type: str
+    required: no
   force_join:
     description: Force client enrollment even if already enrolled
-    required: yes
+    type: bool
+    required: no
   kinit_attempts:
     description: Repeat the request for host Kerberos ticket X times
-    required: yes
+    type: int
+    required: no
+    default: 5
   debug:
     description: Turn on extra debugging
-    required: yes
+    type: bool
+    required: no
 author:
-    - Thomas Woerner
+    - Thomas Woerner (@t-woerner)
 '''
 
 EXAMPLES = '''
@@ -130,7 +146,7 @@ import tempfile
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.ansible_ipa_client import (
-    setup_logging,
+    setup_logging, check_imports,
     SECURE_PATH, sysrestore, paths, options, configure_krb5_conf,
     realm_to_suffix, kinit_keytab, GSSError, kinit_password, NUM_VERSION,
     get_ca_cert, get_ca_certs, errors, run
@@ -140,25 +156,26 @@ from ansible.module_utils.ansible_ipa_client import (
 def main():
     module = AnsibleModule(
         argument_spec=dict(
-            servers=dict(required=True, type='list'),
-            domain=dict(required=True),
-            realm=dict(required=True),
-            hostname=dict(required=True),
-            kdc=dict(required=True),
-            basedn=dict(required=True),
-            principal=dict(required=False),
-            password=dict(required=False, no_log=True),
-            keytab=dict(required=False),
-            admin_keytab=dict(required=False),
-            ca_cert_file=dict(required=False),
+            servers=dict(required=True, type='list', elements='str'),
+            domain=dict(required=True, type='str'),
+            realm=dict(required=True, type='str'),
+            hostname=dict(required=True, type='str'),
+            kdc=dict(required=True, type='str'),
+            basedn=dict(required=True, type='str'),
+            principal=dict(required=False, type='str'),
+            password=dict(required=False, type='str', no_log=True),
+            keytab=dict(required=False, type='str', no_log=False),
+            admin_keytab=dict(required=False, type='str', no_log=False),
+            ca_cert_file=dict(required=False, type='str'),
             force_join=dict(required=False, type='bool'),
             kinit_attempts=dict(required=False, type='int', default=5),
             debug=dict(required=False, type='bool'),
         ),
-        supports_check_mode=True,
+        supports_check_mode=False,
     )
 
     module._ansible_debug = True
+    check_imports(module)
     setup_logging()
 
     servers = module.params.get('servers')

--- a/roles/ipaclient/library/ipaclient_set_hostname.py
+++ b/roles/ipaclient/library/ipaclient_set_hostname.py
@@ -5,7 +5,7 @@
 #
 # Based on ipa-client-install code
 #
-# Copyright (C) 2018  Red Hat
+# Copyright (C) 2018-2022  Red Hat
 # see file 'COPYING' for use and warranty information
 #
 # This program is free software; you can redistribute it and/or modify
@@ -40,9 +40,10 @@ description:
 options:
   hostname:
     description: Fully qualified name of this host
-    required: no
+    type: str
+    required: yes
 author:
-    - Thomas Woerner
+    - Thomas Woerner (@t-woerner)
 '''
 
 EXAMPLES = '''
@@ -57,19 +58,20 @@ RETURN = '''
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.ansible_ipa_client import (
-    setup_logging, sysrestore, paths, tasks
+    setup_logging, check_imports, sysrestore, paths, tasks
 )
 
 
 def main():
     module = AnsibleModule(
         argument_spec=dict(
-            hostname=dict(required=True),
+            hostname=dict(required=True, type='str'),
         ),
-        supports_check_mode=True,
+        supports_check_mode=False,
     )
 
     module._ansible_debug = True
+    check_imports(module)
     setup_logging()
 
     hostname = module.params.get('hostname')

--- a/roles/ipaclient/library/ipaclient_setup_automount.py
+++ b/roles/ipaclient/library/ipaclient_setup_automount.py
@@ -5,7 +5,7 @@
 #
 # Based on ipa-client-install code
 #
-# Copyright (C) 2017  Red Hat
+# Copyright (C) 2017-2022  Red Hat
 # see file 'COPYING' for use and warranty information
 #
 # This program is free software; you can redistribute it and/or modify
@@ -40,15 +40,20 @@ description:
 options:
   servers:
     description: Fully qualified name of IPA servers to enroll to
-    required: no
+    type: list
+    elements: str
+    required: yes
   sssd:
     description: The installer sssd setting
-    required: yes
+    type: bool
+    required: no
+    default: yes
   automount_location:
     description: The automount location
-    required: yes
+    type: str
+    required: no
 author:
-    - Thomas Woerner
+    - Thomas Woerner (@t-woerner)
 '''
 
 EXAMPLES = '''
@@ -63,23 +68,24 @@ RETURN = '''
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.ansible_ipa_client import (
-    setup_logging, options, configure_automount
+    setup_logging, check_imports, options, configure_automount
 )
 
 
 def main():
     module = AnsibleModule(
         argument_spec=dict(
-            servers=dict(required=True, type='list'),
+            servers=dict(required=True, type='list', elements='str'),
             sssd=dict(required=False, type='bool', default='yes'),
-            automount_location=dict(required=False, default=None),
+            automount_location=dict(required=False, type='str', default=None),
         ),
-        supports_check_mode=True,
+        supports_check_mode=False,
     )
 
     # os.environ['KRB5CCNAME'] = paths.IPA_DNS_CCACHE
 
     module._ansible_debug = True
+    check_imports(module)
     setup_logging()
 
     options.servers = module.params.get('servers')

--- a/roles/ipaclient/library/ipaclient_setup_firefox.py
+++ b/roles/ipaclient/library/ipaclient_setup_firefox.py
@@ -5,7 +5,7 @@
 #
 # Based on ipa-client-install code
 #
-# Copyright (C) 2017  Red Hat
+# Copyright (C) 2017-2022  Red Hat
 # see file 'COPYING' for use and warranty information
 #
 # This program is free software; you can redistribute it and/or modify
@@ -40,14 +40,16 @@ description:
 options:
   domain:
     description: Primary DNS domain of the IPA deployment
+    type: str
     required: yes
   firefox_dir:
     description:
       Specify directory where Firefox is installed (for example
       '/usr/lib/firefox')
+    type: str
     required: no
 author:
-    - Thomas Woerner
+    - Thomas Woerner (@t-woerner)
 '''
 
 EXAMPLES = '''
@@ -63,20 +65,21 @@ RETURN = '''
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.ansible_ipa_client import (
-    setup_logging, sysrestore, paths, options, configure_firefox
+    setup_logging, check_imports, sysrestore, paths, options, configure_firefox
 )
 
 
 def main():
     module = AnsibleModule(
         argument_spec=dict(
-            domain=dict(required=True),
-            firefox_dir=dict(required=False),
+            domain=dict(required=True, type='str'),
+            firefox_dir=dict(required=False, type='str'),
         ),
-        supports_check_mode=True,
+        supports_check_mode=False,
     )
 
     module._ansible_debug = True
+    check_imports(module)
     setup_logging()
 
     domain = module.params.get('domain')

--- a/roles/ipaclient/library/ipaclient_setup_krb5.py
+++ b/roles/ipaclient/library/ipaclient_setup_krb5.py
@@ -5,7 +5,7 @@
 #
 # Based on ipa-client-install code
 #
-# Copyright (C) 2018  Red Hat
+# Copyright (C) 2018-2022  Red Hat
 # see file 'COPYING' for use and warranty information
 #
 # This program is free software; you can redistribute it and/or modify
@@ -40,33 +40,46 @@ description:
 options:
   domain:
     description: Primary DNS domain of the IPA deployment
-    required: yes
+    type: str
+    required: no
   servers:
     description: Fully qualified name of IPA servers to enroll to
-    required: yes
+    type: list
+    elements: str
+    required: no
   realm:
     description: Kerberos realm name of the IPA deployment
-    required: yes
+    type: str
+    required: no
   hostname:
     description: Fully qualified name of this host
-    required: yes
+    type: str
+    required: no
   kdc:
     description: The name or address of the host running the KDC
-    required: yes
+    type: str
+    required: no
   dnsok:
     description: The installer dnsok setting
-    required: yes
+    type: bool
+    required: no
+    default: no
   client_domain:
     description: Primary DNS domain of the IPA deployment
-    required: yes
+    type: str
+    required: no
   sssd:
     description: The installer sssd setting
-    required: yes
+    type: bool
+    required: no
+    default: no
   force:
     description: Installer force parameter
-    required: yes
+    type: bool
+    required: no
+    default: no
 author:
-    - Thomas Woerner
+    - Thomas Woerner (@t-woerner)
 '''
 
 EXAMPLES = '''
@@ -84,28 +97,31 @@ RETURN = '''
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.ansible_ipa_client import (
-    setup_logging, sysrestore, paths, configure_krb5_conf, logger
+    setup_logging, check_imports, sysrestore, paths, configure_krb5_conf,
+    logger
 )
 
 
 def main():
     module = AnsibleModule(
         argument_spec=dict(
-            domain=dict(required=False, default=None),
-            servers=dict(required=False, type='list', default=None),
-            realm=dict(required=False, default=None),
-            hostname=dict(required=False, default=None),
-            kdc=dict(required=False, default=None),
+            domain=dict(required=False, type='str', default=None),
+            servers=dict(required=False, type='list', elements='str',
+                         default=None),
+            realm=dict(required=False, type='str', default=None),
+            hostname=dict(required=False, type='str', default=None),
+            kdc=dict(required=False, type='str', default=None),
             dnsok=dict(required=False, type='bool', default=False),
-            client_domain=dict(required=False, default=None),
+            client_domain=dict(required=False, type='str', default=None),
             sssd=dict(required=False, type='bool', default=False),
             force=dict(required=False, type='bool', default=False),
             # on_master=dict(required=False, type='bool', default=False),
         ),
-        supports_check_mode=True,
+        supports_check_mode=False,
     )
 
     module._ansible_debug = True
+    check_imports(module)
     setup_logging()
 
     servers = module.params.get('servers')

--- a/roles/ipaclient/library/ipaclient_setup_nis.py
+++ b/roles/ipaclient/library/ipaclient_setup_nis.py
@@ -5,7 +5,7 @@
 #
 # Based on ipa-client-install code
 #
-# Copyright (C) 2017  Red Hat
+# Copyright (C) 2017-2022  Red Hat
 # see file 'COPYING' for use and warranty information
 #
 # This program is free software; you can redistribute it and/or modify
@@ -40,12 +40,14 @@ description:
 options:
   domain:
     description: Primary DNS domain of the IPA deployment
-    required: no
+    type: str
+    required: yes
   nisdomain:
     description: The NIS domain name
-    required: yes
+    type: str
+    required: no
 author:
-    - Thomas Woerner
+    - Thomas Woerner (@t-woerner)
 '''
 
 EXAMPLES = '''
@@ -59,21 +61,22 @@ RETURN = '''
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.ansible_ipa_client import (
-    setup_logging, options, sysrestore, paths, configure_nisdomain,
-    getargspec
+    setup_logging, check_imports, options, sysrestore, paths,
+    configure_nisdomain, getargspec
 )
 
 
 def main():
     module = AnsibleModule(
         argument_spec=dict(
-            domain=dict(required=True),
-            nisdomain=dict(required=False),
+            domain=dict(required=True, type='str'),
+            nisdomain=dict(required=False, type='str'),
         ),
-        supports_check_mode=True,
+        supports_check_mode=False,
     )
 
     module._ansible_debug = True
+    check_imports(module)
     setup_logging()
 
     domain = module.params.get('domain')

--- a/roles/ipaclient/library/ipaclient_setup_ntp.py
+++ b/roles/ipaclient/library/ipaclient_setup_ntp.py
@@ -5,7 +5,7 @@
 #
 # Based on ipa-client-install code
 #
-# Copyright (C) 2017  Red Hat
+# Copyright (C) 2017-2022  Red Hat
 # see file 'COPYING' for use and warranty information
 #
 # This program is free software; you can redistribute it and/or modify
@@ -40,24 +40,34 @@ description:
 options:
   ntp_servers:
     description: ntp servers to use
-    required: yes
+    type: list
+    elements: str
+    required: no
   ntp_pool:
     description: ntp server pool to use
-    required: yes
+    type: str
+    required: no
   no_ntp:
     description: Do not configure ntp
-    required: yes
+    type: bool
+    required: no
+    default: no
   on_master:
     description: Whether the configuration is done on the master or not
-    required: yes
+    type: bool
+    required: no
+    default: no
   servers:
     description: Fully qualified name of IPA servers to enroll to
-    required: yes
+    type: list
+    elements: str
+    required: no
   domain:
     description: Primary DNS domain of the IPA deployment
-    required: yes
+    type: str
+    required: no
 author:
-    - Thomas Woerner
+    - Thomas Woerner (@t-woerner)
 '''
 
 EXAMPLES = '''
@@ -68,7 +78,7 @@ RETURN = '''
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.ansible_ipa_client import (
-    setup_logging,
+    setup_logging, check_imports,
     options, sysrestore, paths, sync_time, logger, ipadiscovery,
     timeconf, getargspec
 )
@@ -78,19 +88,22 @@ def main():
     module = AnsibleModule(
         argument_spec=dict(
             # basic
-            ntp_servers=dict(required=False, type='list', default=None),
-            ntp_pool=dict(required=False, default=None),
+            ntp_servers=dict(required=False, type='list', elements='str',
+                             default=None),
+            ntp_pool=dict(required=False, type='str', default=None),
             no_ntp=dict(required=False, type='bool', default=False),
             # force_ntpd=dict(required=False, type='bool', default=False),
             on_master=dict(required=False, type='bool', default=False),
             # additional
-            servers=dict(required=False, type='list', default=None),
-            domain=dict(required=False, default=None),
+            servers=dict(required=False, type='list', elements='str',
+                         default=None),
+            domain=dict(required=False, type='str', default=None),
         ),
-        supports_check_mode=True,
+        supports_check_mode=False,
     )
 
     # module._ansible_debug = True
+    check_imports(module)
     setup_logging()
 
     options.ntp_servers = module.params.get('ntp_servers')

--- a/roles/ipaclient/library/ipaclient_setup_ssh.py
+++ b/roles/ipaclient/library/ipaclient_setup_ssh.py
@@ -5,7 +5,7 @@
 #
 # Based on ipa-client-install code
 #
-# Copyright (C) 2017  Red Hat
+# Copyright (C) 2017-2022  Red Hat
 # see file 'COPYING' for use and warranty information
 #
 # This program is free software; you can redistribute it and/or modify
@@ -40,21 +40,31 @@ description:
 options:
   servers:
     description: Fully qualified name of IPA servers to enroll to
-    required: no
+    type: list
+    elements: str
+    required: yes
   no_ssh:
     description: Do not configure OpenSSH client
-    required: yes
+    type: bool
+    required: no
+    default: no
   ssh_trust_dns:
     description: Configure OpenSSH client to trust DNS SSHFP records
-    required: yes
+    type: bool
+    required: no
+    default: no
   no_sshd:
     description: Do not configure OpenSSH server
-    required: yes
+    type: bool
+    required: no
+    default: no
   sssd:
     description: The installer sssd setting
-    required: yes
+    type: bool
+    required: no
+    default: no
 author:
-    - Thomas Woerner
+    - Thomas Woerner (@t-woerner)
 '''
 
 EXAMPLES = '''
@@ -71,7 +81,7 @@ RETURN = '''
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.ansible_ipa_client import (
-    setup_logging,
+    setup_logging, check_imports,
     options, sysrestore, paths, configure_ssh_config, configure_sshd_config
 )
 
@@ -79,16 +89,17 @@ from ansible.module_utils.ansible_ipa_client import (
 def main():
     module = AnsibleModule(
         argument_spec=dict(
-            servers=dict(required=True, type='list'),
+            servers=dict(required=True, type='list', elements='str'),
             no_ssh=dict(required=False, type='bool', default='no'),
             ssh_trust_dns=dict(required=False, type='bool', default='no'),
             no_sshd=dict(required=False, type='bool', default='no'),
             sssd=dict(required=False, type='bool', default='no'),
         ),
-        supports_check_mode=True,
+        supports_check_mode=False,
     )
 
     module._ansible_debug = True
+    check_imports(module)
     setup_logging()
 
     options.servers = module.params.get('servers')

--- a/roles/ipaclient/library/ipaclient_setup_sssd.py
+++ b/roles/ipaclient/library/ipaclient_setup_sssd.py
@@ -5,7 +5,7 @@
 #
 # Based on ipa-client-install code
 #
-# Copyright (C) 2017  Red Hat
+# Copyright (C) 2017-2022  Red Hat
 # see file 'COPYING' for use and warranty information
 #
 # This program is free software; you can redistribute it and/or modify
@@ -33,60 +33,75 @@ ANSIBLE_METADATA = {
 
 DOCUMENTATION = '''
 ---
-module: ipaclient_setup_ssd
+module: ipaclient_setup_sssd
 short_description: Setup sssd for IPA client
 description:
   Setup sssd for IPA client
 options:
   servers:
     description: Fully qualified name of IPA servers to enroll to
-    required: no
+    type: list
+    elements: str
+    required: yes
   domain:
     description: Primary DNS domain of the IPA deployment
-    required: no
+    type: str
+    required: yes
   realm:
     description: Kerberos realm name of the IPA deployment
-    required: no
+    type: str
+    required: yes
   hostname:
     description: Fully qualified name of this host
-    required: no
+    type: str
+    required: yes
   on_master:
     description: Whether the configuration is done on the master or not
-    required: yes
+    type: bool
+    required: no
   no_ssh:
     description: Do not configure OpenSSH client
-    required: yes
+    type: bool
+    required: no
   no_sshd:
     description: Do not configure OpenSSH server
-    required: yes
+    type: bool
+    required: no
   no_sudo:
     description: Do not configure SSSD as data source for sudo
-    required: yes
+    type: bool
+    required: no
   all_ip_addresses:
     description:
       All routable IP addresses configured on any interface will be added
       to DNS
-    required: yes
+    type: bool
+    required: no
   fixed_primary:
     description: Configure sssd to use fixed server as primary IPA server
-    required: yes
+    type: bool
+    required: no
   permit:
     description: Disable access rules by default, permit all access
-    required: yes
+    type: bool
+    required: no
   enable_dns_updates:
     description:
       Configures the machine to attempt dns updates when the ip address
       changes
-    required: yes
+    type: bool
+    required: no
   preserve_sssd:
     description: Preserve old SSSD configuration if possible
-    required: yes
+    type: bool
+    required: no
   no_krb5_offline_passwords:
     description:
       Configure SSSD not to store user password when the server is offline
-    required: yes
+    type: bool
+    required: no
 author:
-    - Thomas Woerner
+    - Thomas Woerner (@t-woerner)
 '''
 
 EXAMPLES = '''
@@ -104,17 +119,18 @@ RETURN = '''
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.ansible_ipa_client import (
-    setup_logging, options, sysrestore, paths, configure_sssd_conf, logger
+    setup_logging, check_imports, options, sysrestore, paths,
+    configure_sssd_conf, logger
 )
 
 
 def main():
     module = AnsibleModule(
         argument_spec=dict(
-            servers=dict(required=True, type='list'),
-            domain=dict(required=True),
-            realm=dict(required=True),
-            hostname=dict(required=True),
+            servers=dict(required=True, type='list', elements='str'),
+            domain=dict(required=True, type='str'),
+            realm=dict(required=True, type='str'),
+            hostname=dict(required=True, type='str'),
             on_master=dict(required=False, type='bool'),
             no_ssh=dict(required=False, type='bool'),
             no_sshd=dict(required=False, type='bool'),
@@ -127,12 +143,13 @@ def main():
             preserve_sssd=dict(required=False, type='bool'),
             no_krb5_offline_passwords=dict(required=False, type='bool'),
         ),
-        supports_check_mode=True,
+        supports_check_mode=False,
     )
     # ansible_log = AnsibleModuleLog(module, logger)
     # options.set_logger(ansible_log)
 
     module._ansible_debug = True
+    check_imports(module)
     setup_logging()
 
     cli_server = module.params.get('servers')

--- a/roles/ipaclient/library/ipaclient_test_keytab.py
+++ b/roles/ipaclient/library/ipaclient_test_keytab.py
@@ -5,7 +5,7 @@
 #
 # Based on ipa-client-install code
 #
-# Copyright (C) 2017  Red Hat
+# Copyright (C) 2017-2022  Red Hat
 # see file 'COPYING' for use and warranty information
 #
 # This program is free software; you can redistribute it and/or modify
@@ -42,24 +42,31 @@ description:
 options:
   servers:
     description: Fully qualified name of IPA servers to enroll to
-    required: no
+    type: list
+    elements: str
+    required: yes
   domain:
     description: Primary DNS domain of the IPA deployment
-    required: no
+    type: str
+    required: yes
   realm:
     description: Kerberos realm name of the IPA deployment
-    required: no
+    type: str
+    required: yes
   hostname:
     description: Fully qualified name of this host
-    required: no
+    type: str
+    required: yes
   kdc:
     description: The name or address of the host running the KDC
-    required: no
+    type: str
+    required: yes
   kinit_attempts:
     description: Repeat the request for host Kerberos ticket X times
-    required: yes
+    type: int
+    default: 5
 author:
-    - Thomas Woerner
+    - Thomas Woerner (@t-woerner)
 '''
 
 EXAMPLES = '''
@@ -91,6 +98,7 @@ krb5_keytab_ok:
 ca_crt_exists:
   description: The flag describes if ca.crt exists.
   returned: always
+  type: str
 krb5_conf_ok:
   description: The flag describes if krb5.conf on the host is usable.
   returned: always
@@ -106,7 +114,7 @@ import tempfile
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.ansible_ipa_client import (
-    setup_logging,
+    setup_logging, check_imports,
     SECURE_PATH, paths, kinit_keytab, run, GSSError, configure_krb5_conf
 )
 
@@ -114,17 +122,18 @@ from ansible.module_utils.ansible_ipa_client import (
 def main():
     module = AnsibleModule(
         argument_spec=dict(
-            servers=dict(required=True, type='list'),
-            domain=dict(required=True),
-            realm=dict(required=True),
-            hostname=dict(required=True),
-            kdc=dict(required=True),
+            servers=dict(required=True, type='list', elements='str'),
+            domain=dict(required=True, type='str'),
+            realm=dict(required=True, type='str'),
+            hostname=dict(required=True, type='str'),
+            kdc=dict(required=True, type='str'),
             kinit_attempts=dict(required=False, type='int', default=5),
         ),
-        supports_check_mode=True,
+        supports_check_mode=False,
     )
 
     module._ansible_debug = True
+    check_imports(module)
     setup_logging()
 
     servers = module.params.get('servers')


### PR DESCRIPTION
All imports that are only available after installing IPA need to be in a
try exception clause to be able to pass the fake execution test. The old
workaround "if 'ansible.executor' in sys.modules:" is not working with
this test anymore.

ansible-test with ansible-2.14 is adding a lot of new tests to ensure
that the documentation section and the agument spec is complete.

The module_utils file ansible_ipa_client and also all the modules in the
role had to be changed.