### PR TITLE
Migrated to SPDX license.

### DIFF
--- a/utils/ansible-freeipa.spec.in
+++ b/utils/ansible-freeipa.spec.in
@@ -10,7 +10,7 @@ Name: ansible-freeipa
 Version: @@VERSION@@
 Release: @@RELEASE@@%{?dist}
 URL: https://github.com/freeipa/ansible-freeipa
-License: GPLv3+
+License: GPL-3.0-or-later
 Source: %{name}-%{version}-@@RELEASE@@.tar.bz2
 BuildArch: noarch
 


### PR DESCRIPTION
According to [1] all Fedora packages need to be updated to use a SPDX expression. This patch updates the ansible-freeipa spec template to comply with this change.

[1] https://fedoraproject.org/wiki/Changes/SPDX_Licenses_Phase_1