### PR TITLE
linters: Fix versions of linter packages due to Python 3.11.

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -68,7 +68,7 @@ jobs:
           python-version: "3.x"
       - name: Run pylint
         run: |
-            pip install pylint==2.12.2
+            pip install pylint==2.13.7 wrapt==1.14.0
             pylint plugins roles --disable=import-error
 
   shellcheck:

--- a/plugins/module_utils/ansible_freeipa_module.py
+++ b/plugins/module_utils/ansible_freeipa_module.py
@@ -99,9 +99,10 @@ try:
 
     try:
         from ipalib.x509 import load_pem_x509_certificate
+        certificate_loader = load_pem_x509_certificate
     except ImportError:
         from ipalib.x509 import load_certificate
-        load_pem_x509_certificate = None
+        certificate_loader = load_certificate
 
     # Try to import is_ipa_configured or use a fallback implementation.
     try:
@@ -147,7 +148,6 @@ except ImportError as _err:
     uuid = None
     netaddr = None
     is_ipa_configured = None
-    load_certificate = None
     kerberos = None
     ipaserver = None  # pylint: disable=C0103
 else:
@@ -588,10 +588,7 @@ def load_cert_from_str(cert):
     if not cert.endswith("-----END CERTIFICATE-----"):
         cert += "\n-----END CERTIFICATE-----"
 
-    if load_pem_x509_certificate is not None:
-        cert = load_pem_x509_certificate(cert.encode('utf-8'))
-    else:
-        cert = load_certificate(cert.encode('utf-8'))
+    cert = certificate_loader(cert.encode('utf-8'))
     return cert
 
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,11 +2,9 @@
 ipdb==0.13.4
 pre-commit
 flake8==4.0.1
-flake8-bugbear
+flake8-bugbear==22.10.27
 pylint==2.13.7
+wrapt >= 1.14.0
 pydocstyle==6.0.0
 yamllint==1.26.3
 ansible-lint==5.3.2
-dnspython==2.2.0
-netaddr==0.8.0
-gssapi==1.7.2

--- a/roles/ipaserver/module_utils/ansible_ipa_server.py
+++ b/roles/ipaserver/module_utils/ansible_ipa_server.py
@@ -196,9 +196,10 @@ else:
 
         try:
             from ipalib.x509 import load_pem_x509_certificate
+            certificate_loader = load_pem_x509_certificate
         except ImportError:
             from ipalib.x509 import load_certificate
-            load_pem_x509_certificate = None
+            certificate_loader = load_certificate
 
         try:
             from ipaserver.install.server.install import get_min_idstart
@@ -426,10 +427,7 @@ else:
             if not cert.endswith("-----END CERTIFICATE-----"):
                 cert += "\n-----END CERTIFICATE-----"
 
-            if load_pem_x509_certificate is not None:
-                cert = load_pem_x509_certificate(cert.encode('utf-8'))
-            else:
-                cert = load_certificate(cert.encode('utf-8'))
+            cert = certificate_loader(cert.encode('utf-8'))
         else:
             cert = base64.b64decode(cert)
         return cert

--- a/setup.cfg
+++ b/setup.cfg
@@ -59,12 +59,18 @@ disable =
 
 [pylint.BASIC]
 good-names =
-    ex, i, j, k, Run, _, e, x, dn, cn, ip, os, unicode, __metaclass__, ds
+    ex, i, j, k, Run, _, e, x, dn, cn, ip, os, unicode, __metaclass__, ds,
+    # These are utils tools, and not part of the released collection.
+    galaxyfy-playbook, galaxyfy-README, galaxyfy-module-EXAMPLES,
+    module_EXAMPLES
+
 
 [pylint.IMPORTS]
 ignored-modules =
     ansible.errors, ansible.plugins.action,
     ansible.module_utils, ansible.module_utils.ansible_freeipa_module,
+    dns,
+    gssapi,
     ipalib, ipalib.config, ipalib.constants, ipalib.krb_utils, ipalib.errors,
     ipapython.ipautil, ipapython.dn, ipapython.version, ipapython.dnsutil,
     ipapython.ipa_log_manager, ipapython,
@@ -72,7 +78,10 @@ ignored-modules =
     ipaserver.install.installutils, ipaserver.install.server.install,
     ipaserver.install,
     ipaclient.install.ipachangeconf, ipaclient.install.client,
-    ipaserver.dcerpc
+    ipaserver.dcerpc,
+    jinja2,
+    os,
+    SSSDConfig
 
 [pylint.REFACTORING]
 max-nested-blocks = 9

--- a/utils/galaxyfy-module-EXAMPLES.py
+++ b/utils/galaxyfy-module-EXAMPLES.py
@@ -37,7 +37,7 @@ def module_EXAMPLES(module_in, project_prefix, collection_prefix):
                 example = True
                 out_lines.append(line)
                 continue
-            elif example and stripped in ["'''", '"""']:
+            if example and stripped in ["'''", '"""']:
                 _out_lines, _changed = \
                     galaxyfy_playbook(project_prefix, collection_prefix,
                                       example_lines)


### PR DESCRIPTION
Under Python 3.11 some linters have failed to execute due to deprecated items. Increasing or setting specific allow the linters to succeed with Python's lates version.