### PR TITLE
pwpolicy: Fix tests for 'minlength: ""'

### DIFF
--- a/tests/pwpolicy/test_pwpolicy.yml
+++ b/tests/pwpolicy/test_pwpolicy.yml
@@ -175,7 +175,13 @@
       name: ops
       minlength: ""
     register: result
-    failed_when: result.changed or (result.failed and "int() argument must be a string, a bytes-like object" not in result.msg)
+    failed_when:
+        result.changed or (
+            result.failed and not (
+                "an internal error has occurred" in result.msg
+                or "int() argument must be" in result.msg
+            )
+        )
     when: ipa_version is version("4.9", ">=")
 
   - name: Ensure minlength is not cleared due to FreeIPA issue


### PR DESCRIPTION
When clearing minimum length parameter, FreeIPA raises an error, and the error is different when executing the playbook in server or client context. Since the error message is evaluated in the text, both errors must be accepted as "not a failure", since ansible-freeipa did the correct call.

Once https://pagure.io/freeipa/issue/9297 is fixed, the test must be updated to not accept any of these error messages.