### PR TITLE
ipabackup: Use ipabackup_item again in copy_backup_to_server

### DIFF
--- a/roles/ipabackup/tasks/copy_backup_to_server.yml
+++ b/roles/ipabackup/tasks/copy_backup_to_server.yml
@@ -14,13 +14,13 @@
 
 - name: Set ipabackup_item
   ansible.builtin.set_fact:
-    __derived_item:
+    ipabackup_item:
       "{{ ipabackup_name | regex_search('.*_(ipa-.+)', '\\1') | first }}"
   when: "'_ipa-' in ipabackup_name"
 
 - name: Set ipabackup_item
   ansible.builtin.set_fact:
-    __derived_item: "{{ ipabackup_name }}"
+    ipabackup_item: "{{ ipabackup_name }}"
   when: "'_ipa-' not in ipabackup_name"
 
 - name: Stat backup to copy
@@ -35,10 +35,10 @@
     msg: "Unable to find backup {{ ipabackup_name }}"
   when: result_backup_stat.stat.isdir is not defined
 
-- name: Copy backup files to server for "{{ __derived_item }}"
+- name: Copy backup files to server for "{{ ipabackup_item }}"
   ansible.builtin.copy:
     src: "{{ __derived_controller_dir }}/{{ ipabackup_name }}/"
-    dest: "{{ ipabackup_dir }}/{{ __derived_item }}"
+    dest: "{{ ipabackup_dir }}/{{ ipabackup_item }}"
     owner: root
     group: root
     mode: u=rw,go=r


### PR DESCRIPTION
ipabackup_item needs to be set again in copy_backup_to_server.yml. The variable is later on used in restore.yml.