### PR TITLE
Fix bug with ipaclient_test ca_cert_files

### DIFF
--- a/roles/ipaclient/library/ipaclient_test.py
+++ b/roles/ipaclient/library/ipaclient_test.py
@@ -434,7 +434,6 @@ def main():
                 if not isinstance(value, list):
                     raise ValueError("Expected list, got {!r}".format(value))
                 # this is what init() does
-                value = value[-1]
                 if not os.path.exists(value):
                     raise ValueError("'%s' does not exist" % value)
                 if not os.path.isfile(value):

--- a/roles/ipaclient/tasks/install.yml
+++ b/roles/ipaclient/tasks/install.yml
@@ -329,7 +329,7 @@
         domain: "{{ result_ipaclient_test.domain }}"
         servers: "{{ result_ipaclient_test.servers }}"
         kdc: "{{ result_ipaclient_test.kdc }}"
-        dnsok: "{{ result_ipaclient_test.dnsok }}"
+        dnsok: "{{ override_krb5_dns | d(result_ipaclient_test.dnsok) }}"
         client_domain: "{{ result_ipaclient_test.client_domain }}"
         hostname: "{{ result_ipaclient_test.hostname }}"
         sssd: "{{ result_ipaclient_test.sssd }}"


### PR DESCRIPTION
This line appears unnecessary and results in a misleading error when ipaclient_ca_cert_file is set to a list.