### PR TITLE
github worflows: speed up git checkout.

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -9,6 +9,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3.1.0
+        with:
+          fetch-depth: 0
       - uses: actions/setup-python@v4.3.0
         with:
           python-version: '3.x'
@@ -24,6 +26,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3.1.0
+        with:
+          fetch-depth: 0
       - uses: actions/setup-python@v4.3.0
         with:
           python-version: '3.x'
@@ -39,6 +43,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3.1.0
+        with:
+          fetch-depth: 0
       - uses: actions/setup-python@v4.3.0
         with:
           python-version: '3.x'
@@ -55,6 +61,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3.1.0
+        with:
+          fetch-depth: 0
       - uses: actions/setup-python@v4.3.0
         with:
           python-version: '3.x'

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,6 +9,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3.1.0
+        with:
+          fetch-depth: 0
       - uses: actions/setup-python@v4.3.0
         with:
           python-version: "3.x"
@@ -26,6 +28,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3.1.0
+        with:
+          fetch-depth: 0
       - uses: actions/setup-python@v4.3.0
         with:
           python-version: "3.x"
@@ -37,6 +41,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3.1.0
+        with:
+          fetch-depth: 0
       - uses: actions/setup-python@v4.3.0
         with:
           python-version: "3.x"
@@ -50,6 +56,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3.1.0
+        with:
+          fetch-depth: 0
       - uses: actions/setup-python@v4.3.0
         with:
           python-version: "3.x"
@@ -63,6 +71,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3.1.0
+        with:
+          fetch-depth: 0
       - uses: actions/setup-python@v4.3.0
         with:
           python-version: "3.x"
@@ -76,5 +86,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3.1.0
+        with:
+          fetch-depth: 0
       - name: Run ShellCheck
         uses: ludeeus/action-shellcheck@master

--- a/.github/workflows/readme.yml
+++ b/.github/workflows/readme.yml
@@ -9,6 +9,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3.1.0
+        with:
+          fetch-depth: 0
       - name: Run readme test
         run: |
           error=0


### PR DESCRIPTION
This patch add 'fetch-depth: 0' to 'checkout' plugin on Github Worflows to slightly speed up verifications.