### PR TITLE
upstream CI: increase Azure test timeout.

### DIFF
--- a/tests/azure/templates/galaxy_pytest_script.yml
+++ b/tests/azure/templates/galaxy_pytest_script.yml
@@ -15,7 +15,7 @@ parameters:
 jobs:
 - job: Test_PyTests
   displayName: Run pytests on ${{ parameters.scenario }}
-  timeoutInMinutes: 120
+  timeoutInMinutes: 240
   steps:
   - task: UsePythonVersion@0
     inputs:

--- a/tests/azure/templates/galaxy_script.yml
+++ b/tests/azure/templates/galaxy_script.yml
@@ -22,7 +22,7 @@ parameters:
 jobs:
 - job: Test_Group${{ parameters.group_number }}
   displayName: Run playbook tests ${{ parameters.scenario }} (${{ parameters.group_number }}/${{ parameters.number_of_groups }})
-  timeoutInMinutes: 120
+  timeoutInMinutes: 240
   variables:
   - template: variables.yaml
   - template: variables_${{ parameters.scenario }}.yaml

--- a/tests/azure/templates/playbook_fast.yml
+++ b/tests/azure/templates/playbook_fast.yml
@@ -21,7 +21,7 @@ parameters:
 jobs:
 - job: Test_Group${{ parameters.group_number }}
   displayName: Run playbook tests ${{ parameters.scenario }} (${{ parameters.group_number }}/${{ parameters.number_of_groups }})
-  timeoutInMinutes: 120
+  timeoutInMinutes: 240
   variables:
   - template: variables.yaml
   - template: variables_${{ parameters.scenario }}.yaml

--- a/tests/azure/templates/playbook_tests.yml
+++ b/tests/azure/templates/playbook_tests.yml
@@ -21,7 +21,7 @@ parameters:
 jobs:
 - job: Test_Group${{ parameters.group_number }}
   displayName: Run playbook tests ${{ parameters.scenario }} (${{ parameters.group_number }}/${{ parameters.number_of_groups }})
-  timeoutInMinutes: 120
+  timeoutInMinutes: 240
   variables:
   - template: variables.yaml
   - template: variables_${{ parameters.scenario }}.yaml

--- a/tests/azure/templates/pytest_tests.yml
+++ b/tests/azure/templates/pytest_tests.yml
@@ -15,7 +15,7 @@ parameters:
 jobs:
 - job: Test_PyTests
   displayName: Run pytests on ${{ parameters.scenario }}
-  timeoutInMinutes: 120
+  timeoutInMinutes: 240
   variables:
   - template: variables.yaml
   - template: variables_${{ parameters.scenario }}.yaml


### PR DESCRIPTION
Due to DNS issues and the increase number of tests, the timeout setting used for upstream tests was being reached. As we still have room for running the tests using Azure infrastructure, this patch increases the timeout to 240 minutes (4h), per worker.