### PR TITLE
playbooks: Fix automount tasks to make ansible-lint happy

### DIFF
--- a/playbooks/automount/automount-map-absent.yml
+++ b/playbooks/automount/automount-map-absent.yml
@@ -4,7 +4,7 @@
   become: no
 
   tasks:
-  - name: ensure map TestMap is absent
+  - name: Ensure map TestMap is absent
     ipaautomountmap:
       ipaadmin_password: SomeADMINpassword
       name: TestMap

--- a/playbooks/automount/automount-map-present.yml
+++ b/playbooks/automount/automount-map-present.yml
@@ -4,7 +4,7 @@
   become: no
 
   tasks:
-  - name: ensure map TestMap is present
+  - name: Ensure map TestMap is present
     ipaautomountmap:
       ipaadmin_password: SomeADMINpassword
       name: TestMap


### PR DESCRIPTION
A few playbooks still had task name starting with lower case letters.