### PR TITLE
.github/workflows/lint.yml: ansible-lint needs collection source dir

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,11 +17,9 @@ jobs:
       - name: Run ansible-lint
         run: |
           pip install "ansible-core >=2.14,<2.15" ansible-lint
-          find playbooks roles tests -name '*.yml' ! -name "env_*" ! -name "tasks_*" -exec ansible-lint --force-color {} \+
-        env:
-          ANSIBLE_MODULE_UTILS: plugins/module_utils
-          ANSIBLE_LIBRARY: plugins/modules
-          ANSIBLE_DOC_FRAGMENT_PLUGINS: plugins/doc_fragments
+          utils/build-galaxy-release.sh -ki
+          cd .galaxy-build
+          ansible-lint roles plugins
 
   yamllint:
     name: Verify yamllint


### PR DESCRIPTION
ansible-lint required to be run in a collection source directory with correct and working galaxy.yml

As ansible-freeipa is not converted to a collection, the galaxy.yml file can not be used to create the collection. This needs to be done with utils/build-galaxy-release.sh. The script is fixing all the prefixes for the roles and modules in all the yml files and also example snippets and in the documentation.

Therefore utils/build-galaxy-release.sh is called with the "-k" option to keep the dictory that has been used to generate the collection with the script. Afterwards ansible-lint is run in this build directory.