### PR TITLE
Use FQCN for ansible.builtin

### DIFF
--- a/playbooks/config/retrieve-config.yml
+++ b/playbooks/config/retrieve-config.yml
@@ -11,5 +11,5 @@
     register: serverconfig
 
   - name: Display current configuration.
-    debug:
+    ansible.builtin.debug:
       msg: "{{ serverconfig }}"

--- a/playbooks/dnszone/dnszone-reverse-from-ip.yml
+++ b/playbooks/dnszone/dnszone-reverse-from-ip.yml
@@ -11,5 +11,5 @@
     register: result
 
   - name: Zone name inferred from `name_from_ip`
-    debug:
+    ansible.builtin.debug:
       msg: "Zone created: {{ result.dnszone.name }}"

--- a/playbooks/host/ensure_host_with_randompassword.yml
+++ b/playbooks/host/ensure_host_with_randompassword.yml
@@ -14,5 +14,5 @@
     register: ipahost
 
   - name: Print generated random password
-    debug:
+    ansible.builtin.debug:
       var: ipahost.host.randompassword

--- a/playbooks/host/host-present-with-randompassword.yml
+++ b/playbooks/host/host-present-with-randompassword.yml
@@ -13,5 +13,5 @@
     register: ipahost
 
   - name: Print generated random password
-    debug:
+    ansible.builtin.debug:
       var: ipahost.host.randompassword

--- a/playbooks/host/hosts-present-with-randompasswords.yml
+++ b/playbooks/host/hosts-present-with-randompasswords.yml
@@ -17,9 +17,9 @@
     register: ipahost
 
   - name: Print generated random password for host01.example.com
-    debug:
+    ansible.builtin.debug:
       var: ipahost.host["host01.example.com"].randompassword
 
   - name: Print generated random password for host02.example.com
-    debug:
+    ansible.builtin.debug:
       var: ipahost.host["host02.example.com"].randompassword

--- a/playbooks/user/ensure_user_with_randompassword.yml
+++ b/playbooks/user/ensure_user_with_randompassword.yml
@@ -15,5 +15,5 @@
     register: ipauser
 
   - name: Print generated random password
-    debug:
+    ansible.builtin.debug:
       var: ipauser.user.randompassword

--- a/playbooks/user/ensure_users_with_randompasswords.yml
+++ b/playbooks/user/ensure_users_with_randompasswords.yml
@@ -20,9 +20,9 @@
     register: ipauser
 
   - name: Print generated random password for user1
-    debug:
+    ansible.builtin.debug:
       var: ipauser.user.user1.randompassword
 
   - name: Print generated random password for user2
-    debug:
+    ansible.builtin.debug:
       var: ipauser.user.user2.randompassword

--- a/playbooks/vault/retrive-data-asymmetric-vault.yml
+++ b/playbooks/vault/retrive-data-asymmetric-vault.yml
@@ -15,5 +15,5 @@
       register: result
       no_log: true
     - name: Display retrieved data.
-      debug:
+      ansible.builtin.debug:
         msg: "Data: {{ result.vault.data }}"

--- a/playbooks/vault/retrive-data-symmetric-vault.yml
+++ b/playbooks/vault/retrive-data-symmetric-vault.yml
@@ -15,5 +15,5 @@
       register: result
       no_log: true
     - name: Display retrieved data.
-      debug:
+      ansible.builtin.debug:
         msg: "Data: {{ result.vault.data }}"

--- a/playbooks/vault/vault-is-present-with-password-file.yml
+++ b/playbooks/vault/vault-is-present-with-password-file.yml
@@ -6,7 +6,7 @@
 
   tasks:
   - name: Copy file containing password to server.
-    copy:
+    ansible.builtin.copy:
       src: "{{ playbook_dir }}/password.txt"
       dest: "{{ ansible_facts['env'].HOME }}/password.txt"
       owner: "{{ ansible_user }}"
@@ -20,6 +20,6 @@
       vault_type: symmetric
       vault_password_file: "{{ ansible_facts['env'].HOME }}/password.txt"
   - name: Remove file containing password from server.
-    file:
+    ansible.builtin.file:
       path: "{{ ansible_facts['env'].HOME }}/password.txt"
       state: absent

--- a/playbooks/vault/vault-is-present-with-public-key-file.yml
+++ b/playbooks/vault/vault-is-present-with-public-key-file.yml
@@ -11,7 +11,7 @@
 
   tasks:
   - name: Copy public key file to server.
-    copy:
+    ansible.builtin.copy:
       src: "{{ playbook_dir }}/public.pem"
       dest: "{{ ansible_facts['env'].HOME }}/public.pem"
       owner: "{{ ansible_user }}"
@@ -25,6 +25,6 @@
       vault_type: asymmetric
       vault_public_key_file: "{{ ansible_facts['env'].HOME }}/public.pem"
   - name: Remove public key file from server.
-    file:
+    ansible.builtin.file:
       path: "{{ ansible_facts['env'].HOME }}/public.pem"
       state: absent

--- a/roles/ipabackup/tasks/backup.yml
+++ b/roles/ipabackup/tasks/backup.yml
@@ -2,7 +2,7 @@
 # tasks file for ipabackup
 
 - name: Create backup
-  shell: >
+  ansible.builtin.shell: >
     ipa-backup
     {{ "--gpg" if ipabackup_gpg | bool else "" }}
     {{ "--gpg-keyring="+ipabackup_gpg_keyring if ipabackup_gpg_keyring is defined else "" }}
@@ -15,7 +15,7 @@
 
 - block:
   - name: Get ipabackup_item from stderr or stdout output
-    set_fact:
+    ansible.builtin.set_fact:
       ipabackup_item: "{{ item | regex_search('\n.*/([^\n]+)','\\1') | first }}"
     when: item.find("Backed up to "+ipabackup_dir+"/") > 0
     with_items:
@@ -25,15 +25,15 @@
       label: ""
 
   - name: Fail on missing ipabackup_item
-    fail: msg="Failed to get ipabackup_item"
+    ansible.builtin.fail: msg="Failed to get ipabackup_item"
     when: ipabackup_item is not defined
 
   - name: Copy backup to controller
-    include_tasks: "{{ role_path }}/tasks/copy_backup_from_server.yml"
+    ansible.builtin.include_tasks: "{{ role_path }}/tasks/copy_backup_from_server.yml"
     when: state|default("present") == "present"
 
   - name: Remove backup on server
-    include_tasks: "{{ role_path }}/tasks/remove_backup_from_server.yml"
+    ansible.builtin.include_tasks: "{{ role_path }}/tasks/remove_backup_from_server.yml"
     when: not ipabackup_keep_on_server
 
   when: ipabackup_to_controller

--- a/roles/ipabackup/tasks/copy_backup_from_server.yml
+++ b/roles/ipabackup/tasks/copy_backup_from_server.yml
@@ -1,36 +1,36 @@
 ---
 - name: Fail on invalid ipabackup_item
-  fail: msg="ipabackup_item {{ ipabackup_item }} is not valid"
+  ansible.builtin.fail: msg="ipabackup_item {{ ipabackup_item }} is not valid"
   when: ipabackup_item is not defined or
         ipabackup_item | length < 1 or
         (ipabackup_item.find("ipa-full-") == -1 and
          ipabackup_item.find("ipa-data-") == -1)
 
 - name: Set controller destination directory
-  set_fact:
+  ansible.builtin.set_fact:
     ipabackup_controller_dir:
         "{{ ipabackup_controller_path | default(lookup('env','PWD')) }}/{{
          ipabackup_name_prefix | default(ansible_facts['fqdn']) }}_{{
          ipabackup_item }}/"
 
 - name: Stat backup on server
-  stat:
+  ansible.builtin.stat:
     path: "{{ ipabackup_dir }}/{{ ipabackup_item }}"
   register: result_backup_stat
 
 - name: Fail on missing backup directory
-  fail: msg="Unable to find backup {{ ipabackup_item }}"
+  ansible.builtin.fail: msg="Unable to find backup {{ ipabackup_item }}"
   when: result_backup_stat.stat.isdir is not defined
 
 - name: Get backup files to copy for "{{ ipabackup_item }}"
-  shell:
+  ansible.builtin.shell:
     find . -type f | cut -d"/" -f 2
   args:
     chdir: "{{ ipabackup_dir }}/{{ ipabackup_item }}"
   register: result_find_backup_files
 
 - name: Copy server backup files to controller
-  fetch:
+  ansible.builtin.fetch:
     flat: yes
     src: "{{ ipabackup_dir }}/{{ ipabackup_item }}/{{ item }}"
     dest: "{{ ipabackup_controller_dir }}"
@@ -38,7 +38,7 @@
   - "{{ result_find_backup_files.stdout_lines }}"
 
 - name: Fix file modes for backup on controller
-  file:
+  ansible.builtin.file:
     dest: "{{ ipabackup_controller_dir }}"
     mode: u=rwX,go=
     recurse: yes

--- a/roles/ipabackup/tasks/copy_backup_to_server.yml
+++ b/roles/ipabackup/tasks/copy_backup_to_server.yml
@@ -1,40 +1,40 @@
 ---
 - name: Fail on invalid ipabackup_name
-  fail: msg="ipabackup_name {{ ipabackup_name }} is not valid"
+  ansible.builtin.fail: msg="ipabackup_name {{ ipabackup_name }} is not valid"
   when: ipabackup_name is not defined or
         ipabackup_name | length < 1 or
         (ipabackup_name.find("ipa-full-") == -1 and
          ipabackup_name.find("ipa-data-") == -1)
 
 - name: Set controller source directory
-  set_fact:
+  ansible.builtin.set_fact:
     ipabackup_controller_dir:
       "{{ ipabackup_controller_path | default(lookup('env','PWD')) }}"
 
 - name: Set ipabackup_item
-  set_fact:
+  ansible.builtin.set_fact:
     ipabackup_item:
       "{{ ipabackup_name | regex_search('.*_(ipa-.+)','\\1') | first }}"
   when: "'_ipa-' in ipabackup_name"
 
 - name: Set ipabackup_item
-  set_fact:
+  ansible.builtin.set_fact:
     ipabackup_item: "{{ ipabackup_name }}"
   when: "'_ipa-' not in ipabackup_name"
 
 - name: Stat backup to copy
-  stat:
+  ansible.builtin.stat:
     path: "{{ ipabackup_controller_dir }}/{{ ipabackup_name }}"
   register: result_backup_stat
   delegate_to: localhost
   become: no
 
 - name: Fail on missing backup to copy
-  fail: msg="Unable to find backup {{ ipabackup_name }}"
+  ansible.builtin.fail: msg="Unable to find backup {{ ipabackup_name }}"
   when: result_backup_stat.stat.isdir is not defined
 
 - name: Copy backup files to server for "{{ ipabackup_item }}"
-  copy:
+  ansible.builtin.copy:
     src: "{{ ipabackup_controller_dir }}/{{ ipabackup_name }}/"
     dest: "{{ ipabackup_dir }}/{{ ipabackup_item }}"
     owner: root

--- a/roles/ipabackup/tasks/get_ipabackup_dir.yml
+++ b/roles/ipabackup/tasks/get_ipabackup_dir.yml
@@ -4,5 +4,5 @@
   register: result_ipabackup_get_backup_dir
 
 - name: Set IPA backup dir
-  set_fact:
+  ansible.builtin.set_fact:
     ipabackup_dir: "{{ result_ipabackup_get_backup_dir.backup_dir }}"

--- a/roles/ipabackup/tasks/main.yml
+++ b/roles/ipabackup/tasks/main.yml
@@ -2,7 +2,7 @@
 # tasks file for ipabackup
 
 - name: Check for empty vars
-  fail: msg="Variable {{ item }} is empty"
+  ansible.builtin.fail: msg="Variable {{ item }} is empty"
   when: "item in vars and not vars[item]"
   with_items: "{{ ipabackup_empty_var_checks }}"
   vars:
@@ -18,43 +18,43 @@
     - ipabackup_firewalld_zone
 
 - name: Set ipabackup_data if ipabackup_data is not set but ipabackup_online is
-  set_fact:
+  ansible.builtin.set_fact:
     ipabackup_data: yes
   when: ipabackup_online | bool and not ipabackup_data | bool
 
 - name: Fail if ipabackup_from_controller and ipabackup_to_controller are set
-  fail: msg="ipabackup_from_controller and ipabackup_to_controller are set"
+  ansible.builtin.fail: msg="ipabackup_from_controller and ipabackup_to_controller are set"
   when: ipabackup_from_controller | bool and ipabackup_to_controller | bool
 
 - name: Fail for given ipabackup_name if state is not copied, restored or absent
-  fail: msg="ipabackup_name is given and state is not copied, restored or absent"
+  ansible.builtin.fail: msg="ipabackup_name is given and state is not copied, restored or absent"
   when: state is not defined or
         (state != "copied" and state != "restored" and state != "absent") and
         ipabackup_name is defined
 
 - name: Get ipabackup_dir from IPA installation
-  include_tasks: "{{ role_path }}/tasks/get_ipabackup_dir.yml"
+  ansible.builtin.include_tasks: "{{ role_path }}/tasks/get_ipabackup_dir.yml"
 
 - name: Backup IPA server
-  include_tasks: "{{ role_path }}/tasks/backup.yml"
+  ansible.builtin.include_tasks: "{{ role_path }}/tasks/backup.yml"
   when: state|default("present") == "present"
 
 - name: Fail on missing ipabackup_name
-  fail: msg="ipabackup_name is not set"
+  ansible.builtin.fail: msg="ipabackup_name is not set"
   when: (ipabackup_name is not defined or not ipabackup_name) and
         state is defined and
         (state == "copied" or state == "restored" or state == "absent")
 
 - block:
   - name: Get list of all backups on IPA server
-    shell:
+    ansible.builtin.shell:
       find . -name "ipa-full-*" -o -name "ipa-data-*" | cut -d"/" -f 2
     args:
       chdir: "{{ ipabackup_dir }}/"
     register: result_backup_find_backup_files
 
   - name: Set ipabackup_names using backup list
-    set_fact:
+    ansible.builtin.set_fact:
       ipabackup_names: "{{ result_backup_find_backup_files.stdout_lines }}"
 
   when: state is defined and
@@ -64,28 +64,28 @@
 
 - block:
   - name: Fail on ipabackup_name all
-    fail: msg="ipabackup_name can not be all in this case"
+    ansible.builtin.fail: msg="ipabackup_name can not be all in this case"
     when: ipabackup_name is defined and ipabackup_name == "all"
 
   - name: Set ipabackup_names from ipabackup_name string
-    set_fact:
+    ansible.builtin.set_fact:
       ipabackup_names: ["{{ ipabackup_name }}"]
     when: ipabackup_name | type_debug != "list"
 
   - name: Set ipabackup_names from ipabackup_name list
-    set_fact:
+    ansible.builtin.set_fact:
       ipabackup_names: "{{ ipabackup_name }}"
     when: ipabackup_name | type_debug == "list"
   when: ipabackup_names is not defined and ipabackup_name is defined
 
 - name: Set empty ipabackup_names if ipabackup_name is not defined
-  set_fact:
+  ansible.builtin.set_fact:
     ipabackup_names: []
   when: ipabackup_names is not defined and ipabackup_name is not defined
 
 - block:
   - name: Copy backup from IPA server
-    include_tasks: "{{ role_path }}/tasks/copy_backup_from_server.yml"
+    ansible.builtin.include_tasks: "{{ role_path }}/tasks/copy_backup_from_server.yml"
     vars:
       ipabackup_item: "{{ main_item | basename }}"
     with_items:
@@ -95,7 +95,7 @@
     when: state is defined and state == "copied"
 
   - name: Remove backup from IPA server
-    include_tasks: "{{ role_path }}/tasks/remove_backup_from_server.yml"
+    ansible.builtin.include_tasks: "{{ role_path }}/tasks/remove_backup_from_server.yml"
     vars:
       ipabackup_item: "{{ main_item | basename }}"
     with_items:
@@ -111,7 +111,7 @@
 # restore.
 
 - name: Fail to copy or restore more than one backup on the server
-  fail: msg="Only one backup can be copied to the server or restored"
+  ansible.builtin.fail: msg="Only one backup can be copied to the server or restored"
   when: state is defined and (state == "copied" or state == "restored") and
         ipabackup_from_controller | bool and ipabackup_names | length != 1
 
@@ -119,10 +119,10 @@
 
 - block:
   - name: Copy backup to server
-    include_tasks: "{{ role_path }}/tasks/copy_backup_to_server.yml"
+    ansible.builtin.include_tasks: "{{ role_path }}/tasks/copy_backup_to_server.yml"
 
   - name: Restore IPA server after copy
-    include_tasks: "{{ role_path }}/tasks/restore.yml"
+    ansible.builtin.include_tasks: "{{ role_path }}/tasks/restore.yml"
     when: state|default("present") == "restored"
 
   vars:
@@ -131,7 +131,7 @@
         (state|default("present") == "copied" and not ipabackup_to_controller)
 
 - name: Restore IPA server
-  include_tasks: "{{ role_path }}/tasks/restore.yml"
+  ansible.builtin.include_tasks: "{{ role_path }}/tasks/restore.yml"
   vars:
     ipabackup_item: "{{ ipabackup_names[0] | basename }}"
   when: not ipabackup_from_controller and

--- a/roles/ipabackup/tasks/remove_backup_from_server.yml
+++ b/roles/ipabackup/tasks/remove_backup_from_server.yml
@@ -1,5 +1,5 @@
 ---
 - name: Remove backup "{{ ipabackup_item }}"
-  file:
+  ansible.builtin.file:
     path: "{{ ipabackup_dir }}/{{ ipabackup_item }}"
     state: absent

--- a/roles/ipabackup/tasks/restore.yml
+++ b/roles/ipabackup/tasks/restore.yml
@@ -4,7 +4,7 @@
 ### VARIABLES
 
 - name: Import variables specific to distribution
-  include_vars: "{{ item }}"
+  ansible.builtin.include_vars: "{{ item }}"
   with_first_found:
     - "{{ role_path }}/vars/{{ ansible_facts['distribution'] }}-{{ ansible_facts['distribution_version'] }}.yml"
     - "{{ role_path }}/vars/{{ ansible_facts['distribution'] }}-{{ ansible_facts['distribution_major_version'] }}.yml"
@@ -21,30 +21,30 @@
 ### GET SERVICES FROM BACKUP
 
 - name: Stat backup on server
-  stat:
+  ansible.builtin.stat:
     path: "{{ ipabackup_dir }}/{{ ipabackup_item }}"
   register: result_backup_stat
 
 - name: Fail on missing backup directory
-  fail: msg="Unable to find backup {{ ipabackup_item }}"
+  ansible.builtin.fail: msg="Unable to find backup {{ ipabackup_item }}"
   when: result_backup_stat.stat.isdir is not defined
 
 - name: Stat header file in backup "{{ ipabackup_item }}"
-  stat:
+  ansible.builtin.stat:
     path: "{{ ipabackup_dir }}/{{ ipabackup_item }}/header"
   register: result_backup_header_stat
 
 - name: Fail on missing header file in backup
-  fail: msg="Unable to find backup {{ ipabackup_item }} header file"
+  ansible.builtin.fail: msg="Unable to find backup {{ ipabackup_item }} header file"
   when: result_backup_header_stat.stat.isreg is not defined
 
 - name: Get services from backup
-  shell: >
+  ansible.builtin.shell: >
     grep "^services = " "{{ ipabackup_dir }}/{{ ipabackup_item }}/header" | cut -d"=" -f2 | tr -d '[:space:]'
   register: result_services_grep
 
 - name: Set ipabackup_services
-  set_fact:
+  ansible.builtin.set_fact:
     ipabackup_services: "{{ result_services_grep.stdout.split(',') }}"
     ipabackup_service_dns: DNS
     ipabackup_service_adtrust: ADTRUST
@@ -54,24 +54,24 @@
 
 - block:
   - name: Ensure that IPA server packages are installed
-    package:
+    ansible.builtin.package:
       name: "{{ ipaserver_packages }}"
       state: present
 
   - name: Ensure that IPA server packages for dns are installed
-    package:
+    ansible.builtin.package:
       name: "{{ ipaserver_packages_dns }}"
       state: present
     when: ipabackup_service_dns in ipabackup_services
 
   - name: Ensure that IPA server packages for adtrust are installed
-    package:
+    ansible.builtin.package:
       name: "{{ ipaserver_packages_adtrust }}"
       state: present
     when: ipabackup_service_adtrust in ipabackup_services
 
   - name: Ensure that firewalld packages are installed
-    package:
+    ansible.builtin.package:
       name: "{{ ipaserver_packages_firewalld }}"
       state: present
     when: ipabackup_setup_firewalld | bool
@@ -82,20 +82,20 @@
 
 - block:
   - name: Ensure that firewalld is running
-    systemd:
+    ansible.builtin.systemd:
       name: firewalld
       enabled: yes
       state: started
 
   - name: Firewalld - Verify runtime zone "{{ ipabackup_firewalld_zone }}"
-    shell: >
+    ansible.builtin.shell: >
       firewall-cmd
       --info-zone="{{ ipabackup_firewalld_zone }}"
       >/dev/null
     when: ipabackup_firewalld_zone is defined
 
   - name: Firewalld - Verify permanent zone "{{ ipabackup_firewalld_zone }}"
-    shell: >
+    ansible.builtin.shell: >
       firewall-cmd
       --permanent
       --info-zone="{{ ipabackup_firewalld_zone }}"
@@ -108,7 +108,7 @@
 
 - name: Restore backup
   no_log: True
-  shell: >
+  ansible.builtin.shell: >
     ipa-restore
     {{ ipabackup_item }}
     --unattended
@@ -123,7 +123,7 @@
   ignore_errors: yes
 
 - name: Report error for restore operation
-  debug:
+  ansible.builtin.debug:
     msg: "{{ result_iparestore.stderr }}"
   when: result_iparestore is failed
   failed_when: yes
@@ -131,7 +131,7 @@
 ### CONFIGURE FIREWALLD
 
 - name: Configure firewalld
-  command: >
+  ansible.builtin.command: >
     firewall-cmd
     --permanent
     {{ "--zone="+ipabackup_firewalld_zone if ipabackup_firewalld_zone is defined else "" }}
@@ -143,7 +143,7 @@
   when: ipabackup_setup_firewalld | bool
 
 - name: Configure firewalld runtime
-  command: >
+  ansible.builtin.command: >
     firewall-cmd
     {{ "--zone="+ipabackup_firewalld_zone if ipabackup_firewalld_zone is defined else "" }}
     --add-service=freeipa-ldap

--- a/roles/ipaclient/tasks/install.yml
+++ b/roles/ipaclient/tasks/install.yml
@@ -2,28 +2,28 @@
 # tasks file for ipaclient
 
 - name: Install - Ensure that IPA client packages are installed
-  package:
+  ansible.builtin.package:
     name: "{{ ipaclient_packages }}"
     state: present
   when: ipaclient_install_packages | bool
 
 - name: Install - Set ipaclient_servers
-  set_fact:
+  ansible.builtin.set_fact:
     ipaclient_servers: "{{ groups['ipaservers'] | list }}"
   when: groups.ipaservers is defined and ipaclient_servers is not defined
 
 - name: Install - Set ipaclient_servers from cluster inventory
-  set_fact:
+  ansible.builtin.set_fact:
     ipaclient_servers: "{{ groups['ipaserver'] | list }}"
   when: ipaclient_no_dns_lookup | bool and groups.ipaserver is defined and
         ipaclient_servers is not defined
 
 - name: Install - Check that either password or keytab is set
-  fail: msg="ipaadmin_password and ipaadmin_keytab cannot be used together"
+  ansible.builtin.fail: msg="ipaadmin_password and ipaadmin_keytab cannot be used together"
   when: ipaadmin_keytab is defined and ipaadmin_password is defined
 
 - name: Install - Set default principal if no keytab is given
-  set_fact:
+  ansible.builtin.set_fact:
     ipaadmin_principal: admin
   when: ipaadmin_principal is undefined and ipaclient_keytab is undefined
 
@@ -31,11 +31,11 @@
   block:
 
   - name: Install - Fail on missing ipaclient_domain and ipaserver_domain
-    fail: msg="ipaclient_domain or ipaserver_domain is required for ipaclient_configure_dns_resolver"
+    ansible.builtin.fail: msg="ipaclient_domain or ipaserver_domain is required for ipaclient_configure_dns_resolver"
     when: ipaserver_domain is not defined and ipaclient_domain is not defined
 
   - name: Install - Fail on missing ipaclient_servers
-    fail: msg="ipaclient_dns_servers is required for ipaclient_configure_dns_resolver"
+    ansible.builtin.fail: msg="ipaclient_dns_servers is required for ipaclient_configure_dns_resolver"
     when: ipaclient_dns_servers is not defined
 
   - name: Install - Configure DNS resolver
@@ -74,7 +74,7 @@
 
 - block:
   - name: Install - Cleanup leftover ccache
-    file:
+    ansible.builtin.file:
       path: "/etc/ipa/.dns_ccache"
       state: absent
 
@@ -91,12 +91,12 @@
       domain: "{{ result_ipaclient_test.domain }}"
 
   - name: Install - Make sure One-Time Password is enabled if it's already defined
-    set_fact:
+    ansible.builtin.set_fact:
       ipaclient_use_otp: "yes"
     when: ipaclient_otp is defined
 
   - name: Install - Disable One-Time Password for on_master
-    set_fact:
+    ansible.builtin.set_fact:
       ipaclient_use_otp: "no"
     when: ipaclient_use_otp | bool and ipaclient_on_master | bool
 
@@ -112,7 +112,7 @@
 
   - name: Install - Disable One-Time Password for client with working
           krb5.keytab
-    set_fact:
+    ansible.builtin.set_fact:
       ipaclient_use_otp: "no"
     when: ipaclient_use_otp | bool and
           result_ipaclient_test_keytab.krb5_keytab_ok and
@@ -159,14 +159,14 @@
       delegate_to: "{{ result_ipaclient_test.servers[0] }}"
 
     - name: Install - Report error for OTP generation
-      debug:
+      ansible.builtin.debug:
         msg: "{{ result_ipaclient_get_otp.msg }}"
       when: result_ipaclient_get_otp is failed
       failed_when: yes
 
     - name: Install - Store the previously obtained OTP
       no_log: yes
-      set_fact:
+      ansible.builtin.set_fact:
         ipaadmin_orig_password: "{{ ipaadmin_password | default(omit) }}"
         ipaadmin_password: "{{ result_ipaclient_get_otp.host.randompassword
                                if result_ipaclient_get_otp.host is defined }}"
@@ -183,7 +183,7 @@
 
   - name: Store predefined OTP in admin_password
     no_log: yes
-    set_fact:
+    ansible.builtin.set_fact:
       ipaadmin_orig_password: "{{ ipaadmin_password | default(omit) }}"
       ipaadmin_password: "{{ ipaclient_otp }}"
     when: ipaclient_otp is defined
@@ -198,11 +198,11 @@
     #        result_ipaclient_join.already_joined)))
 
     - name: Install - Check if principal and keytab are set
-      fail: msg="Admin principal and client keytab cannot be used together"
+      ansible.builtin.fail: msg="Admin principal and client keytab cannot be used together"
       when: ipaadmin_principal is defined and ipaclient_keytab is defined
 
     - name: Install - Check if one of password or keytabs are set
-      fail: msg="At least one of password or keytabs must be specified"
+      ansible.builtin.fail: msg="At least one of password or keytabs must be specified"
       when: not result_ipaclient_test_keytab.krb5_keytab_ok
             and ipaadmin_password is undefined
             and ipaadmin_keytab is undefined
@@ -210,7 +210,7 @@
     when: not ipaclient_on_master | bool
 
   - name: Install - Purge {{ result_ipaclient_test.realm }} from host keytab
-    command: >
+    ansible.builtin.command: >
       /usr/sbin/ipa-rmkeytab
       -k /etc/krb5.keytab
       -r "{{ result_ipaclient_test.realm }}"
@@ -254,17 +254,17 @@
 
   - block:
     - name: krb5 configuration not correct
-      fail:
+      ansible.builtin.fail:
         msg: >
           The krb5 configuration is not correct, please enable allow_repair
           to fix this.
       when: not result_ipaclient_test_keytab.krb5_conf_ok
     - name: IPA test failed
-      fail:
+      ansible.builtin.fail:
         msg: "The IPA test failed, please enable allow_repair to fix this."
       when: not result_ipaclient_test_keytab.ping_test_ok
     - name: ca.crt file is missing
-      fail:
+      ansible.builtin.fail:
         msg: >
           The ca.crt file is missing, please enable allow_repair to fix this.
       when: not result_ipaclient_test_keytab.ca_crt_exists
@@ -411,11 +411,11 @@
   always:
   - name: Install - Restore original admin password if overwritten by OTP
     no_log: yes
-    set_fact:
+    ansible.builtin.set_fact:
         ipaadmin_password: "{{ ipaadmin_orig_password }}"
     when: ipaclient_use_otp | bool and ipaadmin_orig_password is defined
 
   - name: Cleanup leftover ccache
-    file:
+    ansible.builtin.file:
       path: "/etc/ipa/.dns_ccache"
       state: absent

--- a/roles/ipaclient/tasks/main.yml
+++ b/roles/ipaclient/tasks/main.yml
@@ -2,7 +2,7 @@
 # tasks file for ipaclient
 
 - name: Import variables specific to distribution
-  include_vars: "{{ item }}"
+  ansible.builtin.include_vars: "{{ item }}"
   with_first_found:
     - "{{ role_path }}/vars/{{ ansible_facts['distribution'] }}-{{ ansible_facts['distribution_version'] }}.yml"
     - "{{ role_path }}/vars/{{ ansible_facts['distribution'] }}-{{ ansible_facts['distribution_major_version'] }}.yml"
@@ -17,9 +17,9 @@
     - "{{ role_path }}/vars/default.yml"
 
 - name: Install IPA client
-  include_tasks: install.yml
+  ansible.builtin.include_tasks: install.yml
   when: state|default('present') == 'present'
 
 - name: Uninstall IPA client
-  include_tasks: uninstall.yml
+  ansible.builtin.include_tasks: uninstall.yml
   when: state|default('present') == 'absent'

--- a/roles/ipaclient/tasks/uninstall.yml
+++ b/roles/ipaclient/tasks/uninstall.yml
@@ -2,7 +2,7 @@
 # tasks to uninstall IPA client
 
 - name: Uninstall - Uninstall IPA client
-  command: >
+  ansible.builtin.command: >
     /usr/sbin/ipa-client-install
     --uninstall
     -U
@@ -17,6 +17,6 @@
   when: ipaclient_cleanup_dns_resolver | bool
 
 #- name: Remove IPA client package
-#  package:
+#  ansible.builtin.package:
 #    name: "{{ ipaclient_packages }}"
 #    state: absent

--- a/roles/ipareplica/tasks/install.yml
+++ b/roles/ipareplica/tasks/install.yml
@@ -4,24 +4,24 @@
 - block:
 
   - name: Install - Ensure IPA replica packages are installed
-    package:
+    ansible.builtin.package:
       name: "{{ ipareplica_packages }}"
       state: present
 
   - name: Install - Ensure IPA replica packages for dns are installed
-    package:
+    ansible.builtin.package:
       name: "{{ ipareplica_packages_dns }}"
       state: present
     when: ipareplica_setup_dns | bool
 
   - name: Install - Ensure IPA replica packages for adtrust are installed
-    package:
+    ansible.builtin.package:
       name: "{{ ipareplica_packages_adtrust }}"
       state: present
     when: ipareplica_setup_adtrust | bool
 
   - name: Install - Ensure that firewall packages installed
-    package:
+    ansible.builtin.package:
       name: "{{ ipareplica_packages_firewalld }}"
       state: present
     when: ipareplica_setup_firewalld | bool
@@ -30,20 +30,20 @@
 
 - block:
   - name: Firewalld service - Ensure that firewalld is running
-    systemd:
+    ansible.builtin.systemd:
       name: firewalld
       enabled: yes
       state: started
 
   - name: Firewalld - Verify runtime zone "{{ ipareplica_firewalld_zone }}"
-    shell: >
+    ansible.builtin.shell: >
       firewall-cmd
       --info-zone="{{ ipareplica_firewalld_zone }}"
       >/dev/null
     when: ipareplica_firewalld_zone is defined
 
   - name: Firewalld - Verify permanent zone "{{ ipareplica_firewalld_zone }}"
-    shell: >
+    ansible.builtin.shell: >
       firewall-cmd
       --permanent
       --info-zone="{{ ipareplica_firewalld_zone }}"
@@ -53,12 +53,12 @@
   when: ipareplica_setup_firewalld | bool
 
 - name: Install - Set ipareplica_servers
-  set_fact:
+  ansible.builtin.set_fact:
     ipareplica_servers: "{{ groups['ipaservers'] | list }}"
   when: groups.ipaservers is defined and ipareplica_servers is not defined
 
 - name: Install - Set default principal if no keytab is given
-  set_fact:
+  ansible.builtin.set_fact:
     ipaadmin_principal: admin
   when: ipaadmin_principal is undefined and ipaclient_keytab is undefined
 
@@ -108,7 +108,7 @@
   #      result_ipareplica_test.server_already_configured is defined)
 
   - name: Install - Setup client
-    include_role:
+    ansible.builtin.include_role:
       name: ipaclient
     vars:
       state: present
@@ -120,7 +120,7 @@
     when: not result_ipareplica_test.client_enrolled
 
   - name: Install - Configure firewalld
-    command: >
+    ansible.builtin.command: >
       firewall-cmd
       --permanent
       --zone="{{ ipareplica_firewalld_zone if ipareplica_firewalld_zone is
@@ -134,7 +134,7 @@
     when: ipareplica_setup_firewalld | bool
 
   - name: Install - Configure firewalld runtime
-    command: >
+    ansible.builtin.command: >
       firewall-cmd
       --zone="{{ ipareplica_firewalld_zone if ipareplica_firewalld_zone is
          defined else '' }}"
@@ -222,7 +222,7 @@
 
   - name: Install - Set dirman password
     no_log: yes
-    set_fact:
+    ansible.builtin.set_fact:
       ipareplica_dirman_password:
         "{{ result_ipareplica_master_password.password }}"
 
@@ -776,14 +776,14 @@
     register: result_ipareplica_enable_ipa
 
   - name: Install - Cleanup root IPA cache
-    file:
+    ansible.builtin.file:
       path: "/root/.ipa_cache"
       state: absent
     when: result_ipareplica_enable_ipa.changed
 
   always:
   - name: Cleanup temporary files
-    file:
+    ansible.builtin.file:
       path: "{{ item }}"
       state: absent
     with_items:

--- a/roles/ipareplica/tasks/main.yml
+++ b/roles/ipareplica/tasks/main.yml
@@ -2,7 +2,7 @@
 # tasks file for ipareplica
 
 - name: Import variables specific to distribution
-  include_vars: "{{ item }}"
+  ansible.builtin.include_vars: "{{ item }}"
   with_first_found:
     - "vars/{{ ansible_facts['distribution'] }}-{{ ansible_facts['distribution_version'] }}.yml"
     - "vars/{{ ansible_facts['distribution'] }}-{{ ansible_facts['distribution_major_version'] }}.yml"
@@ -17,9 +17,9 @@
     - "vars/default.yml"
 
 - name: Install IPA replica
-  include_tasks: install.yml
+  ansible.builtin.include_tasks: install.yml
   when: state|default('present') == 'present'
 
 - name: Uninstall IPA replica
-  include_tasks: uninstall.yml
+  ansible.builtin.include_tasks: uninstall.yml
   when: state|default('present') == 'absent'

--- a/roles/ipareplica/tasks/uninstall.yml
+++ b/roles/ipareplica/tasks/uninstall.yml
@@ -2,7 +2,7 @@
 # tasks to uninstall IPA replica
 
 - name: Uninstall - Uninstall IPA replica
-  command: >
+  ansible.builtin.command: >
     /usr/sbin/ipa-server-install
     --uninstall
     -U
@@ -22,7 +22,7 @@
   delay: 1
 
 #- name: Uninstall - Remove all replication agreements and data about replica
-#  command: >
+#  ansible.builtin.command: >
 #    /usr/sbin/ipa-replica-manage
 #    del
 #    {{ ipareplica_hostname | default(ansible_facts['fqdn']) }}
@@ -32,6 +32,6 @@
 #  delegate_to: "{{ groups.ipaserver[0] | default(fail) }}"
 
 #- name: Remove IPA replica packages
-#  package:
+#  ansible.builtin.package:
 #    name: "{{ ipareplica_packages }}"
 #    state: absent

--- a/roles/ipaserver/tasks/copy_external_cert.yml
+++ b/roles/ipaserver/tasks/copy_external_cert.yml
@@ -1,14 +1,14 @@
 ---
 - name: Install - Initialize ipaserver_external_cert_files
-  set_fact:
+  ansible.builtin.set_fact:
      ipaserver_external_cert_files: []
   when: ipaserver_external_cert_files is undefined
 - name: Install - Copy "{{ item }}" "{{ inventory_hostname }}':/root/'{{ item | basename }}"
-  copy:
+  ansible.builtin.copy:
     src: "{{ item }}"
     dest: "/root/{{ item | basename }}"
     mode: preserve
     force: yes
 - name: Install - Extend ipaserver_external_cert_files with "/root/{{ item | basename }}"
-  set_fact:
+  ansible.builtin.set_fact:
     ipaserver_external_cert_files: "{{ ipaserver_external_cert_files + [ '/root/' + (item | basename) ] }}"

--- a/roles/ipaserver/tasks/install.yml
+++ b/roles/ipaserver/tasks/install.yml
@@ -3,24 +3,24 @@
 
 - block:
   - name: Install - Ensure that IPA server packages are installed
-    package:
+    ansible.builtin.package:
       name: "{{ ipaserver_packages }}"
       state: present
 
   - name: Install - Ensure that IPA server packages for dns are installed
-    package:
+    ansible.builtin.package:
       name: "{{ ipaserver_packages_dns }}"
       state: present
     when: ipaserver_setup_dns | bool
 
   - name: Install - Ensure that IPA server packages for adtrust are installed
-    package:
+    ansible.builtin.package:
       name: "{{ ipaserver_packages_adtrust }}"
       state: present
     when: ipaserver_setup_adtrust | bool
 
   - name: Install - Ensure that firewall packages installed
-    package:
+    ansible.builtin.package:
       name: "{{ ipaserver_packages_firewalld }}"
       state: present
     when: ipaserver_setup_firewalld | bool
@@ -29,20 +29,20 @@
 
 - block:
   - name: Firewalld service - Ensure that firewalld is running
-    systemd:
+    ansible.builtin.systemd:
       name: firewalld
       enabled: yes
       state: started
 
   - name: Firewalld - Verify runtime zone "{{ ipaserver_firewalld_zone }}"
-    shell: >
+    ansible.builtin.shell: >
       firewall-cmd
       --info-zone="{{ ipaserver_firewalld_zone }}"
       >/dev/null
     when: ipaserver_firewalld_zone is defined
 
   - name: Firewalld - Verify permanent zone "{{ ipaserver_firewalld_zone }}"
-    shell: >
+    ansible.builtin.shell: >
       firewall-cmd
       --permanent
       --info-zone="{{ ipaserver_firewalld_zone }}"
@@ -51,7 +51,7 @@
 
   when: ipaserver_setup_firewalld | bool
 
-- include_tasks: "{{ role_path }}/tasks/copy_external_cert.yml"
+- ansible.builtin.include_tasks: "{{ role_path }}/tasks/copy_external_cert.yml"
   with_items: "{{ ipaserver_external_cert_files_from_controller }}"
   when: ipaserver_external_cert_files_from_controller is defined and
         ipaserver_external_cert_files_from_controller|length > 0 and
@@ -144,7 +144,7 @@
 
     - name: Install - Use new master password
       no_log: yes
-      set_fact:
+      ansible.builtin.set_fact:
         ipaserver_master_password:
           "{{ result_ipaserver_master_password.password }}"
 
@@ -308,7 +308,7 @@
     register: result_ipaserver_setup_ca
 
   - name: Copy /root/ipa.csr to "{{ inventory_hostname }}-ipa.csr"
-    fetch:
+    ansible.builtin.fetch:
       src: /root/ipa.csr
       dest: "{{ inventory_hostname }}-ipa.csr"
       flat: yes
@@ -416,7 +416,7 @@
         _dirsrv_pkcs12_info: "{{ result_ipaserver_test._dirsrv_pkcs12_info if result_ipaserver_test._dirsrv_pkcs12_info != None else omit }}"
 
     - name: Install - Setup client
-      include_role:
+      ansible.builtin.include_role:
         name: ipaclient
       vars:
         state: present
@@ -438,13 +438,13 @@
       register: result_ipaserver_enable_ipa
 
     - name: Install - Cleanup root IPA cache
-      file:
+      ansible.builtin.file:
         path: "/root/.ipa_cache"
         state: absent
       when: result_ipaserver_enable_ipa.changed
 
     - name: Install - Configure firewalld
-      command: >
+      ansible.builtin.command: >
         firewall-cmd
         --permanent
         --zone="{{ ipaserver_firewalld_zone if ipaserver_firewalld_zone is
@@ -458,7 +458,7 @@
       when: ipaserver_setup_firewalld | bool
 
     - name: Install - Configure firewalld runtime
-      command: >
+      ansible.builtin.command: >
         firewall-cmd
         --zone="{{ ipaserver_firewalld_zone if ipaserver_firewalld_zone is
            defined else '' }}"
@@ -474,7 +474,7 @@
 
   always:
   - name: Cleanup temporary files
-    file:
+    ansible.builtin.file:
       path: "{{ item }}"
       state: absent
     with_items:

--- a/roles/ipaserver/tasks/main.yml
+++ b/roles/ipaserver/tasks/main.yml
@@ -2,7 +2,7 @@
 # tasks file for ipaserver
 
 - name: Import variables specific to distribution
-  include_vars: "{{ item }}"
+  ansible.builtin.include_vars: "{{ item }}"
   with_first_found:
     - "vars/{{ ansible_facts['distribution'] }}-{{ ansible_facts['distribution_version'] }}.yml"
     - "vars/{{ ansible_facts['distribution'] }}-{{ ansible_facts['distribution_major_version'] }}.yml"
@@ -17,9 +17,9 @@
     - "vars/default.yml"
 
 - name: Install IPA server
-  include_tasks: install.yml
+  ansible.builtin.include_tasks: install.yml
   when: state|default('present') == 'present'
 
 - name: Uninstall IPA server
-  include_tasks: uninstall.yml
+  ansible.builtin.include_tasks: uninstall.yml
   when: state|default('present') == 'absent'

--- a/roles/ipaserver/tasks/uninstall.yml
+++ b/roles/ipaserver/tasks/uninstall.yml
@@ -2,7 +2,7 @@
 # tasks to uninstall IPA server
 
 - name: Uninstall - Uninstall IPA server
-  command: >
+  ansible.builtin.command: >
     /usr/sbin/ipa-server-install
     --uninstall
     -U
@@ -15,6 +15,6 @@
   changed_when: uninstall.rc == 0
 
 #- name: Remove IPA server packages
-#  package:
+#  ansible.builtin.package:
 #    name: "{{ ipaserver_packages }}"
 #    state: absent

--- a/tests/automember/test_automember_client_context.yml
+++ b/tests/automember/test_automember_client_context.yml
@@ -6,7 +6,7 @@
 
   tasks:
   - name: Include FreeIPA facts.
-    include_tasks: ../env_freeipa_facts.yml
+    ansible.builtin.include_tasks: ../env_freeipa_facts.yml
 
   # Test will only be executed if host is not a server.
   - name: Execute with server context in the client.
@@ -28,13 +28,13 @@
 # in upstream CI.
 
 - name: Test automember using client context, in client host.
-  import_playbook: test_automember.yml
+  ansible.builtin.import_playbook: test_automember.yml
   when: groups['ipaclients']
   vars:
     ipa_test_host: ipaclients
 
 - name: Test automember using client context, in server host.
-  import_playbook: test_automember.yml
+  ansible.builtin.import_playbook: test_automember.yml
   when: groups['ipaclients'] is not defined or not groups['ipaclients']
   vars:
     ipa_context: client

--- a/tests/automember/test_automember_orphans_removed.yml
+++ b/tests/automember/test_automember_orphans_removed.yml
@@ -8,7 +8,7 @@
   # SET FACTS
 
   - name: Get Domain from server name
-    set_fact:
+    ansible.builtin.set_fact:
       ipaserver_domain: "{{ ansible_facts['fqdn'].split('.')[1:] |
                             join ('.') }}"
     when: ipaserver_domain is not defined

--- a/tests/automember/test_automember_rebuilt.yml
+++ b/tests/automember/test_automember_rebuilt.yml
@@ -8,7 +8,7 @@
   # SET FACTS
 
   - name: Get Domain from server name
-    set_fact:
+    ansible.builtin.set_fact:
       ipaserver_domain: "{{ ansible_facts['fqdn'].split('.')[1:] |
                             join ('.') }}"
     when: ipaserver_domain is not defined

--- a/tests/automount/test_automountkey_client_context.yml
+++ b/tests/automount/test_automountkey_client_context.yml
@@ -6,7 +6,7 @@
 
   tasks:
   - name: Include FreeIPA facts.
-    include_tasks: ../env_freeipa_facts.yml
+    ansible.builtin.include_tasks: ../env_freeipa_facts.yml
 
   # Test will only be executed if host is not a server.
   - name: Execute with server context in the client.
@@ -29,13 +29,13 @@
 # in upstream CI.
 
 - name: Test automountlocation using client context, in client host.
-  import_playbook: test_automountkey.yml
+  ansible.builtin.import_playbook: test_automountkey.yml
   when: groups['ipaclients']
   vars:
     ipa_test_host: ipaclients
 
 - name: Test automountlocation using client context, in server host.
-  import_playbook: test_automountkey.yml
+  ansible.builtin.import_playbook: test_automountkey.yml
   when: groups['ipaclients'] is not defined or not groups['ipaclients']
   vars:
     ipa_context: client

--- a/tests/automount/test_automountlocation_client_context.yml
+++ b/tests/automount/test_automountlocation_client_context.yml
@@ -6,7 +6,7 @@
 
   tasks:
   - name: Include FreeIPA facts.
-    include_tasks: ../env_freeipa_facts.yml
+    ansible.builtin.include_tasks: ../env_freeipa_facts.yml
 
   # Test will only be executed if host is not a server.
   - name: Execute with server context in the client.
@@ -27,13 +27,13 @@
 # in upstream CI.
 
 - name: Test automountlocation using client context, in client host.
-  import_playbook: test_automountlocation.yml
+  ansible.builtin.import_playbook: test_automountlocation.yml
   when: groups['ipaclients']
   vars:
     ipa_test_host: ipaclients
 
 - name: Test automountlocation using client context, in server host.
-  import_playbook: test_automountlocation.yml
+  ansible.builtin.import_playbook: test_automountlocation.yml
   when: groups['ipaclients'] is not defined or not groups['ipaclients']
   vars:
     ipa_context: client

--- a/tests/automount/test_automountmap_client_context.yml
+++ b/tests/automount/test_automountmap_client_context.yml
@@ -6,7 +6,7 @@
 
   tasks:
   - name: Include FreeIPA facts.
-    include_tasks: ../env_freeipa_facts.yml
+    ansible.builtin.include_tasks: ../env_freeipa_facts.yml
 
   # Test will only be executed if host is not a server.
   - name: Execute with server context in the client.
@@ -28,13 +28,13 @@
 # in upstream CI.
 
 - name: Test automountmap using client context, in client host.
-  import_playbook: test_automountmap.yml
+  ansible.builtin.import_playbook: test_automountmap.yml
   when: groups['ipaclients']
   vars:
     ipa_test_host: ipaclients
 
 - name: Test automountmap using client context, in server host.
-  import_playbook: test_automountmap.yml
+  ansible.builtin.import_playbook: test_automountmap.yml
   when: groups['ipaclients'] is not defined or not groups['ipaclients']
   vars:
     ipa_context: client

--- a/tests/ca-less/clean_up_certificates.yml
+++ b/tests/ca-less/clean_up_certificates.yml
@@ -5,7 +5,7 @@
 
   tasks:
   - name: Run generate-certificates.sh
-    command: >
+    ansible.builtin.command: >
       /bin/bash
       generate-certificates.sh delete "{{ item }}"
     args:

--- a/tests/ca-less/install_replica_without_ca.yml
+++ b/tests/ca-less/install_replica_without_ca.yml
@@ -5,7 +5,7 @@
 
   tasks:
   - name: Run generate-certificates.sh
-    command: >
+    ansible.builtin.command: >
       /bin/bash
       generate-certificates.sh create
       "{{ groups.ipareplicas[0] }}"
@@ -40,18 +40,18 @@
 
   pre_tasks:
     - name: Remove "/root/ca-less-test"
-      file:
+      ansible.builtin.file:
         path: "/root/ca-less-test"
         state: absent
 
     - name: Generate "/root/ca-less-test"
-      file:
+      ansible.builtin.file:
         path: "/root/ca-less-test"
         state: directory
         mode: 0775
 
     - name: Copy CA certificate
-      copy:
+      ansible.builtin.copy:
         src: "{{ playbook_dir }}/certificates/root-ca/cert.pem"
         dest: "/root/ca-less-test/ca.crt"
         owner: root
@@ -59,7 +59,7 @@
         mode: "0644"
 
     - name: Copy p12 certificates
-      copy:
+      ansible.builtin.copy:
         src: "{{ playbook_dir }}/certificates/{{ item }}/{{ groups.ipareplicas[0] }}/cert.p12"
         dest: "/root/ca-less-test/{{ item }}.p12"
         owner: root
@@ -76,7 +76,7 @@
 
   post_tasks:
     - name: Fix KDC certificate permissions
-      file:
+      ansible.builtin.file:
         path: /var/kerberos/krb5kdc/kdc.crt
         owner: root
         group: root

--- a/tests/ca-less/install_server_without_ca.yml
+++ b/tests/ca-less/install_server_without_ca.yml
@@ -5,7 +5,7 @@
 
   tasks:
   - name: Run generate-certificates.sh
-    command: >
+    ansible.builtin.command: >
       /bin/bash
       generate-certificates.sh create
       "{{ groups.ipaserver[0] }}"
@@ -40,18 +40,18 @@
 
   pre_tasks:
     - name: Remove "/root/ca-less-test"
-      file:
+      ansible.builtin.file:
         path: "/root/ca-less-test"
         state: absent
 
     - name: Generate "/root/ca-less-test"
-      file:
+      ansible.builtin.file:
         path: "/root/ca-less-test"
         state: directory
         mode: 0775
 
     - name: Copy CA certificate
-      copy:
+      ansible.builtin.copy:
         src: "{{ playbook_dir }}/certificates/root-ca/cert.pem"
         dest: "/root/ca-less-test/ca.crt"
         owner: root
@@ -59,7 +59,7 @@
         mode: "0644"
 
     - name: Copy p12 certificates
-      copy:
+      ansible.builtin.copy:
         src: "{{ playbook_dir }}/certificates/{{ item }}/{{ groups.ipaserver[0] }}/cert.p12"
         dest: "/root/ca-less-test/{{ item }}.p12"
         owner: root

--- a/tests/config/test_config.yml
+++ b/tests/config/test_config.yml
@@ -5,7 +5,7 @@
   gather_facts: false
 
   tasks:
-  - include_tasks: ../env_freeipa_facts.yml
+  - ansible.builtin.include_tasks: ../env_freeipa_facts.yml
 
   - block:
       # Retrieve current configuration.
@@ -16,7 +16,7 @@
         register: previousconfig
 
       - name: Display current configuration.
-        debug:
+        ansible.builtin.debug:
           var: previousconfig
 
       # setup environment.
@@ -481,7 +481,7 @@
         register: result
 
       - name: "CA-Renewal server warning."
-        debug:
+        ansible.builtin.debug:
           msg: "Due to a test failure, IPA CA-Renewal Server might not be correctly be set. Check your configuration."
 
     always:

--- a/tests/config/test_config_client_context.yml
+++ b/tests/config/test_config_client_context.yml
@@ -6,7 +6,7 @@
 
   tasks:
   - name: Include FreeIPA facts.
-    include_tasks: ../env_freeipa_facts.yml
+    ansible.builtin.include_tasks: ../env_freeipa_facts.yml
 
   # Test will only be executed if host is not a server.
   - name: Execute with server context in the client.
@@ -26,13 +26,13 @@
 # in upstream CI.
 
 - name: Test config using client context, in client host.
-  import_playbook: test_config.yml
+  ansible.builtin.import_playbook: test_config.yml
   when: groups['ipaclients']
   vars:
     ipa_test_host: ipaclients
 
 - name: Test config using client context, in server host.
-  import_playbook: test_config.yml
+  ansible.builtin.import_playbook: test_config.yml
   when: groups['ipaclients'] is not defined or not groups['ipaclients']
   vars:
     ipa_context: client

--- a/tests/config/test_config_sid.yml
+++ b/tests/config/test_config_sid.yml
@@ -7,7 +7,7 @@
   tasks:
 
   - name: Set FreeIPA facts.
-    include_tasks: ../env_freeipa_facts.yml
+    ansible.builtin.include_tasks: ../env_freeipa_facts.yml
 
   # GET CURRENT CONFIG
 

--- a/tests/delegation/test_delegation_client_context.yml
+++ b/tests/delegation/test_delegation_client_context.yml
@@ -6,7 +6,7 @@
 
   tasks:
   - name: Include FreeIPA facts.
-    include_tasks: ../env_freeipa_facts.yml
+    ansible.builtin.include_tasks: ../env_freeipa_facts.yml
 
   # Test will only be executed if host is not a server.
   - name: Execute with server context in the client.
@@ -27,13 +27,13 @@
 # in upstream CI.
 
 - name: Test delegation using client context, in client host.
-  import_playbook: test_delegation.yml
+  ansible.builtin.import_playbook: test_delegation.yml
   when: groups['ipaclients']
   vars:
     ipa_test_host: ipaclients
 
 - name: Test delegation using client context, in server host.
-  import_playbook: test_delegation.yml
+  ansible.builtin.import_playbook: test_delegation.yml
   when: groups['ipaclients'] is not defined or not groups['ipaclients']
   vars:
     ipa_context: client

--- a/tests/dnsconfig/test_dnsconfig_client_context.yml
+++ b/tests/dnsconfig/test_dnsconfig_client_context.yml
@@ -6,7 +6,7 @@
 
   tasks:
   - name: Include FreeIPA facts.
-    include_tasks: ../env_freeipa_facts.yml
+    ansible.builtin.include_tasks: ../env_freeipa_facts.yml
 
   # Test will only be executed if host is not a server.
   - name: Execute with server context in the client.
@@ -27,13 +27,13 @@
 # in upstream CI.
 
 - name: Test dnsconfig using client context, in client host.
-  import_playbook: test_dnsconfig.yml
+  ansible.builtin.import_playbook: test_dnsconfig.yml
   when: groups['ipaclients']
   vars:
     ipa_test_host: ipaclients
 
 - name: Test dnsconfig using client context, in server host.
-  import_playbook: test_dnsconfig.yml
+  ansible.builtin.import_playbook: test_dnsconfig.yml
   when: groups['ipaclients'] is not defined or not groups['ipaclients']
   vars:
     ipa_context: client

--- a/tests/dnsforwardzone/test_dnsforwardzone_client_context.yml
+++ b/tests/dnsforwardzone/test_dnsforwardzone_client_context.yml
@@ -6,7 +6,7 @@
 
   tasks:
   - name: Include FreeIPA facts.
-    include_tasks: ../env_freeipa_facts.yml
+    ansible.builtin.include_tasks: ../env_freeipa_facts.yml
 
   # Test will only be executed if host is not a server.
   - name: Execute with server context in the client.
@@ -27,13 +27,13 @@
 # in upstream CI.
 
 - name: Test dnsforwardzone using client context, in client host.
-  import_playbook: test_dnsforwardzone.yml
+  ansible.builtin.import_playbook: test_dnsforwardzone.yml
   when: groups['ipaclients']
   vars:
     ipa_test_host: ipaclients
 
 - name: Test dnsforwardzone using client context, in server host.
-  import_playbook: test_dnsforwardzone.yml
+  ansible.builtin.import_playbook: test_dnsforwardzone.yml
   when: groups['ipaclients'] is not defined or not groups['ipaclients']
   vars:
     ipa_context: client

--- a/tests/dnsrecord/env_setup.yml
+++ b/tests/dnsrecord/env_setup.yml
@@ -1,10 +1,10 @@
 ---
   - name: Setup variables and facts.
-    include_tasks: env_vars.yml
+    ansible.builtin.include_tasks: env_vars.yml
 
   # Cleanup before setup.
   - name: Cleanup test environment.
-    include_tasks: env_cleanup.yml
+    ansible.builtin.include_tasks: env_cleanup.yml
 
   # Common setup tasks.
   - name: Ensure DNS testing zones are present.

--- a/tests/dnsrecord/env_vars.yml
+++ b/tests/dnsrecord/env_vars.yml
@@ -1,7 +1,7 @@
 ---
 # Set common vars and facts for test.
 - name: Set IPv4 address prefix.
-  set_fact:
+  ansible.builtin.set_fact:
     ipv4_prefix: "{{ ansible_facts['default_ipv4'].address.split('.')[:-1] |
                      join('.') }}"
     ipv4_reverse: "{{ ansible_facts['default_ipv4'].address.split('.')[:-1] |
@@ -9,7 +9,7 @@
                       join('.') }}"
 
 - name: Set zone prefixes.
-  set_fact:
+  ansible.builtin.set_fact:
     testzone: 'testzone.test'
     safezone: 'safezone.test'
     zone_ipv6_reverse: "ip6.arpa."

--- a/tests/dnsrecord/test_dnsrecord.yml
+++ b/tests/dnsrecord/test_dnsrecord.yml
@@ -7,10 +7,10 @@
   tasks:
 
   - name: Setup testing environment.
-    include_tasks: env_setup.yml
+    ansible.builtin.include_tasks: env_setup.yml
 
   - name: Generate self-signed certificates.
-    shell:
+    ansible.builtin.shell:
       cmd: |
         openssl req -x509 -newkey rsa:2048 -days 365 -nodes -keyout "private{{ item }}.key" -out "cert{{ item }}.pem" -subj '/CN=test'
         openssl x509 -outform der -in "cert{{ item }}.pem" -out "cert{{ item }}.der"
@@ -1547,7 +1547,7 @@
 
   # cleanup
   - name: Cleanup test environment.
-    include_tasks: env_cleanup.yml
+    ansible.builtin.include_tasks: env_cleanup.yml
 
   - name: Remove certificate files.  # noqa: deprecated-command-syntax
     ansible.builtin.shell: rm -f "private{{ item }}.key" "cert{{ item }}.pem" "cert{{ item }}.der" "cert{{ item }}.b64"

--- a/tests/dnsrecord/test_dnsrecord_client_context.yml
+++ b/tests/dnsrecord/test_dnsrecord_client_context.yml
@@ -6,7 +6,7 @@
 
   tasks:
   - name: Include FreeIPA facts.
-    include_tasks: ../env_freeipa_facts.yml
+    ansible.builtin.include_tasks: ../env_freeipa_facts.yml
 
   # Test will only be executed if host is not a server.
   - name: Execute with server context in the client.
@@ -27,13 +27,13 @@
 # in upstream CI.
 
 - name: Test dnsrecord using client context, in client host.
-  import_playbook: test_dnsrecord.yml
+  ansible.builtin.import_playbook: test_dnsrecord.yml
   when: groups['ipaclients']
   vars:
     ipa_test_host: ipaclients
 
 - name: Test dnsrecord using client context, in server host.
-  import_playbook: test_dnsrecord.yml
+  ansible.builtin.import_playbook: test_dnsrecord.yml
   when: groups['ipaclients'] is not defined or not groups['ipaclients']
   vars:
     ipa_context: client

--- a/tests/dnsrecord/test_dnsrecord_full_records.yml
+++ b/tests/dnsrecord/test_dnsrecord_full_records.yml
@@ -7,7 +7,7 @@
   tasks:
 
   - name: Setup test environment
-    include_tasks: env_setup.yml
+    ansible.builtin.include_tasks: env_setup.yml
 
   # tests
 
@@ -147,4 +147,4 @@
 
   # Cleanup
   - name: Cleanup test environment.
-    include_tasks: env_cleanup.yml
+    ansible.builtin.include_tasks: env_cleanup.yml

--- a/tests/dnsrecord/test_dnsrecord_modify_record.yml
+++ b/tests/dnsrecord/test_dnsrecord_modify_record.yml
@@ -6,7 +6,7 @@
 
   tasks:
   - name: Setup testing environment.
-    include_tasks: env_setup.yml
+    ansible.builtin.include_tasks: env_setup.yml
 
   - name: Add test host.
     ipahost:
@@ -177,4 +177,4 @@
       state: absent
   # cleanup
   - name: Cleanup test environment.
-    include_tasks: env_cleanup.yml
+    ansible.builtin.include_tasks: env_cleanup.yml

--- a/tests/dnszone/env_setup.yml
+++ b/tests/dnszone/env_setup.yml
@@ -1,3 +1,3 @@
 ---
 - name: Cleanup test environment.
-  include_tasks: env_cleanup.yml
+  ansible.builtin.include_tasks: env_cleanup.yml

--- a/tests/dnszone/env_teardown.yml
+++ b/tests/dnszone/env_teardown.yml
@@ -1,3 +1,3 @@
 ---
 - name: Cleanup test environment.
-  include_tasks: env_cleanup.yml
+  ansible.builtin.include_tasks: env_cleanup.yml

--- a/tests/dnszone/test_dnszone.yml
+++ b/tests/dnszone/test_dnszone.yml
@@ -8,7 +8,7 @@
 
   # Setup
   - name: Setup testing environment
-    include_tasks: env_setup.yml
+    ansible.builtin.include_tasks: env_setup.yml
 
   # Tests
   - name: Check if zone is present, when in shouldn't be.
@@ -267,4 +267,4 @@
 
   # Teardown
   - name: Teardown testing environment
-    include_tasks: env_teardown.yml
+    ansible.builtin.include_tasks: env_teardown.yml

--- a/tests/dnszone/test_dnszone_client_context.yml
+++ b/tests/dnszone/test_dnszone_client_context.yml
@@ -6,7 +6,7 @@
 
   tasks:
   - name: Include FreeIPA facts.
-    include_tasks: ../env_freeipa_facts.yml
+    ansible.builtin.include_tasks: ../env_freeipa_facts.yml
 
   # Test will only be executed if host is not a server.
   - name: Execute with server context in the client.
@@ -27,13 +27,13 @@
 # in upstream CI.
 
 - name: Test dnszone using client context, in client host.
-  import_playbook: test_dnszone.yml
+  ansible.builtin.import_playbook: test_dnszone.yml
   when: groups['ipaclients']
   vars:
     ipa_test_host: ipaclients
 
 - name: Test dnszone using client context, in server host.
-  import_playbook: test_dnszone.yml
+  ansible.builtin.import_playbook: test_dnszone.yml
   when: groups['ipaclients'] is not defined or not groups['ipaclients']
   vars:
     ipa_context: client

--- a/tests/dnszone/test_dnszone_mod.yml
+++ b/tests/dnszone/test_dnszone_mod.yml
@@ -8,7 +8,7 @@
 
   # Setup
   - name: Setup testing environment
-    include_tasks: env_setup.yml
+    ansible.builtin.include_tasks: env_setup.yml
 
   - name: Ensure zone is present.
     ipadnszone:
@@ -291,4 +291,4 @@
 
   # Teardown
   - name: Teardown testing environment
-    include_tasks: env_teardown.yml
+    ansible.builtin.include_tasks: env_teardown.yml

--- a/tests/dnszone/test_dnszone_name_from_ip.yml
+++ b/tests/dnszone/test_dnszone_name_from_ip.yml
@@ -8,7 +8,7 @@
 
   # Setup
   - name: Setup testing environment
-    include_tasks: env_setup.yml
+    ansible.builtin.include_tasks: env_setup.yml
 
   # Tests
   - name: Ensure zone exists for reverse IP.
@@ -55,7 +55,7 @@
     register: ipv6_zone
     failed_when: not ipv6_zone.changed or ipv6_zone.failed
 
-  # - debug:
+  # - ansible.builtin.debug:
   #     msg: "{{ipv6_zone}}"
 
   - name: Ensure ipv6 zone was created.
@@ -95,4 +95,4 @@
 
   # Teardown
   - name: Teardown testing environment
-    include_tasks: env_teardown.yml
+    ansible.builtin.include_tasks: env_teardown.yml

--- a/tests/env_freeipa_facts.yml
+++ b/tests/env_freeipa_facts.yml
@@ -8,12 +8,12 @@
 #
 ---
 - name: Retrieving FreeIPA version.
-  shell:
+  ansible.builtin.shell:
     cmd: 'ipa --version | sed -n "s/VERSION: \([^,]*\).*API_VERSION: \([^,]*\).*/\1\\n\2/p"'
   register: ipa_cmd_version
 
 - name: Verify if host is an IPA server or client.
-  shell:
+  ansible.builtin.shell:
     cmd: |
       echo SomeADMINpassword | kinit -c {{ krb5ccname }} admin
       RESULT=$(KRB5CCNAME={{ krb5ccname }} ipa server-show `hostname` && echo SERVER || echo CLIENT)
@@ -24,7 +24,7 @@
   register: output
 
 - name: Set FreeIPA facts.
-  set_fact:
+  ansible.builtin.set_fact:
     ipa_version: "{{ ipa_cmd_version.stdout_lines[0] }}"
     ipa_api_version: "{{ ipa_cmd_version.stdout_lines[1] }}"
     ipa_host_is_client: "{{ (output.stdout_lines[-1] == 'CLIENT') | bool }}"
@@ -32,12 +32,12 @@
 
 - block:
   - name: Get Domain from server name
-    set_fact:
+    ansible.builtin.set_fact:
       ipaserver_domain: "{{ ansible_facts['fqdn'].split('.')[1:] | join ('.') }}"
     when: "'fqdn' in ansible_facts"
 
   - name: Set Domain to 'ipa.test' if FQDN could not be retrieved.
-    set_fact:
+    ansible.builtin.set_fact:
       ipaserver_domain: "ipa.test"
     when: "'fqdn' not in ansible_facts"
   when: ipaserver_domain is not defined

--- a/tests/external-signed-ca-with-automatic-copy/install-server-with-external-ca-with-automatic-copy.yml
+++ b/tests/external-signed-ca-with-automatic-copy/install-server-with-external-ca-with-automatic-copy.yml
@@ -15,7 +15,7 @@
 
   tasks:
   - name: Run external-ca.sh
-    command: >
+    ansible.builtin.command: >
       /bin/bash
       external-ca.sh
       "{{ groups.ipaserver[0] }}"

--- a/tests/external-signed-ca-with-manual-copy/install-server-with-external-ca-with-manual-copy.yml
+++ b/tests/external-signed-ca-with-manual-copy/install-server-with-external-ca-with-manual-copy.yml
@@ -11,7 +11,7 @@
 
   post_tasks:
   - name: Copy CSR /root/ipa.csr from node to "{{ groups.ipaserver[0] + '-ipa.csr' }}"
-    fetch:
+    ansible.builtin.fetch:
       src: /root/ipa.csr
       dest: "{{ groups.ipaserver[0] + '-ipa.csr' }}"
       flat: yes
@@ -21,7 +21,7 @@
 
   tasks:
   - name: Run external-ca.sh
-    command: >
+    ansible.builtin.command: >
       /bin/bash
       external-ca.sh
       "{{ groups.ipaserver[0] }}"
@@ -38,7 +38,7 @@
 
   pre_tasks:
   - name: Copy "{{ groups.ipaserver[0] + '-chain.crt' }}" to /root/chain.crt on node
-    copy:
+    ansible.builtin.copy:
       src: "{{ groups.ipaserver[0] + '-chain.crt' }}"
       dest: "/root/chain.crt"
       force: yes

--- a/tests/group/test_group.yml
+++ b/tests/group/test_group.yml
@@ -6,12 +6,12 @@
 
   tasks:
   # setup
-  - include_tasks: ../env_freeipa_facts.yml
+  - ansible.builtin.include_tasks: ../env_freeipa_facts.yml
 
   # GET FQDN_AT_DOMAIN
 
   - name: Get fqdn_at_domain
-    set_fact:
+    ansible.builtin.set_fact:
       fqdn_at_domain: "{{ ansible_facts['fqdn'] + '@' + ipaserver_realm }}"
 
   # CLEANUP TEST ITEMS

--- a/tests/group/test_group_client_context.yml
+++ b/tests/group/test_group_client_context.yml
@@ -6,7 +6,7 @@
 
   tasks:
   - name: Include FreeIPA facts.
-    include_tasks: ../env_freeipa_facts.yml
+    ansible.builtin.include_tasks: ../env_freeipa_facts.yml
 
   # Test will only be executed if host is not a server.
   - name: Execute with server context in the client.
@@ -27,13 +27,13 @@
 # in upstream CI.
 
 - name: Test group using client context, in client host.
-  import_playbook: test_group.yml
+  ansible.builtin.import_playbook: test_group.yml
   when: groups['ipaclients']
   vars:
     ipa_test_host: ipaclients
 
 - name: Test group using client context, in server host.
-  import_playbook: test_group.yml
+  ansible.builtin.import_playbook: test_group.yml
   when: groups['ipaclients'] is not defined or not groups['ipaclients']
   vars:
     ipa_context: client

--- a/tests/group/test_group_external_members.yml
+++ b/tests/group/test_group_external_members.yml
@@ -6,7 +6,7 @@
 
   tasks:
 
-  - include_tasks: ../env_freeipa_facts.yml
+  - ansible.builtin.include_tasks: ../env_freeipa_facts.yml
 
   - block:
 

--- a/tests/group/test_group_idoverrideuser.yml
+++ b/tests/group/test_group_idoverrideuser.yml
@@ -9,11 +9,11 @@
       ad_domain: "{{ test_ad_domain | default('ad.ipa.test') }}"
 
   tasks:
-    - include_tasks: ../env_freeipa_facts.yml
+    - ansible.builtin.include_tasks: ../env_freeipa_facts.yml
 
     - block:
       - name: Create idoverrideuser.
-        shell: |
+        ansible.builtin.shell: |
           kinit -c idoverride_cache admin <<< SomeADMINpassword
           ipa idoverrideuser-add "Default Trust View" {{ ad_user }}
           kdestroy -A -q -c idoverride_cache
@@ -95,7 +95,7 @@
 
       always:
       - name: Remove idoverrideuser.
-        shell: |
+        ansible.builtin.shell: |
           kinit -c idoverride_cache admin <<< SomeADMINpassword
           ipa idoverrideuser-del "Default Trust View" {{ ad_user }}
           kdestroy -A -q -c idoverride_cache

--- a/tests/group/test_group_membermanager.yml
+++ b/tests/group/test_group_membermanager.yml
@@ -5,7 +5,7 @@
   gather_facts: false
 
   tasks:
-  - include_tasks: ../env_freeipa_facts.yml
+  - ansible.builtin.include_tasks: ../env_freeipa_facts.yml
 
   - name: Tests requiring IPA version 4.8.4+
     block:

--- a/tests/hbacrule/test_hbacrule.yml
+++ b/tests/hbacrule/test_hbacrule.yml
@@ -5,7 +5,7 @@
 
   tasks:
   - name: Get Domain from server name
-    set_fact:
+    ansible.builtin.set_fact:
       ipaserver_domain: "{{ ansible_facts['fqdn'].split('.')[1:] | join ('.') }}"
     when: ipaserver_domain is not defined
 

--- a/tests/hbacrule/test_hbacrule_client_context.yml
+++ b/tests/hbacrule/test_hbacrule_client_context.yml
@@ -6,7 +6,7 @@
 
   tasks:
   - name: Include FreeIPA facts.
-    include_tasks: ../env_freeipa_facts.yml
+    ansible.builtin.include_tasks: ../env_freeipa_facts.yml
 
   # Test will only be executed if host is not a server.
   - name: Execute with server context in the client.
@@ -27,13 +27,13 @@
 # in upstream CI.
 
 - name: Test hbacrule using client context, in client host.
-  import_playbook: test_hbacrule.yml
+  ansible.builtin.import_playbook: test_hbacrule.yml
   when: groups['ipaclients']
   vars:
     ipa_test_host: ipaclients
 
 - name: Test hbacrule using client context, in server host.
-  import_playbook: test_hbacrule.yml
+  ansible.builtin.import_playbook: test_hbacrule.yml
   when: groups['ipaclients'] is not defined or not groups['ipaclients']
   vars:
     ipa_context: client

--- a/tests/hbacrule/test_hbacrule_member_case_insensitive.yml
+++ b/tests/hbacrule/test_hbacrule_member_case_insensitive.yml
@@ -25,7 +25,7 @@
       - sVCgrOUp1
 
   tasks:
-  - include_tasks: ../env_freeipa_facts.yml
+  - ansible.builtin.include_tasks: ../env_freeipa_facts.yml
 
   - block:
       # setup

--- a/tests/hbacrule/test_hbacrule_member_empty.yml
+++ b/tests/hbacrule/test_hbacrule_member_empty.yml
@@ -5,7 +5,7 @@
 
   tasks:
   - name: Get Domain from server name
-    set_fact:
+    ansible.builtin.set_fact:
       ipaserver_domain: "{{ ansible_facts['fqdn'].split('.')[1:] | join ('.') }}"
     when: ipaserver_domain is not defined
 

--- a/tests/hbacsvc/test_hbacsvc_client_context.yml
+++ b/tests/hbacsvc/test_hbacsvc_client_context.yml
@@ -6,7 +6,7 @@
 
   tasks:
   - name: Include FreeIPA facts.
-    include_tasks: ../env_freeipa_facts.yml
+    ansible.builtin.include_tasks: ../env_freeipa_facts.yml
 
   # Test will only be executed if host is not a server.
   - name: Execute with server context in the client.
@@ -27,13 +27,13 @@
 # in upstream CI.
 
 - name: Test hbacsvc using client context, in client host.
-  import_playbook: test_hbacsvc.yml
+  ansible.builtin.import_playbook: test_hbacsvc.yml
   when: groups['ipaclients']
   vars:
     ipa_test_host: ipaclients
 
 - name: Test hbacsvc using client context, in server host.
-  import_playbook: test_hbacsvc.yml
+  ansible.builtin.import_playbook: test_hbacsvc.yml
   when: groups['ipaclients'] is not defined or not groups['ipaclients']
   vars:
     ipa_context: client

--- a/tests/hbacsvcgroup/test_hbacsvcgroup_client_context.yml
+++ b/tests/hbacsvcgroup/test_hbacsvcgroup_client_context.yml
@@ -6,7 +6,7 @@
 
   tasks:
   - name: Include FreeIPA facts.
-    include_tasks: ../env_freeipa_facts.yml
+    ansible.builtin.include_tasks: ../env_freeipa_facts.yml
 
   # Test will only be executed if host is not a server.
   - name: Execute with server context in the client.
@@ -27,13 +27,13 @@
 # in upstream CI.
 
 - name: Test hbacsvcgroup using client context, in client host.
-  import_playbook: test_hbacsvcgroup.yml
+  ansible.builtin.import_playbook: test_hbacsvcgroup.yml
   when: groups['ipaclients']
   vars:
     ipa_test_host: ipaclients
 
 - name: Test hbacsvcgroup using client context, in server host.
-  import_playbook: test_hbacsvcgroup.yml
+  ansible.builtin.import_playbook: test_hbacsvcgroup.yml
   when: groups['ipaclients'] is not defined or not groups['ipaclients']
   vars:
     ipa_context: client

--- a/tests/host/certificate/test_host_certificate.yml
+++ b/tests/host/certificate/test_host_certificate.yml
@@ -5,12 +5,12 @@
 
   tasks:
   - name: Get Domain from server name
-    set_fact:
+    ansible.builtin.set_fact:
       ipaserver_domain: "{{ ansible_facts['fqdn'].split('.')[1:] | join ('.') }}"
     when: ipaserver_domain is not defined
 
   - name: Generate self-signed certificates.
-    shell:
+    ansible.builtin.shell:
       cmd: |
         openssl req -x509 -newkey rsa:2048 -days 365 -nodes -keyout "private{{ item }}.key" -out "cert{{ item }}.pem" -subj '/CN=test'
         openssl x509 -outform der -in "cert{{ item }}.pem" -out "cert{{ item }}.der"
@@ -100,7 +100,7 @@
     failed_when: result.changed or result.failed
 
   - name: Remove certificate files.  # noqa: deprecated-command-syntax
-    shell:
+    ansible.builtin.shell:
       cmd: rm -f "private{{ item }}.key" "cert{{ item }}.pem" "cert{{ item }}.der" "cert{{ item }}.b64"
     with_items: [1, 2, 3]
     become: no

--- a/tests/host/certificate/test_hosts_certificate.yml
+++ b/tests/host/certificate/test_hosts_certificate.yml
@@ -5,7 +5,7 @@
 
   tasks:
   - name: Get Domain from server name
-    set_fact:
+    ansible.builtin.set_fact:
       ipaserver_domain: "{{ ansible_facts['fqdn'].split('.')[1:] | join ('.') }}"
     when: ipaserver_domain is not defined
 
@@ -26,7 +26,7 @@
     failed_when: not result.changed or result.failed
 
   - name: Generate self-signed certificates.
-    shell:
+    ansible.builtin.shell:
       cmd: |
         openssl req -x509 -newkey rsa:2048 -days 365 -nodes -keyout "private{{ item }}.key" -out "cert{{ item }}.pem" -subj '/CN=test'
         openssl x509 -outform der -in "cert{{ item }}.pem" -out "cert{{ item }}.der"
@@ -99,7 +99,7 @@
     failed_when: not result.changed or result.failed
 
   - name: Remove certificate files.  # noqa: deprecated-command-syntax
-    shell:
+    ansible.builtin.shell:
       cmd: rm -f "private{{ item }}.key" "cert{{ item }}.pem" "cert{{ item }}.der" "cert{{ item }}.b64"
     with_items: [1, 2, 3]
     become: no

--- a/tests/host/test_host.yml
+++ b/tests/host/test_host.yml
@@ -5,12 +5,12 @@
 
   tasks:
   - name: Get Domain from server name
-    set_fact:
+    ansible.builtin.set_fact:
       ipaserver_domain: "{{ ansible_facts['fqdn'].split('.')[1:] | join ('.') }}"
     when: ipaserver_domain is not defined
 
   - name: Set host1_fqdn .. host6_fqdn
-    set_fact:
+    ansible.builtin.set_fact:
       host1_fqdn: "{{ 'host1.' + ipaserver_domain }}"
       host2_fqdn: "{{ 'host2.' + ipaserver_domain }}"
       host3_fqdn: "{{ 'host3.' + ipaserver_domain }}"
@@ -33,7 +33,7 @@
       state: absent
 
   - name: Get IPv4 address prefix from server node
-    set_fact:
+    ansible.builtin.set_fact:
       ipv4_prefix: "{{ ansible_facts['default_ipv4'].address.split('.')[:-1] |
                        join('.') }}"
 

--- a/tests/host/test_host_allow_create_keytab.yml
+++ b/tests/host/test_host_allow_create_keytab.yml
@@ -5,17 +5,17 @@
 
   tasks:
   - name: Get Domain from server name
-    set_fact:
+    ansible.builtin.set_fact:
       ipaserver_domain: "{{ ansible_facts['fqdn'].split('.')[1:] | join ('.') }}"
     when: ipaserver_domain is not defined
 
   - name: Get Realm from server name
-    set_fact:
+    ansible.builtin.set_fact:
       ipaserver_realm: "{{ ansible_facts['fqdn'].split('.')[1:] | join ('.') | upper }}"
     when: ipaserver_realm is not defined
 
   - name: Set host1_fqdn .. host3_fqdn
-    set_fact:
+    ansible.builtin.set_fact:
       host1_fqdn: "{{ 'host1.' + ipaserver_domain }}"
       host2_fqdn: "{{ 'host2.' + ipaserver_domain }}"
       host3_fqdn: "{{ 'host3.' + ipaserver_domain }}"

--- a/tests/host/test_host_allow_retrieve_keytab.yml
+++ b/tests/host/test_host_allow_retrieve_keytab.yml
@@ -5,17 +5,17 @@
 
   tasks:
   - name: Get Domain from server name
-    set_fact:
+    ansible.builtin.set_fact:
       ipaserver_domain: "{{ ansible_facts['fqdn'].split('.')[1:] | join ('.') }}"
     when: ipaserver_domain is not defined
 
   - name: Get Realm from server name
-    set_fact:
+    ansible.builtin.set_fact:
       ipaserver_realm: "{{ ansible_facts['fqdn'].split('.')[1:] | join ('.') | upper }}"
     when: ipaserver_realm is not defined
 
   - name: Set host1_fqdn .. host3_fqdn
-    set_fact:
+    ansible.builtin.set_fact:
       host1_fqdn: "{{ 'host1.' + ipaserver_domain }}"
       host2_fqdn: "{{ 'host2.' + ipaserver_domain }}"
       host3_fqdn: "{{ 'host3.' + ipaserver_domain }}"

--- a/tests/host/test_host_bool_params.yml
+++ b/tests/host/test_host_bool_params.yml
@@ -5,12 +5,12 @@
 
   tasks:
   - name: Get Domain from server name
-    set_fact:
+    ansible.builtin.set_fact:
       ipaserver_domain: "{{ ansible_facts['fqdn'].split('.')[1:] | join ('.') }}"
     when: ipaserver_domain is not defined
 
   - name: Set host1_fqdn .. host6_fqdn
-    set_fact:
+    ansible.builtin.set_fact:
       host1_fqdn: "{{ 'host1.' + ipaserver_domain }}"
 
   - name: Host absent

--- a/tests/host/test_host_client_context.yml
+++ b/tests/host/test_host_client_context.yml
@@ -6,7 +6,7 @@
 
   tasks:
   - name: Include FreeIPA facts.
-    include_tasks: ../env_freeipa_facts.yml
+    ansible.builtin.include_tasks: ../env_freeipa_facts.yml
 
   # Test will only be executed if host is not a server.
   - name: Execute with server context in the client.
@@ -27,13 +27,13 @@
 # in upstream CI.
 
 - name: Test automember using client context, in client host.
-  import_playbook: test_host.yml
+  ansible.builtin.import_playbook: test_host.yml
   when: groups['ipaclients']
   vars:
     ipa_test_host: ipaclients
 
 - name: Test automember using client context, in server host.
-  import_playbook: test_host.yml
+  ansible.builtin.import_playbook: test_host.yml
   when: groups['ipaclients'] is not defined or not groups['ipaclients']
   vars:
     ipa_context: client

--- a/tests/host/test_host_empty_string_params.yml
+++ b/tests/host/test_host_empty_string_params.yml
@@ -6,12 +6,12 @@
 
   tasks:
   - name: Get Domain from server name
-    set_fact:
+    ansible.builtin.set_fact:
       ipaserver_domain: "{{ ansible_facts['fqdn'].split('.')[1:] | join ('.') }}"
     when: ipaserver_domain is not defined
 
   - name: Set host1_fqdn .. host6_fqdn
-    set_fact:
+    ansible.builtin.set_fact:
       host1_fqdn: "{{ 'host1.' + ipaserver_domain }}"
 
   # CLEANUP TEST ITEMS

--- a/tests/host/test_host_ipaddresses.yml
+++ b/tests/host/test_host_ipaddresses.yml
@@ -5,18 +5,18 @@
 
   tasks:
   - name: Get Domain from server name
-    set_fact:
+    ansible.builtin.set_fact:
       ipaserver_domain: "{{ ansible_facts['fqdn'].split('.')[1:] | join ('.') }}"
     when: ipaserver_domain is not defined
 
   - name: Set host1_fqdn .. host6_fqdn
-    set_fact:
+    ansible.builtin.set_fact:
       host1_fqdn: "{{ 'host1.' + ipaserver_domain }}"
       host2_fqdn: "{{ 'host2.' + ipaserver_domain }}"
       host3_fqdn: "{{ 'host3.' + ipaserver_domain }}"
 
   - name: Get IPv4 address prefix from server node
-    set_fact:
+    ansible.builtin.set_fact:
       ipv4_prefix: "{{ ansible_facts['default_ipv4'].address.split('.')[:-1] |
                        join('.') }}"
 

--- a/tests/host/test_host_managedby_host.yml
+++ b/tests/host/test_host_managedby_host.yml
@@ -5,12 +5,12 @@
 
   tasks:
   - name: Get Domain from server name
-    set_fact:
+    ansible.builtin.set_fact:
       ipaserver_domain: "{{ ansible_facts['fqdn'].split('.')[1:] | join ('.') }}"
     when: ipaserver_domain is not defined
 
   - name: Set host1_fqdn .. host2_fqdn
-    set_fact:
+    ansible.builtin.set_fact:
       host1_fqdn: "{{ 'host1.' + ipaserver_domain }}"
       host2_fqdn: "{{ 'host2.' + ipaserver_domain }}"
 

--- a/tests/host/test_host_principal.yml
+++ b/tests/host/test_host_principal.yml
@@ -5,17 +5,17 @@
 
   tasks:
   - name: Get Domain from server name
-    set_fact:
+    ansible.builtin.set_fact:
       ipaserver_domain: "{{ ansible_facts['fqdn'].split('.')[1:] | join ('.') }}"
     when: ipaserver_domain is not defined
 
   - name: Get Realm from server name
-    set_fact:
+    ansible.builtin.set_fact:
       ipaserver_realm: "{{ ansible_facts['fqdn'].split('.')[1:] | join ('.') | upper }}"
     when: ipaserver_realm is not defined
 
   - name: Set host1_fqdn
-    set_fact:
+    ansible.builtin.set_fact:
       host1_fqdn: "{{ 'host1.' + ipaserver_domain }}"
 
   - name: Host host1 absent

--- a/tests/host/test_host_random.yml
+++ b/tests/host/test_host_random.yml
@@ -5,12 +5,12 @@
 
   tasks:
   - name: Get Domain from server name
-    set_fact:
+    ansible.builtin.set_fact:
       ipaserver_domain: "{{ ansible_facts['fqdn'].split('.')[1:] | join ('.') }}"
     when: ipaserver_domain is not defined
 
   - name: Set host1_fqdn and host2_fqdn
-    set_fact:
+    ansible.builtin.set_fact:
       host1_fqdn: "{{ 'host1.' + ipaserver_domain }}"
       host2_fqdn: "{{ 'host2.' + ipaserver_domain }}"
 
@@ -34,12 +34,12 @@
     failed_when: not ipahost.changed or ipahost.failed
 
   - name: Assert ipahost.host.randompassword is defined.
-    assert:
+    ansible.builtin.assert:
       that:
       - ipahost.host.randompassword is defined
 
   - name: Print generated random password
-    debug:
+    ansible.builtin.debug:
       var: ipahost.host.randompassword
 
   - name: Host "{{ host1_fqdn }}" absent
@@ -64,7 +64,7 @@
     failed_when: not ipahost.changed or ipahost.failed
 
   - name: Assert randompassword is defined for host1 and host2.
-    assert:
+    ansible.builtin.assert:
       that:
       - ipahost.host["{{ host1_fqdn }}"].randompassword is
         defined
@@ -72,11 +72,11 @@
         defined
 
   - name: Print generated random password for "{{ host1_fqdn }}"
-    debug:
+    ansible.builtin.debug:
       var: ipahost.host["{{ host1_fqdn }}"].randompassword
 
   - name: Print generated random password for "{{ host2_fqdn }}"
-    debug:
+    ansible.builtin.debug:
       var: ipahost.host["{{ host2_fqdn }}"].randompassword
 
   - name: Enrolled host "{{ ansible_facts['fqdn'] }}" fails to set random password with update_password always
@@ -90,7 +90,7 @@
     failed_when: ipahost.changed or not ipahost.failed
 
   - name: Assert randompassword is not defined for 'ansible_fqdn'.
-    assert:
+    ansible.builtin.assert:
       that:
       - ipahost.host["{{ ansible_facts['fqdn'] }}"].randompassword is
         not defined

--- a/tests/host/test_host_reverse.yml
+++ b/tests/host/test_host_reverse.yml
@@ -5,12 +5,12 @@
 
   tasks:
   - name: Get Domain from server name
-    set_fact:
+    ansible.builtin.set_fact:
       ipaserver_domain: "{{ ansible_facts['fqdn'].split('.')[1:] | join ('.') }}"
     when: ipaserver_domain is not defined
 
   - name: Set host1_fqdn
-    set_fact:
+    ansible.builtin.set_fact:
       host1_fqdn: "{{ 'host1.' + ipaserver_domain }}"
 
   - name: Host absent
@@ -22,12 +22,12 @@
       state: absent
 
   - name: Get IPv4 address prefix from server node
-    set_fact:
+    ansible.builtin.set_fact:
       ipv4_prefix: "{{ ansible_facts['default_ipv4'].address.split('.')[:-1] |
                        join('.') }}"
 
   - name: Set zone prefixes.
-    set_fact:
+    ansible.builtin.set_fact:
       zone_ipv6_reverse: "ip6.arpa."
       zone_ipv6_reverse_workaround: "d.f.ip6.arpa."
       zone_prefix_reverse: "in-addr.arpa"

--- a/tests/host/test_host_sshpubkey.yml
+++ b/tests/host/test_host_sshpubkey.yml
@@ -5,12 +5,12 @@
 
   tasks:
   - name: Get Domain from server name
-    set_fact:
+    ansible.builtin.set_fact:
       ipaserver_domain: "{{ ansible_facts['fqdn'].split('.')[1:] | join ('.') }}"
     when: ipaserver_domain is not defined
 
   - name: Set host1_fqdn
-    set_fact:
+    ansible.builtin.set_fact:
       host1_fqdn: "{{ 'host1.' + ipaserver_domain }}"
 
   - name: Host host1 absent

--- a/tests/host/test_hosts.yml
+++ b/tests/host/test_hosts.yml
@@ -5,12 +5,12 @@
 
   tasks:
   - name: Get Domain from server name
-    set_fact:
+    ansible.builtin.set_fact:
       ipaserver_domain: "{{ ansible_facts['fqdn'].split('.')[1:] | join ('.') }}"
     when: ipaserver_domain is not defined
 
   - name: Set host1_fqdn .. host6_fqdn
-    set_fact:
+    ansible.builtin.set_fact:
       host1_fqdn: "{{ 'host1.' + ipaserver_domain }}"
       host2_fqdn: "{{ 'host2.' + ipaserver_domain }}"
       host3_fqdn: "{{ 'host3.' + ipaserver_domain }}"

--- a/tests/host/test_hosts_managedby_host.yml
+++ b/tests/host/test_hosts_managedby_host.yml
@@ -5,12 +5,12 @@
 
   tasks:
   - name: Get Domain from server name
-    set_fact:
+    ansible.builtin.set_fact:
       ipaserver_domain: "{{ ansible_facts['fqdn'].split('.')[1:] | join ('.') }}"
     when: ipaserver_domain is not defined
 
   - name: Set host1_fqdn .. host5_fqdn
-    set_fact:
+    ansible.builtin.set_fact:
       host1_fqdn: "{{ 'host1.' + ipaserver_domain }}"
       host2_fqdn: "{{ 'host2.' + ipaserver_domain }}"
       host3_fqdn: "{{ 'host3.' + ipaserver_domain }}"

--- a/tests/host/test_hosts_principal.yml
+++ b/tests/host/test_hosts_principal.yml
@@ -5,17 +5,17 @@
 
   tasks:
   - name: Get Domain from server name
-    set_fact:
+    ansible.builtin.set_fact:
       ipaserver_domain: "{{ ansible_facts['fqdn'].split('.')[1:] | join ('.') }}"
     when: ipaserver_domain is not defined
 
   - name: Get Realm from server name
-    set_fact:
+    ansible.builtin.set_fact:
       ipaserver_realm: "{{ ansible_facts['fqdn'].split('.')[1:] | join ('.') | upper }}"
     when: ipaserver_realm is not defined
 
   - name: Set host1_fqdn .. host2_fqdn
-    set_fact:
+    ansible.builtin.set_fact:
       host1_fqdn: "{{ 'host1.' + ipaserver_domain }}"
       host2_fqdn: "{{ 'host2.' + ipaserver_domain }}"
 

--- a/tests/hostgroup/test_hostgroup.yml
+++ b/tests/hostgroup/test_hostgroup.yml
@@ -6,7 +6,7 @@
 
   tasks:
   - name: Get Domain from server name
-    set_fact:
+    ansible.builtin.set_fact:
       ipaserver_domain: "{{ ansible_facts['fqdn'].split('.')[1:] | join ('.') }}"
     when: ipaserver_domain is not defined
 

--- a/tests/hostgroup/test_hostgroup_client_context.yml
+++ b/tests/hostgroup/test_hostgroup_client_context.yml
@@ -6,7 +6,7 @@
 
   tasks:
   - name: Include FreeIPA facts.
-    include_tasks: ../env_freeipa_facts.yml
+    ansible.builtin.include_tasks: ../env_freeipa_facts.yml
 
   # Test will only be executed if host is not a server.
   - name: Execute with server context in the client.
@@ -27,13 +27,13 @@
 # in upstream CI.
 
 - name: Test hostgroup using client context, in client host.
-  import_playbook: test_hostgroup.yml
+  ansible.builtin.import_playbook: test_hostgroup.yml
   when: groups['ipaclients']
   vars:
     ipa_test_host: ipaclients
 
 - name: Test hostgroup using client context, in server host.
-  import_playbook: test_hostgroup.yml
+  ansible.builtin.import_playbook: test_hostgroup.yml
   when: groups['ipaclients'] is not defined or not groups['ipaclients']
   vars:
     ipa_context: client

--- a/tests/hostgroup/test_hostgroup_membermanager.yml
+++ b/tests/hostgroup/test_hostgroup_membermanager.yml
@@ -5,7 +5,7 @@
   gather_facts: false
 
   tasks:
-  - include_tasks: ../env_freeipa_facts.yml
+  - ansible.builtin.include_tasks: ../env_freeipa_facts.yml
 
   - name: Tests requiring IPA version 4.8.4+
     block:

--- a/tests/hostgroup/test_hostgroup_rename.yml
+++ b/tests/hostgroup/test_hostgroup_rename.yml
@@ -5,7 +5,7 @@
   gather_facts: false
 
   tasks:
-  - include_tasks: ../env_freeipa_facts.yml
+  - ansible.builtin.include_tasks: ../env_freeipa_facts.yml
 
   - name: Tests requiring IPA version 4.8.7+
     block:

--- a/tests/idrange/tasks_set_trust.yml
+++ b/tests/idrange/tasks_set_trust.yml
@@ -23,7 +23,7 @@
   failed_when: result.failed
 
 - name: Retrieve Domain Security Identifier
-  shell:
+  ansible.builtin.shell:
     cmd: |
       kinit -c test_krb5_cache admin <<< SomeADMINpassword > /dev/null
       KRB5CCNAME=test_krb5_cache ipa trust-show {{ adserver.domain }} | sed -n "/Domain Security Identifier/s/ //gp" | cut -d":" -f2
@@ -32,5 +32,5 @@
   no_log: yes
 
 - name: Set ipa_domain_sid.
-  set_fact:
+  ansible.builtin.set_fact:
     ipa_domain_sid: "{{ getsid.stdout }}"

--- a/tests/idrange/test_idrange.yml
+++ b/tests/idrange/test_idrange.yml
@@ -14,7 +14,7 @@
   tasks:
   # CLEANUP TEST ITEMS
   - name: Remove test trust.
-    include_tasks: tasks_remove_trust.yml
+    ansible.builtin.include_tasks: tasks_remove_trust.yml
     when: trust_test_is_supported | default(false)
 
   - name: Ensure testing idranges are absent
@@ -121,7 +121,7 @@
   - block:
       # Create trust with range_type: ipa-ad-trust
       - name: Create trust with range_type 'ipa-ad-trust'
-        include_tasks: tasks_set_trust.yml
+        ansible.builtin.include_tasks: tasks_set_trust.yml
         vars:
           trust_base_id: 10000000
           trust_range_size: 200000
@@ -218,7 +218,7 @@
 
       # Remove trust and idrange
       - name: Remove test trust.
-        include_tasks: tasks_remove_trust.yml
+        ansible.builtin.include_tasks: tasks_remove_trust.yml
 
       - name: Ensure AD-trust idrange is absent
         ipaidrange:
@@ -229,7 +229,7 @@
 
       # Create trust with range_type: ipa-ad-trust-posix
       - name: Create trust with range_type 'ipa-ad-trust'
-        include_tasks: tasks_set_trust.yml
+        ansible.builtin.include_tasks: tasks_set_trust.yml
         vars:
           trust_base_id: 10000000
           trust_range_size: 200000
@@ -251,7 +251,7 @@
 
       # Remove trust and idrange
       - name: Remove test trust.
-        include_tasks: tasks_remove_trust.yml
+        ansible.builtin.include_tasks: tasks_remove_trust.yml
 
       - name: Ensure AD-trust idrange is absent
         ipaidrange:
@@ -262,7 +262,7 @@
 
       # Remove trust and idrange
       - name: Remove test trust.
-        include_tasks: tasks_remove_trust.yml
+        ansible.builtin.include_tasks: tasks_remove_trust.yml
 
       - name: Ensure AD-trust idrange is absent
         ipaidrange:
@@ -273,7 +273,7 @@
 
       # Create trust with range_type: ipa-ad-trust-posix
       - name: Create trust with range_type 'ipa-ad-trust-posix'
-        include_tasks: tasks_set_trust.yml
+        ansible.builtin.include_tasks: tasks_set_trust.yml
         vars:
           trust_base_id: 10000000
           trust_range_size: 2000000
@@ -319,7 +319,7 @@
 
       # Remove trust and idrange
       - name: Remove test trust.
-        include_tasks: tasks_remove_trust.yml
+        ansible.builtin.include_tasks: tasks_remove_trust.yml
 
       - name: Ensure AD-trust idrange is absent
         ipaidrange:
@@ -330,7 +330,7 @@
 
       # Create trust with range_type: ipa-ad-trust-posix
       - name: Create trust with range_type 'ipa-ad-trust-posix'
-        include_tasks: tasks_set_trust.yml
+        ansible.builtin.include_tasks: tasks_set_trust.yml
         vars:
           trust_base_id: 10000000
           trust_range_size: 2000000
@@ -352,7 +352,7 @@
     always:
       # CLEANUP TEST ITEMS
       - name: Remove test trust.
-        include_tasks: tasks_remove_trust.yml
+        ansible.builtin.include_tasks: tasks_remove_trust.yml
 
       - name: Ensure testing idranges are absent
         ipaidrange:

--- a/tests/idrange/test_idrange_client_context.yml
+++ b/tests/idrange/test_idrange_client_context.yml
@@ -8,7 +8,7 @@
 
   tasks:
   - name: Include FreeIPA facts.
-    include_tasks: ../env_freeipa_facts.yml
+    ansible.builtin.include_tasks: ../env_freeipa_facts.yml
 
   # Test will only be executed if host is not a server.
   - name: Execute with server context in the client.
@@ -29,11 +29,11 @@
 # in upstream CI.
 
 - name: Test idrange using client context, in client host.
-  import_playbook: test_idrange.yml
+  ansible.builtin.import_playbook: test_idrange.yml
   when: groups['ipaclients']
   vars:
     ipa_test_host: ipaclients
 
 - name: Test idrange using client context, in server host.
-  import_playbook: test_idrange.yml
+  ansible.builtin.import_playbook: test_idrange.yml
   when: groups['ipaclients'] is not defined or not groups['ipaclients']

--- a/tests/location/test_location_client_context.yml
+++ b/tests/location/test_location_client_context.yml
@@ -6,7 +6,7 @@
 
   tasks:
   - name: Include FreeIPA facts.
-    include_tasks: ../env_freeipa_facts.yml
+    ansible.builtin.include_tasks: ../env_freeipa_facts.yml
 
   # Test will only be executed if host is not a server.
   - name: Execute with server context in the client.
@@ -27,13 +27,13 @@
 # in upstream CI.
 
 - name: Test location using client context, in client host.
-  import_playbook: test_location.yml
+  ansible.builtin.import_playbook: test_location.yml
   when: groups['ipaclients']
   vars:
     ipa_test_host: ipaclients
 
 - name: Test location using client context, in server host.
-  import_playbook: test_location.yml
+  ansible.builtin.import_playbook: test_location.yml
   when: groups['ipaclients'] is not defined or not groups['ipaclients']
   vars:
     ipa_context: client

--- a/tests/netgroup/test_netgroup.yml
+++ b/tests/netgroup/test_netgroup.yml
@@ -19,7 +19,7 @@
 
     # CREATE TEST ITEMS
     - name: Get Domain from server name
-      set_fact:
+      ansible.builtin.set_fact:
         ipaserver_domain: "{{ ansible_facts['fqdn'].split('.')[1:] | join ('.') }}"
       when: ipaserver_domain is not defined
 

--- a/tests/netgroup/test_netgroup_client_context.yml
+++ b/tests/netgroup/test_netgroup_client_context.yml
@@ -6,7 +6,7 @@
 
   tasks:
   - name: Include FreeIPA facts.
-    include_tasks: ../env_freeipa_facts.yml
+    ansible.builtin.include_tasks: ../env_freeipa_facts.yml
 
   # Test will only be executed if host is not a server.
   - name: Execute with server context in the client.
@@ -27,25 +27,25 @@
 # in upstream CI.
 
 - name: Test netgroup using client context, in client host.
-  import_playbook: test_netgroup.yml
+  ansible.builtin.import_playbook: test_netgroup.yml
   when: groups['ipaclients']
   vars:
     ipa_test_host: ipaclients
 
 - name: Test netgroup using client context, in server host.
-  import_playbook: test_netgroup.yml
+  ansible.builtin.import_playbook: test_netgroup.yml
   when: groups['ipaclients'] is not defined or not groups['ipaclients']
   vars:
     ipa_context: client
 
 - name: Test netgroup with member using client context, in client host.
-  import_playbook: test_netgroup_member.yml
+  ansible.builtin.import_playbook: test_netgroup_member.yml
   when: groups['ipaclients']
   vars:
     ipa_test_host: ipaclients
 
 - name: Test netgroup with member using client context, in server host.
-  import_playbook: test_netgroup_member.yml
+  ansible.builtin.import_playbook: test_netgroup_member.yml
   when: groups['ipaclients'] is not defined or not groups['ipaclients']
   vars:
     ipa_context: client

--- a/tests/netgroup/test_netgroup_member.yml
+++ b/tests/netgroup/test_netgroup_member.yml
@@ -7,12 +7,12 @@
   tasks:
   - block:
     - name: Get Domain from server name
-      set_fact:
+      ansible.builtin.set_fact:
         ipaserver_domain: "{{ ansible_facts['fqdn'].split('.')[1:] | join ('.') }}"
       when: ipaserver_domain is not defined
 
     - name: Set host1_fqdn .. host2_fqdn
-      set_fact:
+      ansible.builtin.set_fact:
         host1_fqdn: "{{ 'host1.' + ipaserver_domain }}"
         host2_fqdn: "{{ 'host2.' + ipaserver_domain }}"
 

--- a/tests/netgroup/test_netgroup_member_absent.yml
+++ b/tests/netgroup/test_netgroup_member_absent.yml
@@ -7,12 +7,12 @@
   tasks:
   - block:
     - name: Get Domain from server name
-      set_fact:
+      ansible.builtin.set_fact:
         ipaserver_domain: "{{ ansible_facts['fqdn'].split('.')[1:] | join ('.') }}"
       when: ipaserver_domain is not defined
 
     - name: Set host1_fqdn .. host2_fqdn
-      set_fact:
+      ansible.builtin.set_fact:
         host1_fqdn: "{{ 'host1.' + ipaserver_domain }}"
         host2_fqdn: "{{ 'host2.' + ipaserver_domain }}"
 

--- a/tests/netgroup/test_netgroup_member_case_insensitive.yml
+++ b/tests/netgroup/test_netgroup_member_case_insensitive.yml
@@ -16,7 +16,7 @@
   - block:
     # SETUP
     - name: Get Domain from server name
-      set_fact:
+      ansible.builtin.set_fact:
         ipaserver_domain: "{{ ansible_facts['fqdn'].split('.')[1:] | join ('.') }}"
       when: ipaserver_domain is not defined
 
@@ -62,7 +62,7 @@
 
     # TESTS
     - name: Start tests.
-      debug:
+      ansible.builtin.debug:
         msg: "Tests are starting."
 
     - name: Ensure netgroups exist
@@ -203,7 +203,7 @@
       failed_when: result.failed or result.changed
 
     - name: End tests.
-      debug:
+      ansible.builtin.debug:
         msg: "All tests executed."
 
     always:

--- a/tests/permission/test_permission.yml
+++ b/tests/permission/test_permission.yml
@@ -4,7 +4,7 @@
   become: true
 
   tasks:
-  - include_tasks: ../env_freeipa_facts.yml
+  - ansible.builtin.include_tasks: ../env_freeipa_facts.yml
 
   - name: Ensure testing groups are present.
     ipagroup:

--- a/tests/permission/test_permission_client_context.yml
+++ b/tests/permission/test_permission_client_context.yml
@@ -6,7 +6,7 @@
 
   tasks:
   - name: Include FreeIPA facts.
-    include_tasks: ../env_freeipa_facts.yml
+    ansible.builtin.include_tasks: ../env_freeipa_facts.yml
 
   # Test will only be executed if host is not a server.
   - name: Execute with server context in the client.
@@ -27,13 +27,13 @@
 # in upstream CI.
 
 - name: Test permission using client context, in client host.
-  import_playbook: test_permission.yml
+  ansible.builtin.import_playbook: test_permission.yml
   when: groups['ipaclients']
   vars:
     ipa_test_host: ipaclients
 
 - name: Test permission using client context, in server host.
-  import_playbook: test_permission.yml
+  ansible.builtin.import_playbook: test_permission.yml
   when: groups['ipaclients'] is not defined or not groups['ipaclients']
   vars:
     ipa_context: client

--- a/tests/privilege/test_privilege_client_context.yml
+++ b/tests/privilege/test_privilege_client_context.yml
@@ -6,7 +6,7 @@
 
   tasks:
   - name: Include FreeIPA facts.
-    include_tasks: ../env_freeipa_facts.yml
+    ansible.builtin.include_tasks: ../env_freeipa_facts.yml
 
   # Test will only be executed if host is not a server.
   - name: Execute with server context in the client.
@@ -27,13 +27,13 @@
 # in upstream CI.
 
 - name: Test privilege using client context, in client host.
-  import_playbook: test_privilege.yml
+  ansible.builtin.import_playbook: test_privilege.yml
   when: groups['ipaclients']
   vars:
     ipa_test_host: ipaclients
 
 - name: Test privilege using client context, in server host.
-  import_playbook: test_privilege.yml
+  ansible.builtin.import_playbook: test_privilege.yml
   when: groups['ipaclients'] is not defined or not groups['ipaclients']
   vars:
     ipa_context: client

--- a/tests/pwpolicy/test_pwpolicy.yml
+++ b/tests/pwpolicy/test_pwpolicy.yml
@@ -6,7 +6,7 @@
 
   tasks:
   - name: Setup FreeIPA test facts.
-    import_tasks: ../env_freeipa_facts.yml
+    ansible.builtin.import_tasks: ../env_freeipa_facts.yml
 
   - name: Ensure maxlife of 90 for global_policy
     ipapwpolicy:

--- a/tests/pwpolicy/test_pwpolicy_client_context.yml
+++ b/tests/pwpolicy/test_pwpolicy_client_context.yml
@@ -6,7 +6,7 @@
 
   tasks:
   - name: Include FreeIPA facts.
-    include_tasks: ../env_freeipa_facts.yml
+    ansible.builtin.include_tasks: ../env_freeipa_facts.yml
 
   # Test will only be executed if host is not a server.
   - name: Execute with server context in the client.
@@ -27,13 +27,13 @@
 # in upstream CI.
 
 - name: Test pwpolicy using client context, in client host.
-  import_playbook: test_pwpolicy.yml
+  ansible.builtin.import_playbook: test_pwpolicy.yml
   when: groups['ipaclients']
   vars:
     ipa_test_host: ipaclients
 
 - name: Test pwpolicy using client context, in server host.
-  import_playbook: test_pwpolicy.yml
+  ansible.builtin.import_playbook: test_pwpolicy.yml
   when: groups['ipaclients'] is not defined or not groups['ipaclients']
   vars:
     ipa_context: client

--- a/tests/role/env_facts.yml
+++ b/tests/role/env_facts.yml
@@ -1,21 +1,21 @@
 ---
 - block:
   - name: Get Domain from server name
-    set_fact:
+    ansible.builtin.set_fact:
       ipaserver_domain: "{{ ansible_facts['fqdn'].split('.')[1:] | join ('.') }}"
     when: "'fqdn' in ansible_facts"
   - name: Set Domain to 'ipa.test' if FQDN could not be retrieved.
-    set_fact:
+    ansible.builtin.set_fact:
       ipaserver_domain: "ipa.test"
     when: "'fqdn' not in ansible_facts"
   when: ipaserver_domain is not defined
 
 - name: Set ipaserver_realm.
-  set_fact:
+  ansible.builtin.set_fact:
     ipaserver_realm: "{{ ipaserver_domain | upper }}"
   when: ipaserver_realm is not defined
 
 - name: Create FQDN for host01
-  set_fact:
+  ansible.builtin.set_fact:
     host1_fqdn: "host01.{{ ipaserver_domain }}"
     host2_fqdn: "host02.{{ ipaserver_domain }}"

--- a/tests/role/env_setup.yml
+++ b/tests/role/env_setup.yml
@@ -1,6 +1,6 @@
 ---
 - name: Cleanup environment.
-  import_tasks: env_cleanup.yml
+  ansible.builtin.import_tasks: env_cleanup.yml
 
 - name: Ensure test user is present.
   ipauser:

--- a/tests/role/test_role.yml
+++ b/tests/role/test_role.yml
@@ -6,10 +6,10 @@
 
   tasks:
   - name: Set environment facts.
-    import_tasks: env_facts.yml
+    ansible.builtin.import_tasks: env_facts.yml
 
   - name: Setup environment.
-    import_tasks: env_setup.yml
+    ansible.builtin.import_tasks: env_setup.yml
 
   # tests
   - name: Ensure role is present.
@@ -424,4 +424,4 @@
 
   # cleanup
   - name: Cleanup environment.
-    include_tasks: env_cleanup.yml
+    ansible.builtin.include_tasks: env_cleanup.yml

--- a/tests/role/test_role_client_context.yml
+++ b/tests/role/test_role_client_context.yml
@@ -6,7 +6,7 @@
 
   tasks:
   - name: Include FreeIPA facts.
-    include_tasks: ../env_freeipa_facts.yml
+    ansible.builtin.include_tasks: ../env_freeipa_facts.yml
 
   # Test will only be executed if host is not a server.
   - name: Execute with server context in the client.
@@ -27,13 +27,13 @@
 # in upstream CI.
 
 - name: Test role using client context, in client host.
-  import_playbook: test_role.yml
+  ansible.builtin.import_playbook: test_role.yml
   when: groups['ipaclients']
   vars:
     ipa_test_host: ipaclients
 
 - name: Test role using client context, in server host.
-  import_playbook: test_role.yml
+  ansible.builtin.import_playbook: test_role.yml
   when: groups['ipaclients'] is not defined or not groups['ipaclients']
   vars:
     ipa_context: client

--- a/tests/role/test_role_lists_handling.yml
+++ b/tests/role/test_role_lists_handling.yml
@@ -6,10 +6,10 @@
 
   tasks:
   - name: Set environment facts.
-    import_tasks: env_facts.yml
+    ansible.builtin.import_tasks: env_facts.yml
 
   - name: Setup environment.
-    import_tasks: env_setup.yml
+    ansible.builtin.import_tasks: env_setup.yml
 
   - name: Add role.
     iparole:
@@ -41,7 +41,7 @@
     failed_when: result.failed or not result.changed
 
   - name: Verify role privileges.
-    shell:
+    ansible.builtin.shell:
       cmd: |
         echo SomeADMINpassword | kinit -c {{ krb5ccname }} admin
         KRB5CCNAME={{ krb5ccname }} ipa role-show testrole
@@ -71,7 +71,7 @@
     failed_when: result.failed or not result.changed
 
   - name: Verify role users.
-    shell:
+    ansible.builtin.shell:
       cmd: |
         echo SomeADMINpassword | kinit -c {{ krb5ccname }} admin
         KRB5CCNAME={{ krb5ccname }} ipa role-show testrole
@@ -95,7 +95,7 @@
     failed_when: result.failed or not result.changed
 
   - name: Verify role group.
-    shell:
+    ansible.builtin.shell:
       cmd: |
         echo SomeADMINpassword | kinit -c {{ krb5ccname }} admin
         KRB5CCNAME={{ krb5ccname }} ipa role-show testrole
@@ -119,7 +119,7 @@
     failed_when: result.failed or not result.changed
 
   - name: Verify role hosts.
-    shell:
+    ansible.builtin.shell:
       cmd: |
         echo SomeADMINpassword | kinit -c {{ krb5ccname }} admin
         KRB5CCNAME={{ krb5ccname }} ipa role-show testrole
@@ -145,7 +145,7 @@
     failed_when: result.failed or not result.changed
 
   - name: Verify role hostgroups.
-    shell:
+    ansible.builtin.shell:
       cmd: |
         echo SomeADMINpassword | kinit -c {{ krb5ccname }} admin
         KRB5CCNAME={{ krb5ccname }} ipa role-show testrole
@@ -169,7 +169,7 @@
     failed_when: result.failed or not result.changed
 
   - name: Verify role services.
-    shell:
+    ansible.builtin.shell:
       cmd: |
         echo SomeADMINpassword | kinit -c {{ krb5ccname }} admin
         KRB5CCNAME={{ krb5ccname }} ipa role-show testrole
@@ -197,7 +197,7 @@
     failed_when: result.failed or not result.changed
 
   - name: Verify role services.
-    shell:
+    ansible.builtin.shell:
       cmd: |
         echo SomeADMINpassword | kinit -c {{ krb5ccname }} admin
         KRB5CCNAME={{ krb5ccname }} ipa role-show testrole
@@ -225,7 +225,7 @@
     failed_when: result.failed or not result.changed
 
   - name: Verify role services.
-    shell:
+    ansible.builtin.shell:
       cmd: |
         echo SomeADMINpassword | kinit -c {{ krb5ccname }} admin
         KRB5CCNAME={{ krb5ccname }} ipa role-show testrole
@@ -256,4 +256,4 @@
 
   # cleanup
   - name: Cleanup environment.
-    include_tasks: env_cleanup.yml
+    ansible.builtin.include_tasks: env_cleanup.yml

--- a/tests/role/test_role_member_case_insensitive.yml
+++ b/tests/role/test_role_member_case_insensitive.yml
@@ -22,7 +22,7 @@
       - MySVC/host01
 
   tasks:
-  - include_tasks: ../env_freeipa_facts.yml
+  - ansible.builtin.include_tasks: ../env_freeipa_facts.yml
 
   - block:
       # setup

--- a/tests/role/test_role_service_member.yml
+++ b/tests/role/test_role_service_member.yml
@@ -6,10 +6,10 @@
 
   tasks:
   - name: Set environment facts.
-    import_tasks: env_facts.yml
+    ansible.builtin.import_tasks: env_facts.yml
 
   - name: Setup environment.
-    import_tasks: env_setup.yml
+    ansible.builtin.import_tasks: env_setup.yml
 
   # tests
 
@@ -92,4 +92,4 @@
 
   # cleanup
   - name: Cleanup environment.
-    include_tasks: env_cleanup.yml
+    ansible.builtin.include_tasks: env_cleanup.yml

--- a/tests/selfservice/test_selfservice_client_context.yml
+++ b/tests/selfservice/test_selfservice_client_context.yml
@@ -6,7 +6,7 @@
 
   tasks:
   - name: Include FreeIPA facts.
-    include_tasks: ../env_freeipa_facts.yml
+    ansible.builtin.include_tasks: ../env_freeipa_facts.yml
 
   # Test will only be executed if host is not a server.
   - name: Execute with server context in the client.
@@ -27,13 +27,13 @@
 # in upstream CI.
 
 - name: Test selfservice using client context, in client host.
-  import_playbook: test_selfservice.yml
+  ansible.builtin.import_playbook: test_selfservice.yml
   when: groups['ipaclients']
   vars:
     ipa_test_host: ipaclients
 
 - name: Test selfservice using client context, in server host.
-  import_playbook: test_selfservice.yml
+  ansible.builtin.import_playbook: test_selfservice.yml
   when: groups['ipaclients'] is not defined or not groups['ipaclients']
   vars:
     ipa_context: client

--- a/tests/server/test_server.yml
+++ b/tests/server/test_server.yml
@@ -9,21 +9,21 @@
   # CLEANUP TEST ITEMS
   - block:
       - name: Get server name from hostname
-        set_fact:
+        ansible.builtin.set_fact:
           ipa_server_name: "{{ ansible_facts['fqdn'].split('.')[0] }}"
     rescue:
       - name: Fallback to 'ipaserver'
-        set_fact:
+        ansible.builtin.set_fact:
           ipa_server_name: ipaserver
     when: ipa_server_name is not defined
 
   - block:
       - name: Get domain name from hostname.
-        set_fact:
+        ansible.builtin.set_fact:
           ipaserver_domain: "{{ ansible_facts['fqdn'].split('.')[1:] | join('.') }}"
     rescue:
       - name: Fallback to 'ipa.test'
-        set_fact:
+        ansible.builtin.set_fact:
           ipaserver_domain: "ipa.test"
     when: ipaserver_domain is not defined
 

--- a/tests/server/test_server_client_context.yml
+++ b/tests/server/test_server_client_context.yml
@@ -6,7 +6,7 @@
 
   tasks:
   - name: Include FreeIPA facts.
-    include_tasks: ../env_freeipa_facts.yml
+    ansible.builtin.include_tasks: ../env_freeipa_facts.yml
 
   # Test will only be executed if host is not a server.
   - name: Execute with server context in the client.
@@ -27,13 +27,13 @@
 # in upstream CI.
 
 - name: Test server using client context, in client host.
-  import_playbook: test_server.yml
+  ansible.builtin.import_playbook: test_server.yml
   when: groups['ipaclients']
   vars:
     ipa_test_host: ipaclients
 
 - name: Test server using client context, in server host.
-  import_playbook: test_server.yml
+  ansible.builtin.import_playbook: test_server.yml
   when: groups['ipaclients'] is not defined or not groups['ipaclients']
   vars:
     ipa_context: client

--- a/tests/service/certificate/test_service_certificate.yml
+++ b/tests/service/certificate/test_service_certificate.yml
@@ -6,7 +6,7 @@
   tasks:
   # setup
   - name: Generate self-signed certificates.
-    shell:
+    ansible.builtin.shell:
       cmd: |
         openssl req -x509 -newkey rsa:2048 -days 365 -nodes -keyout "private{{ item }}.key" -out "cert{{ item }}.pem" -subj '/CN=test'
         openssl x509 -outform der -in "cert{{ item }}.pem" -out "cert{{ item }}.der"
@@ -16,17 +16,17 @@
     delegate_to: localhost
 
   - name: Get Domain from server name
-    set_fact:
+    ansible.builtin.set_fact:
       ipaserver_domain: "{{ ansible_facts['fqdn'].split('.')[1:] | join ('.') }}"
     when: ipaserver_domain is not defined
 
   - name: Get IPv4 address prefix from server node
-    set_fact:
+    ansible.builtin.set_fact:
       ipv4_prefix: "{{ ansible_facts['default_ipv4'].address.split('.')[:-1] |
                        join('.') }}"
 
   - name: Set test host FQDN
-    set_fact:
+    ansible.builtin.set_fact:
       test_subdomain: testcert
       test_host: "{{ 'testcert.' + ipaserver_domain }}"
 
@@ -215,7 +215,7 @@
       state: absent
 
   - name: Remove certificate files.  # noqa: deprecated-command-syntax
-    shell:
+    ansible.builtin.shell:
       cmd: rm -f "private{{ item }}.key" "cert{{ item }}.pem" "cert{{ item }}.der" "cert{{ item }}.b64"
     with_items: [1, 2]
     become: no

--- a/tests/service/env_setup.yml
+++ b/tests/service/env_setup.yml
@@ -1,11 +1,11 @@
 # Setup environment for service module tests.
 ---
 - name: Setup variables and facts.
-  include_tasks: env_vars.yml
+  ansible.builtin.include_tasks: env_vars.yml
 
 # Cleanup before setup.
 - name: Cleanup test environment.
-  include_tasks: env_cleanup.yml
+  ansible.builtin.include_tasks: env_cleanup.yml
 
 - name: Add IP address for "nohost" host.
   ipadnsrecord:

--- a/tests/service/env_vars.yml
+++ b/tests/service/env_vars.yml
@@ -1,15 +1,15 @@
 ---
     - name: Get Domain from server name
-      set_fact:
+      ansible.builtin.set_fact:
         test_domain: "{{ ansible_facts['fqdn'].split('.')[1:] | join('.') }}"
 
     - name: Set host1, host2 and svc hosts fqdn
-      set_fact:
+      ansible.builtin.set_fact:
         host1_fqdn: "{{ 'host1.' + test_domain }}"
         host2_fqdn: "{{ 'host2.' + test_domain }}"
         svc_fqdn: "{{ 'svc.' + test_domain }}"
         nohost_fqdn: "{{ 'nohost.' + test_domain }}"
 
     - name: Get IPv4 address prefix from server node
-      set_fact:
+      ansible.builtin.set_fact:
         ipv4_prefix: "{{ ansible_facts['default_ipv4'].address.split('.')[:-1] | join('.') }}"

--- a/tests/service/test_service.yml
+++ b/tests/service/test_service.yml
@@ -17,13 +17,13 @@
 
   tasks:
   # setup
-  - include_tasks: ../env_freeipa_facts.yml
+  - ansible.builtin.include_tasks: ../env_freeipa_facts.yml
 
   # tests
   - name: Tests with skip_host_check, require IPA version 4.8.0+.
     block:
       - name: Setup test environment
-        include_tasks: env_setup.yml
+        ansible.builtin.include_tasks: env_setup.yml
 
       - name: Ensure service is present
         ipaservice:
@@ -575,5 +575,5 @@
 
       # cleanup
       - name: Cleanup test environment
-        include_tasks: env_cleanup.yml
+        ansible.builtin.include_tasks: env_cleanup.yml
     when: ipa_version is version('4.7.0', '>=')

--- a/tests/service/test_service_client_context.yml
+++ b/tests/service/test_service_client_context.yml
@@ -6,7 +6,7 @@
 
   tasks:
   - name: Include FreeIPA facts.
-    include_tasks: ../env_freeipa_facts.yml
+    ansible.builtin.include_tasks: ../env_freeipa_facts.yml
 
   # Test will only be executed if host is not a server.
   - name: Execute with server context in the client.
@@ -27,13 +27,13 @@
 # in upstream CI.
 
 - name: Test service using client context, in client host.
-  import_playbook: test_service.yml
+  ansible.builtin.import_playbook: test_service.yml
   when: groups['ipaclients']
   vars:
     ipa_test_host: ipaclients
 
 - name: Test service using client context, in server host.
-  import_playbook: test_service.yml
+  ansible.builtin.import_playbook: test_service.yml
   when: groups['ipaclients'] is not defined or not groups['ipaclients']
   vars:
     ipa_context: client

--- a/tests/service/test_service_disable.yml
+++ b/tests/service/test_service_disable.yml
@@ -14,10 +14,10 @@
 
   tasks:
   - name: Get Kerberos ticket for `admin`.
-    shell: echo SomeADMINpassword | kinit -c ${KRB5CCNAME} admin
+    ansible.builtin.shell: echo SomeADMINpassword | kinit -c ${KRB5CCNAME} admin
 
   - name: Generate self-signed certificates.
-    shell:
+    ansible.builtin.shell:
       cmd: |
         openssl req -x509 -newkey rsa:2048 -days 365 -nodes -keyout "private{{ item }}.key" -out "cert{{ item }}.pem" -subj '/CN=test'
         openssl x509 -outform der -in "cert{{ item }}.pem" -out "cert{{ item }}.der"
@@ -43,10 +43,10 @@
     failed_when: not result.changed or result.failed
 
   - name: Obtain keytab
-    shell: ipa-getkeytab -s "{{ ansible_facts['fqdn'] }}" -p "mysvc1/{{ ansible_facts['fqdn'] }}" -k mysvc1.keytab
+    ansible.builtin.shell: ipa-getkeytab -s "{{ ansible_facts['fqdn'] }}" -p "mysvc1/{{ ansible_facts['fqdn'] }}" -k mysvc1.keytab
 
   - name: Verify keytab
-    shell: ipa service-find "mysvc1/{{ ansible_facts['fqdn'] }}"
+    ansible.builtin.shell: ipa service-find "mysvc1/{{ ansible_facts['fqdn'] }}"
     register: result
     failed_when: result.failed or result.stdout | regex_search(" Keytab. true")
 
@@ -59,15 +59,15 @@
     failed_when: not result.changed or result.failed
 
   - name: Verify keytab
-    shell: ipa service-find "mysvc1/{{ ansible_facts['fqdn'] }}"
+    ansible.builtin.shell: ipa service-find "mysvc1/{{ ansible_facts['fqdn'] }}"
     register: result
     failed_when: result.failed or result.stdout | regex_search(" Keytab. true")
 
   - name: Obtain keytab
-    shell: ipa-getkeytab -s "{{ ansible_facts['fqdn'] }}" -p "mysvc1/{{ ansible_facts['fqdn'] }}" -k mysvc1.keytab
+    ansible.builtin.shell: ipa-getkeytab -s "{{ ansible_facts['fqdn'] }}" -p "mysvc1/{{ ansible_facts['fqdn'] }}" -k mysvc1.keytab
 
   - name: Verify keytab
-    shell: ipa service-find "mysvc1/{{ ansible_facts['fqdn'] }}"
+    ansible.builtin.shell: ipa service-find "mysvc1/{{ ansible_facts['fqdn'] }}"
     register: result
     failed_when: result.failed or result.stdout | regex_search(" Keytab. true")
 
@@ -80,7 +80,7 @@
     failed_when: not result.changed or result.failed
 
   - name: Verify keytab
-    shell: ipa service-find "mysvc1/{{ ansible_facts['fqdn'] }}"
+    ansible.builtin.shell: ipa service-find "mysvc1/{{ ansible_facts['fqdn'] }}"
     register: result
     failed_when: result.failed or result.stdout | regex_search(" Keytab. true")
 
@@ -98,10 +98,10 @@
       name: "mysvc1/{{ ansible_facts['fqdn'] }}"
 
   - name: Destroy Kerberos tickets.
-    shell: kdestroy -A -q -c ${KRB5CCNAME}
+    ansible.builtin.shell: kdestroy -A -q -c ${KRB5CCNAME}
 
   - name: Remove certificate files.  # noqa: deprecated-command-syntax
-    shell:
+    ansible.builtin.shell:
       cmd: rm -f "private{{ item }}.key" "cert{{ item }}.pem" "cert{{ item }}.der" "cert{{ item }}.b64"
     with_items: [1]
     become: no

--- a/tests/service/test_service_keytab.yml
+++ b/tests/service/test_service_keytab.yml
@@ -6,7 +6,7 @@
   tasks:
   # setup
   - name: Setup test envirnoment.
-    include_tasks: env_setup.yml
+    ansible.builtin.include_tasks: env_setup.yml
 
   # Add service to test keytab create/retrieve attributes.
   - name: Ensure test service is present
@@ -394,4 +394,4 @@
 
   # cleanup
   - name: Clean-up envirnoment.
-    include_tasks: env_cleanup.yml
+    ansible.builtin.include_tasks: env_cleanup.yml

--- a/tests/service/test_service_without_skip_host_check.yml
+++ b/tests/service/test_service_without_skip_host_check.yml
@@ -8,7 +8,7 @@
   # setup
 
   - name: Setup test environment
-    include_tasks: env_setup.yml
+    ansible.builtin.include_tasks: env_setup.yml
 
   # tests
   - name: Ensure service is present
@@ -461,4 +461,4 @@
 
   # cleanup
   - name: Cleanup test environment
-    include_tasks: env_cleanup.yml
+    ansible.builtin.include_tasks: env_cleanup.yml

--- a/tests/servicedelegationrule/test_servicedelegationrule_client_context.yml
+++ b/tests/servicedelegationrule/test_servicedelegationrule_client_context.yml
@@ -8,7 +8,7 @@
 
   tasks:
   - name: Include FreeIPA facts.
-    include_tasks: ../env_freeipa_facts.yml
+    ansible.builtin.include_tasks: ../env_freeipa_facts.yml
 
   # Test will only be executed if host is not a server.
   - name: Execute with server context in the client.
@@ -29,11 +29,11 @@
 # in upstream CI.
 
 - name: Test servicedelegationrule using client context, in client host.
-  import_playbook: test_servicedelegationrule.yml
+  ansible.builtin.import_playbook: test_servicedelegationrule.yml
   when: groups['ipaclients']
   vars:
     ipa_test_host: ipaclients
 
 - name: Test servicedelegationrule using client context, in server host.
-  import_playbook: test_servicedelegationrule.yml
+  ansible.builtin.import_playbook: test_servicedelegationrule.yml
   when: groups['ipaclients'] is not defined or not groups['ipaclients']

--- a/tests/servicedelegationrule/test_servicedelegationrule_hostprincipal.yml
+++ b/tests/servicedelegationrule/test_servicedelegationrule_hostprincipal.yml
@@ -6,7 +6,7 @@
 
   tasks:
   # setup
-  - include_tasks: ../env_freeipa_facts.yml
+  - ansible.builtin.include_tasks: ../env_freeipa_facts.yml
 
   # host principals are only possible with IPA 4.9.0+
   - block:
@@ -14,17 +14,17 @@
     # SET FACTS
 
     - name: Get Domain from server name
-      set_fact:
+      ansible.builtin.set_fact:
         ipaserver_domain: "{{ ansible_facts['fqdn'].split('.')[1:] | join ('.') }}"
       when: ipaserver_domain is not defined
 
     - name: Get REALM from server name
-      set_fact:
+      ansible.builtin.set_fact:
         ipaserver_realm: "{{ ipaserver_domain | upper }}"
       when: ipaserver_realm is not defined
 
     - name: Set test-host fqdn
-      set_fact:
+      ansible.builtin.set_fact:
         test_host_fqdn: "{{ 'test-host.' + ipaserver_domain }}"
         test_host_fqdn_realm: "{{ 'test-host.' + ipaserver_domain + '@' + ipaserver_realm }}"
 

--- a/tests/servicedelegationtarget/test_servicedelegationtarget_client_context.yml
+++ b/tests/servicedelegationtarget/test_servicedelegationtarget_client_context.yml
@@ -8,7 +8,7 @@
 
   tasks:
   - name: Include FreeIPA facts.
-    include_tasks: ../env_freeipa_facts.yml
+    ansible.builtin.include_tasks: ../env_freeipa_facts.yml
 
   # Test will only be executed if host is not a server.
   - name: Execute with server context in the client.
@@ -29,11 +29,11 @@
 # in upstream CI.
 
 - name: Test servicedelegationtarget using client context, in client host.
-  import_playbook: test_servicedelegationtarget.yml
+  ansible.builtin.import_playbook: test_servicedelegationtarget.yml
   when: groups['ipaclients']
   vars:
     ipa_test_host: ipaclients
 
 - name: Test servicedelegationtarget using client context, in server host.
-  import_playbook: test_servicedelegationtarget.yml
+  ansible.builtin.import_playbook: test_servicedelegationtarget.yml
   when: groups['ipaclients'] is not defined or not groups['ipaclients']

--- a/tests/servicedelegationtarget/test_servicedelegationtarget_hostprincipal.yml
+++ b/tests/servicedelegationtarget/test_servicedelegationtarget_hostprincipal.yml
@@ -6,7 +6,7 @@
 
   tasks:
   # setup
-  - include_tasks: ../env_freeipa_facts.yml
+  - ansible.builtin.include_tasks: ../env_freeipa_facts.yml
 
   # host principals are only possible with IPA 4.9.0+
   - block:
@@ -14,17 +14,17 @@
     # SET FACTS
 
     - name: Get Domain from server name
-      set_fact:
+      ansible.builtin.set_fact:
         ipaserver_domain: "{{ ansible_facts['fqdn'].split('.')[1:] | join ('.') }}"
       when: ipaserver_domain is not defined
 
     - name: Get REALM from server name
-      set_fact:
+      ansible.builtin.set_fact:
         ipaserver_realm: "{{ ipaserver_domain | upper }}"
       when: ipaserver_realm is not defined
 
     - name: Set test-host fqdn
-      set_fact:
+      ansible.builtin.set_fact:
         test_host_fqdn: "{{ 'test-host.' + ipaserver_domain }}"
         test_host_fqdn_realm: "{{ 'test-host.' + ipaserver_domain + '@' + ipaserver_realm }}"
 

--- a/tests/sudocmd/test_sudocmd_client_context.yml
+++ b/tests/sudocmd/test_sudocmd_client_context.yml
@@ -6,7 +6,7 @@
 
   tasks:
   - name: Include FreeIPA facts.
-    include_tasks: ../env_freeipa_facts.yml
+    ansible.builtin.include_tasks: ../env_freeipa_facts.yml
 
   # Test will only be executed if host is not a server.
   - name: Execute with server context in the client.
@@ -27,13 +27,13 @@
 # in upstream CI.
 
 - name: Test sudocmd using client context, in client host.
-  import_playbook: test_sudocmd.yml
+  ansible.builtin.import_playbook: test_sudocmd.yml
   when: groups['ipaclients']
   vars:
     ipa_test_host: ipaclients
 
 - name: Test sudocmd using client context, in server host.
-  import_playbook: test_sudocmd.yml
+  ansible.builtin.import_playbook: test_sudocmd.yml
   when: groups['ipaclients'] is not defined or not groups['ipaclients']
   vars:
     ipa_context: client

--- a/tests/sudocmdgroup/test_sudocmdgroup.yml
+++ b/tests/sudocmdgroup/test_sudocmdgroup.yml
@@ -83,7 +83,7 @@
     failed_when: result.changed or result.failed
 
   - name: Verify sudocmdgroup creation with sudocmds
-    shell: |
+    ansible.builtin.shell: |
       echo SomeADMINpassword | kinit -c verify_sudocmdgroup admin
       KRB5CCNAME="verify_sudocmdgroup" ipa sudocmdgroup-show network --all
       kdestroy -A -q -c verify_sudocmdgroup

--- a/tests/sudocmdgroup/test_sudocmdgroup_client_context.yml
+++ b/tests/sudocmdgroup/test_sudocmdgroup_client_context.yml
@@ -6,7 +6,7 @@
 
   tasks:
   - name: Include FreeIPA facts.
-    include_tasks: ../env_freeipa_facts.yml
+    ansible.builtin.include_tasks: ../env_freeipa_facts.yml
 
   # Test will only be executed if host is not a server.
   - name: Execute with server context in the client.
@@ -27,13 +27,13 @@
 # in upstream CI.
 
 - name: Test sudocmdgroup using client context, in client host.
-  import_playbook: test_sudocmdgroup.yml
+  ansible.builtin.import_playbook: test_sudocmdgroup.yml
   when: groups['ipaclients']
   vars:
     ipa_test_host: ipaclients
 
 - name: Test sudocmdgroup using client context, in server host.
-  import_playbook: test_sudocmdgroup.yml
+  ansible.builtin.import_playbook: test_sudocmdgroup.yml
   when: groups['ipaclients'] is not defined or not groups['ipaclients']
   vars:
     ipa_context: client

--- a/tests/sudorule/test_sudorule_categories.yml
+++ b/tests/sudorule/test_sudorule_categories.yml
@@ -6,7 +6,7 @@
 
   tasks:
   - name: Get Domain from the server name
-    set_fact:
+    ansible.builtin.set_fact:
       ipaserver_domain: "{{ ansible_facts['fqdn'].split('.')[1:] | join ('.') }}"
 
   - name: Ensure sudorules are absent

--- a/tests/sudorule/test_sudorule_client_context.yml
+++ b/tests/sudorule/test_sudorule_client_context.yml
@@ -6,7 +6,7 @@
 
   tasks:
   - name: Include FreeIPA facts.
-    include_tasks: ../env_freeipa_facts.yml
+    ansible.builtin.include_tasks: ../env_freeipa_facts.yml
 
   # Test will only be executed if host is not a server.
   - name: Execute with server context in the client.
@@ -27,13 +27,13 @@
 # in upstream CI.
 
 - name: Test sudorule using client context, in client host.
-  import_playbook: test_sudorule.yml
+  ansible.builtin.import_playbook: test_sudorule.yml
   when: groups['ipaclients']
   vars:
     ipa_test_host: ipaclients
 
 - name: Test sudorule using client context, in server host.
-  import_playbook: test_sudorule.yml
+  ansible.builtin.import_playbook: test_sudorule.yml
   when: groups['ipaclients'] is not defined or not groups['ipaclients']
   vars:
     ipa_context: client

--- a/tests/sudorule/test_sudorule_member_case_insensitive.yml
+++ b/tests/sudorule/test_sudorule_member_case_insensitive.yml
@@ -16,7 +16,7 @@
   - block:
     # SETUP
     - name: Ensure domain name
-      set_fact:
+      ansible.builtin.set_fact:
         ipa_domain: ipa.test
       when: ipa_domain is not defined
 
@@ -56,7 +56,7 @@
 
     # TESTS
     - name: Start tests.
-      debug:
+      ansible.builtin.debug:
         msg: "Tests are starting."
 
     - name: Ensure sudorule exist with runasusers members
@@ -249,7 +249,7 @@
       failed_when: result.failed or result.changed
 
     - name: End tests.
-      debug:
+      ansible.builtin.debug:
         msg: "All tests executed."
 
     always:

--- a/tests/sudorule/test_sudorule_single_hostnames.yml
+++ b/tests/sudorule/test_sudorule_single_hostnames.yml
@@ -8,7 +8,7 @@
   - block:
     # setup test environment
     - name: Get Domain from the server name
-      set_fact:
+      ansible.builtin.set_fact:
         ipaserver_domain: "{{ ansible_facts['fqdn'].split('.')[1:] | join ('.') }}"
       when: ipaserver_domain is not defined
 

--- a/tests/trust/test_trust.yml
+++ b/tests/trust/test_trust.yml
@@ -28,7 +28,7 @@
         state: absent
 
     - name: Clear test idranges
-      shell: |
+      ansible.builtin.shell: |
         kinit -c test_krb5_cache admin <<< SomeADMINpassword
         ipa idrange-del {{ adserver.realm }}_id_range || true
         ipa idrange-del {{ ipaserver.realm }}_subid_range || true
@@ -48,7 +48,7 @@
       failed_when: result.failed or not result.changed
 
     - name: check if 'ipa-ad-trust' trust exists
-      shell: |
+      ansible.builtin.shell: |
         echo 'SomeADMINpassword' | kinit admin
         ipa trust-find
         kdestroy -c test_krb5_cache -q -A
@@ -77,7 +77,7 @@
       failed_when: result.failed or not result.changed
 
     - name: Check if 'ipa-ad-trust' trust was removed
-      shell: |
+      ansible.builtin.shell: |
         kinit -c test_krb5_cache admin <<< SomeADMINpassword
         ipa trust-find
         kdestroy -c test_krb5_cache -q -A
@@ -94,7 +94,7 @@
       failed_when: result.failed or result.changed
 
     - name: Clear test idranges
-      shell: |
+      ansible.builtin.shell: |
         kinit -c test_krb5_cache admin <<< SomeADMINpassword
         ipa idrange-del {{ adserver.realm }}_id_range || true
         ipa idrange-del {{ ipaserver.realm }}_subid_range || true
@@ -113,7 +113,7 @@
       failed_when: result.failed or not result.changed
 
     - name: Check if 'ipa-ad-trust-posix' trust exists
-      shell: |
+      ansible.builtin.shell: |
         kinit -c test_krb5_cache admin <<< SomeADMINpassword
         ipa trust-find
         kdestroy -c test_krb5_cache -q -A
@@ -142,7 +142,7 @@
       failed_when: result.failed or not result.changed
 
     - name: Check if trust 'ipa-ad-trust-posix' was removed
-      shell: |
+      ansible.builtin.shell: |
         kinit -c test_krb5_cache admin <<< SomeADMINpassword
         ipa trust-find
         kdestroy -c test_krb5_cache -q -A
@@ -159,7 +159,7 @@
       failed_when: result.failed or result.changed
 
     - name: Clear test idranges
-      shell: |
+      ansible.builtin.shell: |
         kinit -c test_krb5_cache admin <<< SomeADMINpassword
         ipa idrange-del {{ adserver.realm }}_id_range || true
         ipa idrange-del {{ ipaserver.realm }}_subid_range || true

--- a/tests/trust/test_trust_client_context.yml
+++ b/tests/trust/test_trust_client_context.yml
@@ -6,7 +6,7 @@
 
   tasks:
   - name: Include FreeIPA facts.
-    include_tasks: ../env_freeipa_facts.yml
+    ansible.builtin.include_tasks: ../env_freeipa_facts.yml
 
   # Test will only be executed if host is not a server.
   - name: Execute with server context in the client.
@@ -27,13 +27,13 @@
 # in upstream CI.
 
 - name: Test trust using client context, in client host.
-  import_playbook: test_trust.yml
+  ansible.builtin.import_playbook: test_trust.yml
   when: groups['ipaclients']
   vars:
     ipa_test_host: ipaclients
 
 - name: Test trust using client context, in server host.
-  import_playbook: test_trust.yml
+  ansible.builtin.import_playbook: test_trust.yml
   when: groups['ipaclients'] is not defined or not groups['ipaclients']
   vars:
     ipa_context: client

--- a/tests/user/certificate/test_user_certificate.yml
+++ b/tests/user/certificate/test_user_certificate.yml
@@ -6,7 +6,7 @@
 
   tasks:
   - name: Generate self-signed certificates.
-    shell:
+    ansible.builtin.shell:
       cmd: |
         openssl req -x509 -newkey rsa:2048 -days 365 -nodes -keyout "private{{ item }}.key" -out "cert{{ item }}.pem" -subj '/CN=test'
         openssl x509 -outform der -in "cert{{ item }}.pem" -out "cert{{ item }}.der"
@@ -81,7 +81,7 @@
     failed_when: not result.changed or result.failed
 
   - name: Remove certificate files.  # noqa: deprecated-command-syntax
-    shell:
+    ansible.builtin.shell:
       cmd: rm -f "private{{ item }}.key" "cert{{ item }}.pem" "cert{{ item }}.der" "cert{{ item }}.b64"
     with_items: [1, 2, 3]
     become: no

--- a/tests/user/certificate/test_users_certificate.yml
+++ b/tests/user/certificate/test_users_certificate.yml
@@ -6,7 +6,7 @@
 
   tasks:
   - name: Generate self-signed certificates.
-    shell:
+    ansible.builtin.shell:
       cmd: |
         openssl req -x509 -newkey rsa:2048 -days 365 -nodes -keyout "private{{ item }}.key" -out "cert{{ item }}.pem" -subj '/CN=test'
         openssl x509 -outform der -in "cert{{ item }}.pem" -out "cert{{ item }}.der"
@@ -94,7 +94,7 @@
     failed_when: not result.changed or result.failed
 
   - name: Remove certificate files.  # noqa: deprecated-command-syntax
-    shell:
+    ansible.builtin.shell:
       cmd: rm -f "private{{ item }}.key" "cert{{ item }}.pem" "cert{{ item }}.der" "cert{{ item }}.b64"
     with_items: [1, 2, 3]
     become: no

--- a/tests/user/certmapdata/test_user_certmapdata.yml
+++ b/tests/user/certmapdata/test_user_certmapdata.yml
@@ -6,7 +6,7 @@
 
   tasks:
   - name: Generate self-signed certificates.
-    shell:
+    ansible.builtin.shell:
       cmd: |
         openssl req -x509 -newkey rsa:2048 -days 365 -nodes -keyout "private{{ item }}.key" -out "cert{{ item }}.pem" -subj '/CN=test'
         openssl x509 -outform der -in "cert{{ item }}.pem" -out "cert{{ item }}.der"
@@ -226,7 +226,7 @@
     failed_when: not result.changed or result.failed
 
   - name: Remove certificate files.   # noqa: deprecated-command-syntax
-    shell:
+    ansible.builtin.shell:
       cmd: rm -f "private{{ item }}.key" "cert{{ item }}.pem" "cert{{ item }}.der" "cert{{ item }}.b64"
     with_items: [1, 2, 3]
     become: no

--- a/tests/user/certmapdata/test_users_certmapdata.yml
+++ b/tests/user/certmapdata/test_users_certmapdata.yml
@@ -6,7 +6,7 @@
 
   tasks:
   - name: Generate self-signed certificates.
-    shell:
+    ansible.builtin.shell:
       cmd: |
         openssl req -x509 -newkey rsa:2048 -days 365 -nodes -keyout "private{{ item }}.key" -out "cert{{ item }}.pem" -subj '/CN=test'
         openssl x509 -outform der -in "cert{{ item }}.pem" -out "cert{{ item }}.der"
@@ -162,7 +162,7 @@
     failed_when: not result.changed or result.failed
 
   - name: Remove certificate files.  # noqa: deprecated-command-syntax
-    shell:
+    ansible.builtin.shell:
       cmd: rm -f "private{{ item }}.key" "cert{{ item }}.pem" "cert{{ item }}.der" "cert{{ item }}.b64"
     with_items: [1, 2, 3]
     become: no

--- a/tests/user/create_users_json.yml
+++ b/tests/user/create_users_json.yml
@@ -4,10 +4,10 @@
 
   tasks:
   - name: Check if users.json exists
-    stat:
+    ansible.builtin.stat:
       path: users.json
     register: register_stat_users
 
   - name: Create users.json
-    command: /bin/bash users.sh 500
+    ansible.builtin.command: /bin/bash users.sh 500
     when: not register_stat_users.stat.exists

--- a/tests/user/test_user_client_context.yml
+++ b/tests/user/test_user_client_context.yml
@@ -6,7 +6,7 @@
 
   tasks:
   - name: Include FreeIPA facts.
-    include_tasks: ../env_freeipa_facts.yml
+    ansible.builtin.include_tasks: ../env_freeipa_facts.yml
 
   # Test will only be executed if host is not a server.
   - name: Execute with server context in the client.
@@ -27,13 +27,13 @@
 # in upstream CI.
 
 - name: Test user using client context, in client host.
-  import_playbook: test_user.yml
+  ansible.builtin.import_playbook: test_user.yml
   when: groups['ipaclients']
   vars:
     ipa_test_host: ipaclients
 
 - name: Test user using client context, in server host.
-  import_playbook: test_user.yml
+  ansible.builtin.import_playbook: test_user.yml
   when: groups['ipaclients'] is not defined or not groups['ipaclients']
   vars:
     ipa_context: client

--- a/tests/user/test_user_random.yml
+++ b/tests/user/test_user_random.yml
@@ -26,7 +26,7 @@
                  ipauser.failed
 
   - name: Print generated random password
-    debug:
+    ansible.builtin.debug:
       var: ipauser.user.randompassword
 
   - name: User user1 absent
@@ -56,11 +56,11 @@
                  ipauser.failed
 
   - name: Print generated random password for user1
-    debug:
+    ansible.builtin.debug:
       var: ipauser.user.user1.randompassword
 
   - name: Print generated random password for user2
-    debug:
+    ansible.builtin.debug:
       var: ipauser.user.user2.randompassword
 
   - name: Users user1 and user2 absent

--- a/tests/user/test_users_absent.yml
+++ b/tests/user/test_users_absent.yml
@@ -1,6 +1,6 @@
 ---
 - name: Include create_users_json.yml
-  import_playbook: create_users_json.yml
+  ansible.builtin.import_playbook: create_users_json.yml
 
 - name: Test users absent
   hosts: ipaserver
@@ -9,11 +9,11 @@
 
   tasks:
   - name: Include users.json
-    include_vars:
+    ansible.builtin.include_vars:
       file: users.json  # noqa 505
 
   - name: Create dict with user names
-    set_fact:
+    ansible.builtin.set_fact:
       user_names: "{{ user_names | default([]) + [{ 'name': item.name }] }}"
     loop: "{{ users }}"
 

--- a/tests/user/test_users_invalid_cert.yml
+++ b/tests/user/test_users_invalid_cert.yml
@@ -6,7 +6,7 @@
 
   tasks:
   - name: Generate self-signed certificates.
-    shell:
+    ansible.builtin.shell:
       cmd: |
         openssl req -x509 -newkey rsa:2048 -days 365 -nodes -keyout "private{{ item }}.key" -out "cert{{ item }}.pem" -subj '/CN=test'
         openssl x509 -outform der -in "cert{{ item }}.pem" -out "cert{{ item }}.der"
@@ -55,7 +55,7 @@
     failed_when: not result.changed or result.failed
 
   - name: Remove certificate files.  # noqa: deprecated-command-syntax
-    shell:
+    ansible.builtin.shell:
       cmd: rm -f "private{{ item }}.key" "cert{{ item }}.pem" "cert{{ item }}.der" "cert{{ item }}.b64"
     with_items: [1, 2]
     become: no

--- a/tests/user/test_users_present.yml
+++ b/tests/user/test_users_present.yml
@@ -1,6 +1,6 @@
 ---
 - name: Include create_users_json.yml
-  import_playbook: create_users_json.yml
+  ansible.builtin.import_playbook: create_users_json.yml
 
 - name: Test users present
   hosts: ipaserver
@@ -9,7 +9,7 @@
 
   tasks:
   - name: Include users.json
-    include_vars:
+    ansible.builtin.include_vars:
       file: users.json  # noqa 505
 
   - name: Users present len:{{ users | length }}

--- a/tests/user/test_users_present_slice.yml
+++ b/tests/user/test_users_present_slice.yml
@@ -1,6 +1,6 @@
 ---
 - name: Include create_users_json.yml
-  import_playbook: create_users_json.yml
+  ansible.builtin.import_playbook: create_users_json.yml
 
 - name: Test users present slice
   hosts: ipaserver
@@ -11,10 +11,10 @@
     slice_size: 500
   tasks:
   - name: Include users.json
-    include_vars:
+    ansible.builtin.include_vars:
       file: users.json  # noqa 505
   - name: Size of users slice.
-    debug:
+    ansible.builtin.debug:
       msg: "{{ users | length }}"
   - name: Users present
     ipauser:

--- a/tests/vault/env_cleanup.yml
+++ b/tests/vault/env_cleanup.yml
@@ -41,7 +41,7 @@
       state: absent
 
   - name: Remove files from target host.
-    file:
+    ansible.builtin.file:
       path: "{{ ansible_facts['env'].HOME }}/{{ item }}"
       state: absent
     with_items:
@@ -58,7 +58,7 @@
     - out.txt
 
   - name: Remove files from controller.
-    file:
+    ansible.builtin.file:
       path: "{{ playbook_dir }}/{{ item }}"
       state: absent
     delegate_to: localhost

--- a/tests/vault/env_setup.yml
+++ b/tests/vault/env_setup.yml
@@ -1,10 +1,10 @@
 ---
   # Tasks executed to ensure a sane environment to test IPA Vault module.
   - name: Ensure environment is clean.
-    import_tasks: env_cleanup.yml
+    ansible.builtin.import_tasks: env_cleanup.yml
 
   - name: Create private/public key pair.
-    shell:
+    ansible.builtin.shell:
       cmd: |
         openssl genrsa -out "{{ item }}private.pem" 2048
         openssl rsa -in "{{ item }}private.pem" -outform PEM -pubout -out "{{ item }}public.pem"
@@ -17,7 +17,7 @@
     - B_
 
   - name: Copy files to target host.
-    copy:
+    ansible.builtin.copy:
       src: "{{ playbook_dir }}/{{ item }}"
       dest: "{{ ansible_facts['env'].HOME }}/{{ item }}"
       mode: 0644

--- a/tests/vault/tasks_vault_members.yml
+++ b/tests/vault/tasks_vault_members.yml
@@ -1,7 +1,7 @@
 ---
   # Tasks to test member management for Vault module.
   - name: Setup testing environment.
-    import_tasks: env_setup.yml
+    ansible.builtin.import_tasks: env_setup.yml
 
   - name: Ensure vault is present
     ipavault:
@@ -315,4 +315,4 @@
     failed_when: result.changed or result.failed
 
   - name: Cleanup testing environment.
-    import_tasks: env_cleanup.yml
+    ansible.builtin.import_tasks: env_cleanup.yml

--- a/tests/vault/test_vault_asymmetric.yml
+++ b/tests/vault/test_vault_asymmetric.yml
@@ -7,7 +7,7 @@
 
   tasks:
   - name: Setup testing environment.
-    import_tasks: env_setup.yml
+    ansible.builtin.import_tasks: env_setup.yml
 
   - name: Ensure asymmetric vault is present
     ipavault:
@@ -165,7 +165,7 @@
     failed_when: result.changed or result.failed or (result.vault.data | default(false))
 
   - name: Verify retrieved data.
-    slurp:
+    ansible.builtin.slurp:
       src: "{{ ansible_facts['env'].HOME }}/data.txt"
     register: slurpfile
     failed_when: slurpfile['content'] | b64decode != 'Hello World.'
@@ -299,4 +299,4 @@
     failed_when: result.changed or result.failed
 
   - name: Cleanup testing environment.
-    import_tasks: env_cleanup.yml
+    ansible.builtin.import_tasks: env_cleanup.yml

--- a/tests/vault/test_vault_change_type.yml
+++ b/tests/vault/test_vault_change_type.yml
@@ -7,7 +7,7 @@
 
   tasks:
   - name: Setup testing environment.
-    import_tasks: env_setup.yml
+    ansible.builtin.import_tasks: env_setup.yml
 
   - name: Ensure test_vault is absent.
     ipavault:
@@ -42,7 +42,7 @@
       failed_when: result.failed or not result.changed
 
     - name: Verify assymetric-only fields are not present.
-      shell: |
+      ansible.builtin.shell: |
          echo SomeADMINpassword | kinit -c {{ krb5ccname }} admin
          KRB5CCNAME={{ krb5ccname }} ipa vault-show test_vault
          kdestroy -A -q -c {{ krb5ccname }}
@@ -63,7 +63,7 @@
       failed_when: result.failed or not result.changed
 
     - name: Verify salt is not present.
-      shell: |
+      ansible.builtin.shell: |
          echo SomeADMINpassword | kinit -c {{ krb5ccname }} admin
          KRB5CCNAME={{ krb5ccname }} ipa vault-show test_vault
          kdestroy -A -q -c {{ krb5ccname }}
@@ -94,7 +94,7 @@
       failed_when: result.failed or not result.changed
 
     - name: Verify salt is not present.
-      shell: |
+      ansible.builtin.shell: |
          echo SomeADMINpassword | kinit -c {{ krb5ccname }} admin
          KRB5CCNAME={{ krb5ccname }} ipa vault-show test_vault
          kdestroy -A -q -c {{ krb5ccname }}
@@ -115,7 +115,7 @@
       failed_when: result.failed or not result.changed
 
     - name: Verify assymetric-only fields are not present.
-      shell: |
+      ansible.builtin.shell: |
          echo SomeADMINpassword | kinit -c {{ krb5ccname }} admin
          KRB5CCNAME={{ krb5ccname }} ipa vault-show test_vault
          kdestroy -A -q -c {{ krb5ccname }}
@@ -168,7 +168,7 @@
       failed_when: result.failed or not result.changed
 
     - name: Verify assymetric-only fields are not present.
-      shell: |
+      ansible.builtin.shell: |
          echo SomeADMINpassword | kinit -c {{ krb5ccname }} admin
          KRB5CCNAME={{ krb5ccname }} ipa vault-show test_vault
          kdestroy -A -q -c {{ krb5ccname }}
@@ -198,7 +198,7 @@
       failed_when: result.failed or not result.changed
 
     - name: Verify salt is not present.
-      shell: |
+      ansible.builtin.shell: |
          echo SomeADMINpassword | kinit -c {{ krb5ccname }} admin
          KRB5CCNAME={{ krb5ccname }} ipa vault-show test_vault
          kdestroy -A -q -c {{ krb5ccname }}
@@ -246,7 +246,7 @@
       failed_when: result.failed or not result.changed
 
     - name: Verify salt is not present.
-      shell: |
+      ansible.builtin.shell: |
          echo SomeADMINpassword | kinit -c {{ krb5ccname }} admin
          KRB5CCNAME={{ krb5ccname }} ipa vault-show test_vault
          kdestroy -A -q -c {{ krb5ccname }}
@@ -276,7 +276,7 @@
       failed_when: result.failed or not result.changed or result.failed
 
     - name: Verify assymetric-only fields are not present.
-      shell: |
+      ansible.builtin.shell: |
          echo SomeADMINpassword | kinit -c {{ krb5ccname }} admin
          KRB5CCNAME={{ krb5ccname }} ipa vault-show test_vault
          kdestroy -A -q -c {{ krb5ccname }}
@@ -301,4 +301,4 @@
       state: absent
 
   - name: Cleanup testing environment.
-    import_tasks: env_cleanup.yml
+    ansible.builtin.import_tasks: env_cleanup.yml

--- a/tests/vault/test_vault_client_context.yml
+++ b/tests/vault/test_vault_client_context.yml
@@ -7,7 +7,7 @@
 
   tasks:
   - name: Setup testing environment.
-    import_tasks: env_setup.yml
+    ansible.builtin.import_tasks: env_setup.yml
 
   # vault requires 'ipaapi_context: client', and uses this
   # context by defoult, so we test only for the case where
@@ -22,4 +22,4 @@
     failed_when: not (result.failed and result.msg is regex("Context 'server' for ipavault not yet supported."))
 
   - name: Cleanup testing environment.
-    import_tasks: env_cleanup.yml
+    ansible.builtin.import_tasks: env_cleanup.yml

--- a/tests/vault/test_vault_members.yml
+++ b/tests/vault/test_vault_members.yml
@@ -7,7 +7,7 @@
 
   tasks:
   - name: Test vault module member operations.
-    include_tasks:
+    ansible.builtin.include_tasks:
       file: tasks_vault_members.yml
       apply:
         tags:

--- a/tests/vault/test_vault_standard.yml
+++ b/tests/vault/test_vault_standard.yml
@@ -7,7 +7,7 @@
 
   tasks:
   - name: Setup testing environment.
-    import_tasks: env_setup.yml
+    ansible.builtin.import_tasks: env_setup.yml
 
   - name: Ensure standard vault is present
     ipavault:
@@ -67,7 +67,7 @@
     failed_when: result.changed or result.failed or (result.vault.data | default(false))
 
   - name: Verify retrieved data.
-    slurp:
+    ansible.builtin.slurp:
       src: "{{ ansible_facts['env'].HOME }}/data.txt"
     register: slurpfile
     failed_when: slurpfile['content'] | b64decode != 'Hello World.'
@@ -138,4 +138,4 @@
     failed_when: result.changed or result.failed
 
   - name: Cleanup testing environment.
-    import_tasks: env_cleanup.yml
+    ansible.builtin.import_tasks: env_cleanup.yml

--- a/tests/vault/test_vault_symmetric.yml
+++ b/tests/vault/test_vault_symmetric.yml
@@ -7,7 +7,7 @@
 
   tasks:
   - name: Setup testing environment.
-    import_tasks: env_setup.yml
+    ansible.builtin.import_tasks: env_setup.yml
 
   - name: Ensure symmetric vault is present
     ipavault:
@@ -74,7 +74,7 @@
     failed_when: result.changed or result.failed or (result.vault.data | default(false))
 
   - name: Verify retrieved data.
-    slurp:
+    ansible.builtin.slurp:
       src: "{{ ansible_facts['env'].HOME }}/data.txt"
     register: slurpfile
     failed_when: slurpfile['content'] | b64decode != 'Hello World.'
@@ -351,4 +351,4 @@
     failed_when: result.failed or not result.changed
 
   - name: Cleanup testing environment.
-    import_tasks: env_cleanup.yml
+    ansible.builtin.import_tasks: env_cleanup.yml


### PR DESCRIPTION
Use Fully Qualified Collection Name (FQCN) for ansible builtins. This is
ansible.builtin.set_fact instead of set_fact for example and aplies for
all actions that are part of ansible.builtin.

All the replaced ansible.builtins:
  assert, command, copy, debug, fail, fetch, file, import_playbook,
  import_tasks, include_role, include_tasks, include_vars, package,
  set_fact, shell, slurp, stat, systemd
