### PR TITLE
upstream ci: Update Github actions due to old Node.js.     

### DIFF
--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -8,7 +8,7 @@ jobs:
     name: Verify ansible-test sanity
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3.1.0
         with:
           fetch-depth: 0
       - name: Install virtualenv using pip

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -8,8 +8,8 @@ jobs:
     name: Check Ansible Documentation with Ansible 2.9.
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v3.1.0
+      - uses: actions/setup-python@v4.3.0
         with:
           python-version: '3.x'
       - name: Install Ansible 2.9
@@ -23,8 +23,8 @@ jobs:
     name: Check Ansible Documentation with ansible-core 2.11.
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v3.1.0
+      - uses: actions/setup-python@v4.3.0
         with:
           python-version: '3.x'
       - name: Install Ansible 2.11
@@ -38,8 +38,8 @@ jobs:
     name: Check Ansible Documentation with ansible-core 2.12.
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v3.1.0
+      - uses: actions/setup-python@v4.3.0
         with:
           python-version: '3.x'
       - name: Install Ansible 2.12
@@ -54,8 +54,8 @@ jobs:
     name: Check Ansible Documentation with latest Ansible version.
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v3.1.0
+      - uses: actions/setup-python@v4.3.0
         with:
           python-version: '3.x'
       - name: Install Ansible-latest

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,8 +8,8 @@ jobs:
     name: Verify ansible-lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v3.1.0
+      - uses: actions/setup-python@v4.3.0
         with:
           python-version: "3.x"
       - name: Run ansible-lint
@@ -25,8 +25,8 @@ jobs:
     name: Verify yamllint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v3.1.0
+      - uses: actions/setup-python@v4.3.0
         with:
           python-version: "3.x"
       - name: Run yaml-lint
@@ -36,8 +36,8 @@ jobs:
     name: Verify pydocstyle
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v3.1.0
+      - uses: actions/setup-python@v4.3.0
         with:
           python-version: "3.x"
       - name: Run pydocstyle
@@ -49,8 +49,8 @@ jobs:
     name: Verify flake8
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v3.1.0
+      - uses: actions/setup-python@v4.3.0
         with:
           python-version: "3.x"
       - name: Run flake8
@@ -62,8 +62,8 @@ jobs:
     name: Verify pylint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v3.1.0
+      - uses: actions/setup-python@v4.3.0
         with:
           python-version: "3.x"
       - name: Run pylint
@@ -75,6 +75,6 @@ jobs:
     name: Shellcheck
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3.1.0
       - name: Run ShellCheck
         uses: ludeeus/action-shellcheck@1.1.0

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -77,4 +77,4 @@ jobs:
     steps:
       - uses: actions/checkout@v3.1.0
       - name: Run ShellCheck
-        uses: ludeeus/action-shellcheck@1.1.0
+        uses: ludeeus/action-shellcheck@master

--- a/.github/workflows/readme.yml
+++ b/.github/workflows/readme.yml
@@ -8,7 +8,7 @@ jobs:
     name: Verify readme
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3.1.0
       - name: Run readme test
         run: |
           error=0


### PR DESCRIPTION
There are warnings on Github workflows about the need to update actions
'checkout' and 'setup-python' due to the use of Node.js versions that
are too old.

Also Shellcheck is using an old version with deprecated items.

This PR updates the versions of the actions used to remove the warnings.