### PR TITLE
netgroup: Fix environment cleanup on ipanetgroup tests.

### DIFF
--- a/tests/netgroup/test_netgroup_member.yml
+++ b/tests/netgroup/test_netgroup_member.yml
@@ -45,7 +45,8 @@
         ipaadmin_password: SomeADMINpassword
         ipaapi_context: "{{ ipa_context | default(omit) }}"
         name:
-        - TestNetgroup1,admins
+        - TestNetgroup1
+        - admins
         state: absent
 
     # CREATE TEST ITEMS
@@ -155,5 +156,6 @@
         ipaadmin_password: SomeADMINpassword
         ipaapi_context: "{{ ipa_context | default(omit) }}"
         name:
-        - TestNetgroup1,admins
+        - TestNetgroup1
+        - admins
         state: absent

--- a/tests/netgroup/test_netgroup_member_absent.yml
+++ b/tests/netgroup/test_netgroup_member_absent.yml
@@ -45,7 +45,8 @@
         ipaadmin_password: SomeADMINpassword
         ipaapi_context: "{{ ipa_context | default(omit) }}"
         name:
-        - TestNetgroup1,admins
+        - TestNetgroup1
+        - admins
         state: absent
 
     # CREATE TEST ITEMS
@@ -202,5 +203,6 @@
         ipaadmin_password: SomeADMINpassword
         ipaapi_context: "{{ ipa_context | default(omit) }}"
         name:
-        - TestNetgroup1,admins
+        - TestNetgroup1
+        - admins
         state: absent


### PR DESCRIPTION
Tests for ipanetgroup were not correctly clearing up the tests, causing test failures when running them in some specific order.

By fixing the 'name' attribute list the tests succeed, independently of the order they are executed.