### PR TITLE
utils files: Support builtins with ansible.builtin. prefix

### DIFF
--- a/utils/galaxyfy.py
+++ b/utils/galaxyfy.py
@@ -39,13 +39,14 @@ def galaxyfy_playbook(project_prefix, collection_prefix, lines):
         if stripped.startswith("- name:") or \
            stripped.startswith("- block:"):
             changeable = True
-        elif stripped in ["set_fact:", "vars:"]:
+        elif stripped in ["set_fact:", "ansible.builtin.set_fact:", "vars:"]:
             changeable = False
             include_role = False
         elif stripped == "roles:":
             changeable = True
             include_role = False
-        elif stripped.startswith("include_role:"):
+        elif (stripped.startswith("include_role:") or
+              stripped.startswith("ansible.builtin.include_role:")):
             include_role = True
         elif include_role and stripped.startswith("name:"):
             line = po2.sub(pattern2, line)

--- a/utils/get_test_modules.py
+++ b/utils/get_test_modules.py
@@ -27,7 +27,9 @@ def get_plugins_from_playbook(playbook):
                     task = task.split(".")[-1]
                 if task == "block":
                     _result.update(get_tasks(tasks["block"]))
-                elif task in ["include_tasks", "import_tasks"]:
+                elif task in ["include_tasks", "import_tasks"
+                              "ansible.builtin.include_tasks",
+                              "ansible.builtin.import_tasks"]:
                     parent = os.path.dirname(playbook)
                     include_task = tasks[task]
                     if isinstance(include_task, dict):
@@ -37,7 +39,8 @@ def get_plugins_from_playbook(playbook):
                     else:
                         include_file = os.path.join(parent, include_task)
                     _result.update(get_plugins_from_playbook(include_file))
-                elif task == "include_role":
+                elif task in ["include_role",
+                              "ansible.builtin.include_role"]:
                     _result.add(f"_{tasks[original_task]['name']}")
                 elif task.startswith("ipa"):
                     # assume we are only interested in 'ipa*' modules/roles


### PR DESCRIPTION
The ansible builtins are using the ansible.builtin. prefix now, but the utils files were lacking support for this.