### PR TITLE
Add subid option to select the sssd profile with-subid.

### DIFF
--- a/roles/ipaclient/README.md
+++ b/roles/ipaclient/README.md
@@ -183,6 +183,7 @@ Variable | Description | Required
 `ipaclient_no_ssh` | The bool value defines if OpenSSH client will be configured. `ipaclient_no_ssh` defaults to `no`. | no
 `ipaclient_no_sshd` | The bool value defines if OpenSSH server will be configured. `ipaclient_no_sshd` defaults to `no`. | no
 `ipaclient_no_sudo` | The bool value defines if SSSD will be configured as a data source for sudo. `ipaclient_no_sudo` defaults to `no`. | no
+`ipaclient_subid` | The bool value defines if SSSD will be configured as a data source for subid. `ipaclient_subid` defaults to `no`. | no
 `ipaclient_no_dns_sshfp` | The bool value defines if DNS SSHFP records will not be created automatically. `ipaclient_no_dns_sshfp` defaults to `no`. | no
 `ipaclient_force` | The bool value defines if settings will be forced even in the error case. `ipaclient_force` defaults to `no`. | no
 `ipaclient_force_ntpd` | The bool value defines if ntpd usage will be forced. This is not supported anymore and leads to a warning. `ipaclient_force_ntpd` defaults to `no`. | no

--- a/roles/ipaclient/defaults/main.yml
+++ b/roles/ipaclient/defaults/main.yml
@@ -13,6 +13,7 @@ ipaclient_ssh_trust_dns: no
 ipaclient_no_ssh: no
 ipaclient_no_sshd: no
 ipaclient_no_sudo: no
+ipaclient_subid: no
 ipaclient_no_dns_sshfp: no
 ipaclient_force: no
 ipaclient_force_ntpd: no

--- a/roles/ipaclient/tasks/install.yml
+++ b/roles/ipaclient/tasks/install.yml
@@ -378,6 +378,7 @@
         no_ssh: "{{ ipaclient_no_ssh }}"
         no_sshd: "{{ ipaclient_no_sshd }}"
         no_sudo: "{{ ipaclient_no_sudo }}"
+        subid: "{{ ipaclient_subid }}"
         fixed_primary: "{{ ipassd_fixed_primary
                            | default(ipasssd_fixed_primary) }}"
         permit: "{{ ipassd_permit | default(ipasssd_permit) }}"

--- a/roles/ipareplica/README.md
+++ b/roles/ipareplica/README.md
@@ -200,6 +200,7 @@ Variable | Description | Required
 `ipaclient_no_ssh` | The bool value defines if OpenSSH client will be configured. (bool, default: false) | no
 `ipaclient_no_sshd` | The bool value defines if OpenSSH server will be configured. (bool, default: false) | no
 `ipaclient_no_sudo` | The bool value defines if SSSD will be configured as a data source for sudo. (bool, default: false) | no
+`ipaclient_subid` | The bool value defines if SSSD will be configured as a data source for subid. (bool, default: false) | no
 `ipaclient_no_dns_sshfp` | The bool value defines if DNS SSHFP records will not be created automatically. (bool, default: false) | no
 
 Certificate system Variables

--- a/roles/ipaserver/README.md
+++ b/roles/ipaserver/README.md
@@ -252,6 +252,7 @@ Variable | Description | Required
 `ipaclient_no_ssh` | The bool value defines if OpenSSH client will be configured. `ipaclient_no_ssh` defaults to `no`. | no
 `ipaclient_no_sshd` | The bool value defines if OpenSSH server will be configured. `ipaclient_no_sshd` defaults to `no`. | no
 `ipaclient_no_sudo` | The bool value defines if SSSD will be configured as a data source for sudo. `ipaclient_no_sudo` defaults to `no`. | no
+`ipaclient_subid` | The bool value defines if SSSD will be configured as a data source for subid. `ipaclient_subid` defaults to `no`. | no
 `ipaclient_no_dns_sshfp` | The bool value defines if DNS SSHFP records will not be created automatically. `ipaclient_no_dns_sshfp` defaults to `no`. | no
 
 Certificate system Variables


### PR DESCRIPTION
Create support for `subid` option for `ipaclient_setup_nss` role.
RFE #919

Signed-off-by: Denis Karpelevich <dkarpele@redhat.com>