### PR TITLE
ipaclient: No DNS resolver configuration on master

### DIFF
--- a/roles/ipaclient/tasks/install.yml
+++ b/roles/ipaclient/tasks/install.yml
@@ -44,7 +44,8 @@
       searchdomains: "{{ ipaserver_domain | default(ipaclient_domain) }}"
       state: present
 
-  when: ipaclient_configure_dns_resolver
+  when: ipaclient_configure_dns_resolver | bool
+        and not ipaclient_on_master | bool
 
 - name: Install - IPA client test
   ipaclient_test:


### PR DESCRIPTION
The DNS resolver configuration should not happen in the server client part installation where ipaclient_on_master is enabled.