### PR TITLE
ipauser: Make return value depending on users parameter

### DIFF
--- a/README-user.md
+++ b/README-user.md
@@ -434,8 +434,8 @@ There are only return values if one or more random passwords have been generated
 Variable | Description | Returned When
 -------- | ----------- | -------------
 `user` | User dict with random password. (dict) <br>Options: | If random is yes and user did not exist or update_password is yes
-&nbsp; | `randompassword` - The generated random password | If only one user is handled by the module
-&nbsp; | `name` - The user name of the user that got a new random password. (dict) <br> Options: <br> &nbsp; `randompassword` - The generated random password | If several users are handled by the module
+&nbsp; | `randompassword` - The generated random password | If only one user is handled by the module without using the `users` parameter.
+&nbsp; | `name` - The user name of the user that got a new random password. (dict) <br> Options: <br> &nbsp; `randompassword` - The generated random password | If several users are handled by the module with the `users` parameter.
 
 
 Authors

--- a/plugins/modules/ipauser.py
+++ b/plugins/modules/ipauser.py
@@ -589,10 +589,12 @@ user:
     randompassword:
       description: The generated random password
       type: str
-      returned: If only one user is handled by the module
+      returned: |
+        If only one user is handled by the module without using users parameter
     name:
       description: The user name of the user that got a new random password
-      returned: If several users are handled by the module
+      returned: |
+        If several users are handled by the module with the users parameter
       type: dict
       contains:
         randompassword:
@@ -834,11 +836,11 @@ def gen_certmapdata_args(certmapdata):
 
 # pylint: disable=unused-argument
 def result_handler(module, result, command, name, args, errors, exit_args,
-                   one_name):
+                   single_user):
 
     if "random" in args and command in ["user_add", "user_mod"] \
        and "randompassword" in result["result"]:
-        if one_name:
+        if single_user:
             exit_args["randompassword"] = \
                 result["result"]["randompassword"]
         else:
@@ -861,7 +863,7 @@ def result_handler(module, result, command, name, args, errors, exit_args,
 
 
 # pylint: disable=unused-argument
-def exception_handler(module, ex, errors, exit_args, one_name):
+def exception_handler(module, ex, errors, exit_args, single_user):
     msg = str(ex)
     if "already contains" in msg \
        or "does not contain" in msg:
@@ -1511,7 +1513,7 @@ def main():
 
         changed = ansible_module.execute_ipa_commands(
             commands, result_handler, exception_handler,
-            exit_args=exit_args, one_name=len(names) == 1)
+            exit_args=exit_args, single_user=users is None)
 
     # Done
     ansible_module.exit_json(changed=changed, user=exit_args)

--- a/tests/user/test_user_random.yml
+++ b/tests/user/test_user_random.yml
@@ -36,6 +36,27 @@
       - user1
       state: absent
 
+  - name: User user1 is present with random password using users parameter
+    ipauser:
+      ipaadmin_password: SomeADMINpassword
+      users:
+      - name: user1
+        first: first1
+        last: last1
+        random: yes
+      update_password: on_create
+    register: ipauser
+    failed_when: not ipauser.changed or
+                 ipauser.user.user1.randompassword is not defined or
+                 ipauser.failed
+
+  - name: User user1 absent
+    ipauser:
+      ipaadmin_password: SomeADMINpassword
+      name:
+      - user1
+      state: absent
+
   - name: Users user1 and user2 present with random password
     ipauser:
       ipaadmin_password: SomeADMINpassword


### PR DESCRIPTION
The way how randompasswords are returned by the ipauser module depends so far on the number of users that are handled by the module.

This is unexpected if for example a json file is provided with the users parameter. As it might be unknown how many users are in the json file, this behaviour is unexpected. The return should not vary in this case.

This chamge makes the return simply depend on the use of the users paramater. As soon as this parameter is used, the return will always be:

"user": { "\<the user \>": { "randompassword": "\<the user random password\>" } }

In the simply case with one user it will be still

"user": { "randompassword": "\<the user random password\>" }

Fixes: #1052 (ipauser should consitently return randompasswords when
              used with users)