### PR TITLE
environment: Fix os.environ language setting.

### DIFF
--- a/plugins/module_utils/ansible_freeipa_module.py
+++ b/plugins/module_utils/ansible_freeipa_module.py
@@ -32,6 +32,9 @@ __all__ = ["gssapi", "netaddr", "api", "ipalib_errors", "Env",
            "load_pem_x509_certificate", "DNSName", "getargspec"]
 
 import os
+# ansible-freeipa requires locale to be C, IPA requires utf-8.
+os.environ["LANGUAGE"] = "C"
+
 import sys
 import operator
 import tempfile
@@ -153,9 +156,6 @@ except ImportError as _err:
 else:
     ANSIBLE_FREEIPA_MODULE_IMPORT_ERROR = None
 
-
-# ansible-freeipa requires locale to be C, IPA requires utf-8.
-os.environ["LANGUAGE"] = "C"
 
 if six.PY3:
     unicode = str


### PR DESCRIPTION
A combination of ansible-freeipa modifications and a newer version of IPA has brought a regression regarding different OS localization.

For properly setting environment to use "C" language, as required by ansible-freeipa, the setting must be executed before importing the module 'ipaserver.dcerpc', so setting environment language was moved closer to the 'import os' statement, so that it is always set, as soon as possible.

Note that 'import os' should always be imported before any FreeIPA module.

> This issue was found with the latest FreeIPA version (4.9.11) in Fedora 35.