### PR TITLE
Fix ansible-lint on tests

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -13,8 +13,8 @@ homepage: "https://github.com/freeipa/ansible-freeipa"
 issues: "https://github.com/freeipa/ansible-freeipa/issues"
 
 readme: "README.md"
-license: "GPL-3.0-or-later"
-
+license:
+  - "GPL-3.0-or-later"
 tags:
   - "linux"
   - "system"

--- a/tests/config/test_config.yml
+++ b/tests/config/test_config.yml
@@ -59,13 +59,13 @@
           pac_type: ""
 
       - name: Execute tests if ipa_version >= 4.8.0
+        when: ipa_version is version('4.8.0', '>=')
         block:
           - name: Set maxhostname to 255
             ipaconfig:
               ipaadmin_password: SomeADMINpassword
               ipaapi_context: "{{ ipa_context | default(omit) }}"
               maxhostname: 255
-        when: ipa_version is version('4.8.0', '>=')
 
       - name: Set maxusername to 45
         ipaconfig:
@@ -225,6 +225,7 @@
         failed_when: result.changed or result.failed
 
       - name: Execute tests if ipa_version >= 4.8.0
+        when: ipa_version is version('4.8.0', '>=')
         block:
           - name: Set maxhostname to 77
             ipaconfig:
@@ -241,7 +242,6 @@
               maxhostname: 77
             register: result
             failed_when: result.changed or result.failed
-        when: ipa_version is version('4.8.0', '>=')
 
       - name: Set pwdexpnotify to 17
         ipaconfig:
@@ -415,13 +415,13 @@
         failed_when: not result.changed or result.failed
 
       - name: Execute tests if ipa_version >= 4.8.0
+        when: ipa_version is version('4.8.0', '>=')
         block:
           - name: Reset maxhostname
             ipaconfig:
               ipaadmin_password: SomeADMINpassword
               ipaapi_context: "{{ ipa_context | default(omit) }}"
               maxhostname: '{{ previousconfig.config.maxhostname | default(omit) }}'
-        when: ipa_version is version('4.8.0', '>=')
 
       - name: Reset changed fields, again
         ipaconfig:
@@ -451,13 +451,13 @@
         failed_when: result.changed or result.failed
 
       - name: Execute tests if ipa_version >= 4.8.0
+        when: ipa_version is version('4.8.0', '>=')
         block:
           - name: Reset maxhostname
             ipaconfig:
               ipaadmin_password: SomeADMINpassword
               ipaapi_context: "{{ ipa_context | default(omit) }}"
               maxhostname: '{{ previousconfig.config.maxhostname | default(omit) }}'
-        when: ipa_version is version('4.8.0', '>=')
 
     rescue:
       - name: Set fields to IPA default, due to error

--- a/tests/config/test_config_sid.yml
+++ b/tests/config/test_config_sid.yml
@@ -19,6 +19,8 @@
 
   # TESTS
   - name: Test config sid
+    # only run tests if version supports enable-sid
+    when: ipa_version is version("4.9.8", ">=")
     block:
     - name: Check if SID is enabled.
       ipaconfig:
@@ -115,8 +117,6 @@
         ipaapi_context: "{{ ipa_context | default(omit) }}"
         add_sids: yes
 
-    # only run tests if version supports enable-sid
-    when: ipa_version is version("4.9.8", ">=")
     # REVERT TO PREVIOUS CONFIG
     always:
     # Once SID is enabled, it cannot be reverted.

--- a/tests/env_freeipa_facts.yml
+++ b/tests/env_freeipa_facts.yml
@@ -31,6 +31,7 @@
     trust_test_is_supported: no
 
 - name: Ensure ipaserver_domain is set
+  when: ipaserver_domain is not defined
   block:
   - name: Get Domain from server name
     ansible.builtin.set_fact:
@@ -41,4 +42,3 @@
     ansible.builtin.set_fact:
       ipaserver_domain: "ipa.test"
     when: "'fqdn' not in ansible_facts"
-  when: ipaserver_domain is not defined

--- a/tests/group/test_group.yml
+++ b/tests/group/test_group.yml
@@ -138,6 +138,7 @@
     # service
 
   - name: Execute tests if ipa_verison >= 4.7.0
+    when: ipa_version is version('4.7.0', '>=')
     block:
 
     - name: Ensure service "{{ 'HTTP/' + fqdn_at_domain }}" is present in group group1
@@ -281,8 +282,6 @@
         state: absent
       register: result
       failed_when: result.changed or result.failed
-
-    when: ipa_version is version('4.7.0', '>=')
 
     # user
 

--- a/tests/group/test_group_external_members.yml
+++ b/tests/group/test_group_external_members.yml
@@ -10,6 +10,7 @@
     ansible.builtin.include_tasks: ../env_freeipa_facts.yml
 
   - name: Execute group tests if trust test environment is supported
+    when: trust_test_is_supported | default(false)
     block:
 
     - name: Add nonposix group.
@@ -111,5 +112,3 @@
         ipaadmin_password: SomeADMINpassword
         name: extgroup
         state: absent
-
-    when: trust_test_is_supported | default(false)

--- a/tests/group/test_group_external_nonposix.yml
+++ b/tests/group/test_group_external_nonposix.yml
@@ -205,6 +205,7 @@
     # EXTERNAL MEMBER TEST (REQUIRES AD)
 
     - name: Execute group tests if trust test environment is supported
+      when: trust_test_is_supported | default(false)
       block:
 
       - name: Ensure users testuser1, testuser2 and testuser3 are present in group externalgroup
@@ -230,8 +231,6 @@
           - testuser3
         register: result
         failed_when: result.changed or result.failed
-
-      when: trust_test_is_supported | default(false)
 
     # CONVERT NONPOSIX TO POSIX GROUP WITH USERS
 

--- a/tests/group/test_group_idoverrideuser.yml
+++ b/tests/group/test_group_idoverrideuser.yml
@@ -13,6 +13,7 @@
       ansible.builtin.include_tasks: ../env_freeipa_facts.yml
 
     - name: Execute tests if ipa_verison >= 4.8.7 and trust test environment is supported
+      when: ipa_version is version("4.8.7", ">=") and trust_test_is_supported | default(false)
       block:
       - name: Create idoverrideuser.
         ansible.builtin.shell: |
@@ -102,5 +103,3 @@
           ipa idoverrideuser-del "Default Trust View" {{ ad_user }}
           kdestroy -A -q -c idoverride_cache
         when:
-
-      when: ipa_version is version("4.8.7", ">=") and trust_test_is_supported | default(false)

--- a/tests/group/test_group_idoverrideuser.yml
+++ b/tests/group/test_group_idoverrideuser.yml
@@ -98,8 +98,8 @@
 
       always:
       - name: Remove idoverrideuser.
-        ansible.builtin.shell: |
-          kinit -c idoverride_cache admin <<< SomeADMINpassword
-          ipa idoverrideuser-del "Default Trust View" {{ ad_user }}
-          kdestroy -A -q -c idoverride_cache
-        when:
+        ansible.builtin.shell:
+          cmd: |
+            kinit -c idoverride_cache admin <<< SomeADMINpassword
+            ipa idoverrideuser-del "Default Trust View" {{ ad_user }}
+            kdestroy -A -q -c idoverride_cache

--- a/tests/group/test_group_membermanager.yml
+++ b/tests/group/test_group_membermanager.yml
@@ -9,6 +9,7 @@
     ansible.builtin.include_tasks: ../env_freeipa_facts.yml
 
   - name: Execute tests if ipa_verison >= 4.8.4
+    when: ipa_version is version('4.8.4', '>=')
     block:
       - name: Ensure user manangeruser1 and manageruser2 is absent
         ipauser:
@@ -206,5 +207,3 @@
           state: absent
         register: result
         failed_when: not result.changed or result.failed
-
-    when: ipa_version is version('4.8.4', '>=')

--- a/tests/hostgroup/test_hostgroup_membermanager.yml
+++ b/tests/hostgroup/test_hostgroup_membermanager.yml
@@ -9,6 +9,7 @@
     ansible.builtin.include_tasks: ../env_freeipa_facts.yml
 
   - name: Tests requiring IPA version 4.8.4+
+    when: ipa_version is version('4.8.4', '>=')
     block:
       - name: Ensure host-group testhostgroup is absent
         ipahostgroup:
@@ -224,4 +225,3 @@
           state: absent
         register: result
         failed_when: not result.changed or result.failed
-    when: ipa_version is version('4.8.4', '>=')

--- a/tests/hostgroup/test_hostgroup_rename.yml
+++ b/tests/hostgroup/test_hostgroup_rename.yml
@@ -9,6 +9,7 @@
     ansible.builtin.include_tasks: ../env_freeipa_facts.yml
 
   - name: Tests requiring IPA version 4.8.7+
+    when: ipa_version is version('4.8.7', '>=')
     block:
       - name: Ensure testing host-group are absent
         ipahostgroup:
@@ -108,5 +109,3 @@
           - databases
           - datalake
           state: absent
-
-    when: ipa_version is version('4.8.7', '>=')

--- a/tests/idrange/test_idrange.yml
+++ b/tests/idrange/test_idrange.yml
@@ -120,6 +120,7 @@
           name: local_id_range
 
   - name: Execute idrange tests if trust test environment is supported
+    when: trust_test_is_supported | default(false)
     block:
       # Create trust with range_type: ipa-ad-trust
       - name: Create trust with range_type 'ipa-ad-trust'
@@ -367,5 +368,3 @@
             - ad_posix_id_range
           continue: yes
           state: absent
-
-    when: trust_test_is_supported | default(false)

--- a/tests/role/env_facts.yml
+++ b/tests/role/env_facts.yml
@@ -1,5 +1,6 @@
 ---
 - name: Ensure ipaserver_domain is set
+  when: ipaserver_domain is not defined
   block:
   - name: Get Domain from server name
     ansible.builtin.set_fact:
@@ -9,7 +10,6 @@
     ansible.builtin.set_fact:
       ipaserver_domain: "ipa.test"
     when: "'fqdn' not in ansible_facts"
-  when: ipaserver_domain is not defined
 
 - name: Set ipaserver_realm.
   ansible.builtin.set_fact:

--- a/tests/server/test_server.yml
+++ b/tests/server/test_server.yml
@@ -8,6 +8,7 @@
 
   # CLEANUP TEST ITEMS
   - name: Ensure ipa_server_name is set
+    when: ipa_server_name is not defined
     block:
       - name: Get server name from hostname
         ansible.builtin.set_fact:
@@ -16,9 +17,9 @@
       - name: Fallback to 'ipaserver'
         ansible.builtin.set_fact:
           ipa_server_name: ipaserver
-    when: ipa_server_name is not defined
 
   - name: Ensure ipaserver_domain is set
+    when: ipaserver_domain is not defined
     block:
       - name: Get domain name from hostname.
         ansible.builtin.set_fact:
@@ -27,7 +28,6 @@
       - name: Fallback to 'ipa.test'
         ansible.builtin.set_fact:
           ipaserver_domain: "ipa.test"
-    when: ipaserver_domain is not defined
 
   - name: Ensure server "{{ ipa_server_name + '.' + ipaserver_domain }}" without location
     ipaserver:

--- a/tests/service/test_service.yml
+++ b/tests/service/test_service.yml
@@ -22,6 +22,7 @@
 
   # tests
   - name: Tests with skip_host_check, require IPA version 4.8.0+.
+    when: ipa_version is version('4.7.0', '>=')
     block:
       - name: Setup test environment
         ansible.builtin.include_tasks: env_setup.yml
@@ -577,4 +578,3 @@
       # cleanup
       - name: Cleanup test environment
         ansible.builtin.include_tasks: env_cleanup.yml
-    when: ipa_version is version('4.7.0', '>=')

--- a/tests/servicedelegationrule/test_servicedelegationrule_hostprincipal.yml
+++ b/tests/servicedelegationrule/test_servicedelegationrule_hostprincipal.yml
@@ -10,6 +10,7 @@
     ansible.builtin.include_tasks: ../env_freeipa_facts.yml
 
   - name: Host principals are only possible with IPA 4.9.0+
+    when: ipa_version is version('4.9.0', '>=')
     block:
 
     # SET FACTS
@@ -145,5 +146,3 @@
         state: absent
       register: result
       failed_when: not result.changed or result.failed
-
-    when: ipa_version is version('4.9.0', '>=')

--- a/tests/servicedelegationtarget/test_servicedelegationtarget_hostprincipal.yml
+++ b/tests/servicedelegationtarget/test_servicedelegationtarget_hostprincipal.yml
@@ -10,6 +10,7 @@
     ansible.builtin.include_tasks: ../env_freeipa_facts.yml
 
   - name: Host principals are only possible with IPA 4.9.0+
+    when: ipa_version is version('4.9.0', '>=')
     block:
 
     # SET FACTS
@@ -145,5 +146,3 @@
         state: absent
       register: result
       failed_when: not result.changed or result.failed
-
-    when: ipa_version is version('4.9.0', '>=')

--- a/tests/trust/test_trust.yml
+++ b/tests/trust/test_trust.yml
@@ -17,10 +17,9 @@
     ipa_range_exists: 'Range name: {{ ipaserver.realm }}_subid_range'
 
   tasks:
-
   - name: Run tust tests, if supported by environment
+    when: trust_test_is_supported | default(false)
     block:
-
     - name: Delete test trust
       ipatrust:
         ipaadmin_password: SomeADMINpassword
@@ -165,5 +164,3 @@
         ipa idrange-del {{ adserver.realm }}_id_range || true
         ipa idrange-del {{ ipaserver.realm }}_subid_range || true
         kdestroy -c test_krb5_cache -q -A
-
-    when: trust_test_is_supported | default(false)

--- a/tests/user/test_users_absent.yml
+++ b/tests/user/test_users_absent.yml
@@ -10,7 +10,7 @@
   tasks:
   - name: Include users.json
     ansible.builtin.include_vars:
-      file: users.json  # noqa 505
+      file: users.json  # noqa missing-import
 
   - name: Create dict with user names
     ansible.builtin.set_fact:

--- a/tests/user/test_users_present.yml
+++ b/tests/user/test_users_present.yml
@@ -10,7 +10,7 @@
   tasks:
   - name: Include users.json
     ansible.builtin.include_vars:
-      file: users.json  # noqa 505
+      file: users.json  # noqa missing-import
 
   - name: Users present len:{{ users | length }}
     ipauser:

--- a/tests/user/test_users_present_slice.yml
+++ b/tests/user/test_users_present_slice.yml
@@ -12,7 +12,7 @@
   tasks:
   - name: Include users.json
     ansible.builtin.include_vars:
-      file: users.json  # noqa 505
+      file: users.json  # noqa missing-import
   - name: Size of users slice.
     ansible.builtin.debug:
       msg: "{{ users | length }}"

--- a/tests/vault/test_vault_change_type.yml
+++ b/tests/vault/test_vault_change_type.yml
@@ -31,6 +31,8 @@
     failed_when: result.failed or not result.changed
 
   - name: Change vault type from asymmetric to symmetric
+    vars:
+      krb5ccname: verify_change_from_asymmetric
     block:
     - name: Change from asymmetric to symmetric
       ipavault:
@@ -50,10 +52,9 @@
       register: result
       failed_when: result.failed or "Public Key:" in result.stdout
 
-    vars:
-      krb5ccname: verify_change_from_asymmetric
-
   - name: Change vault type from symmetric to standard
+    vars:
+      krb5ccname: verify_change_from_symmetric
     block:
     - name: Change from symmetric to standard
       ipavault:
@@ -72,9 +73,6 @@
       register: result
       failed_when: result.failed or "Salt:" in result.stdout
 
-    vars:
-      krb5ccname: verify_change_from_symmetric
-
   - name: Change from standard to symmetric
     ipavault:
       ipaadmin_password: SomeADMINpassword
@@ -85,6 +83,8 @@
     failed_when: result.failed or not result.changed
 
   - name: Change vault type from symmetric to asymmetric
+    vars:
+      krb5ccname: verify_change_from_symmetric
     block:
     - name: Change from symmetric to asymmetric
       ipavault:
@@ -104,10 +104,9 @@
       register: result
       failed_when: result.failed or "Salt:" in result.stdout
 
-    vars:
-      krb5ccname: verify_change_from_symmetric
-
   - name: Change vault type from asymmetric to standard
+    vars:
+      krb5ccname: verify_change_from_asymmetric
     block:
     - name: Change from asymmetric to standard
       ipavault:
@@ -125,9 +124,6 @@
          kdestroy -A -q -c {{ krb5ccname }}
       register: result
       failed_when: result.failed or "Public Key:" in result.stdout
-
-    vars:
-      krb5ccname: verify_change_from_asymmetric
 
   - name: Ensure test_vault is absent.
     ipavault:
@@ -161,6 +157,8 @@
     failed_when: result.failed or result.changed or result.vault.data != 'hello'
 
   - name: Change vault type from asymmetric to symmetric, with data
+    vars:
+      krb5ccname: verify_change_from_asymmetric
     block:
     - name: Change from asymmetric to symmetric, with data
       ipavault:
@@ -180,9 +178,6 @@
       register: result
       failed_when: result.failed or "Public Key:" in result.stdout
 
-    vars:
-      krb5ccname: verify_change_from_asymmetric
-
   - name: Retrieve data from symmetric vault.
     ipavault:
       ipaadmin_password: SomeADMINpassword
@@ -193,6 +188,8 @@
     failed_when: result.failed or result.changed or result.vault.data != 'hello'
 
   - name: Change vault type from symmetric to standard, with data
+    vars:
+      krb5ccname: verify_change_from_symmetric
     block:
     - name: Change from symmetric to standard, with data
       ipavault:
@@ -210,9 +207,6 @@
          kdestroy -A -q -c {{ krb5ccname }}
       register: result
       failed_when: result.failed or "Salt:" in result.stdout
-
-    vars:
-      krb5ccname: verify_change_from_symmetric
 
   - name: Retrieve data from standard vault.
     ipavault:
@@ -241,6 +235,8 @@
     failed_when: result.failed or result.changed or result.vault.data != 'hello'
 
   - name: Change vault type from symmetric to asymmetric, with data
+    vars:
+      krb5ccname: verify_change_from_symmetric
     block:
     - name: Change from symmetric to asymmetric, with data
       ipavault:
@@ -260,9 +256,6 @@
       register: result
       failed_when: result.failed or "Salt:" in result.stdout
 
-    vars:
-      krb5ccname: verify_change_from_symmetric
-
   - name: Retrieve data from asymmetric vault.
     ipavault:
       ipaadmin_password: SomeADMINpassword
@@ -273,6 +266,8 @@
     failed_when: result.failed or result.changed or result.vault.data != 'hello'
 
   - name: Change vault type from asymmetric to standard, with data
+    vars:
+      krb5ccname: verify_change_from_asymmetric
     block:
     - name: Change from asymmetric to standard, with data
       ipavault:
@@ -290,9 +285,6 @@
          kdestroy -A -q -c {{ krb5ccname }}
       register: result
       failed_when: result.failed or "Public Key:" in result.stdout
-
-    vars:
-      krb5ccname: verify_change_from_asymmetric
 
   - name: Retrieve data from standard vault.
     ipavault:


### PR DESCRIPTION
Recent PR checks are failing due to `ansible-lint` being more strict and complaining about errors it didn't before.

With this PR, the errors are fixed and pre-commit is updated to match the upstream tool versions, so verification can be done, also, on commit time, before opening a PR.

> By merging this changes, the PRs which are showing `ansible-lint` failures need to be rebased to `upstream/master`.