### PR TITLE
pre-commit: Fix pycqa pre-commit repos.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,11 +15,11 @@ repos:
   hooks:
   - id: yamllint
     files: \.(yaml|yml)$
-- repo: https://gitlab.com/pycqa/flake8
+- repo: https://github.com/pycqa/flake8
   rev: 3.9.2
   hooks:
   - id: flake8
-- repo: https://gitlab.com/pycqa/pydocstyle
+- repo: https://github.com/pycqa/pydocstyle
   rev: 6.1.1
   hooks:
   - id: pydocstyle


### PR DESCRIPTION
The pycqa pre-commit repos were using 'gitlab.com', instead of 'github.com', which is, today, the correct repository to use.

This patch fixes the addresses for Flake8 and pydocstyle checks.