### PR TITLE
ipahost: Make return value depending on hosts parameter

### DIFF
--- a/README-host.md
+++ b/README-host.md
@@ -372,8 +372,8 @@ There are only return values if one or more random passwords have been generated
 Variable | Description | Returned When
 -------- | ----------- | -------------
 `host` | Host dict with random password. (dict) <br>Options: | If random is yes and host did not exist or update_password is yes
-&nbsp; | `randompassword` - The generated random password | If only one host is handled by the module
-&nbsp; | `name` - The host name of the host that got a new random password. (dict) <br> Options: <br> &nbsp; `randompassword` - The generated random password | If several hosts are handled by the module
+&nbsp; | `randompassword` - The generated random password | If only one host is handled by the module without using the `hosts` parameter.
+&nbsp; | `name` - The host name of the host that got a new random password. (dict) <br> Options: <br> &nbsp; `randompassword` - The generated random password | If several hosts are handled by the module with the `hosts` parameter.
 
 
 Authors

--- a/plugins/modules/ipahost.py
+++ b/plugins/modules/ipahost.py
@@ -44,7 +44,7 @@ options:
     aliases: ["fqdn"]
     required: false
   hosts:
-    description: The list of user host dicts
+    description: The list of host dicts
     required: false
     type: list
     elements: dict
@@ -466,16 +466,18 @@ EXAMPLES = """
 RETURN = """
 host:
   description: Host dict with random password
-  returned: If random is yes and user did not exist or update_password is yes
+  returned: If random is yes and host did not exist or update_password is yes
   type: dict
   contains:
     randompassword:
       description: The generated random password
       type: str
-      returned: If only one user is handled by the module
+      returned: |
+        If only one host is handled by the module without using hosts parameter
     name:
-      description: The user name of the user that got a new random password
-      returned: If several users are handled by the module
+      description: The host name of the host that got a new random password
+      returned: |
+        If several hosts are handled by the module with the hosts parameter
       type: dict
       contains:
         randompassword:
@@ -646,10 +648,10 @@ def check_parameters(   # pylint: disable=unused-argument
 
 # pylint: disable=unused-argument
 def result_handler(module, result, command, name, args, errors, exit_args,
-                   one_name):
+                   single_host):
     if "random" in args and command in ["host_add", "host_mod"] \
        and "randompassword" in result["result"]:
-        if one_name:
+        if single_host:
             exit_args["randompassword"] = \
                 result["result"]["randompassword"]
         else:
@@ -671,7 +673,7 @@ def result_handler(module, result, command, name, args, errors, exit_args,
 
 
 # pylint: disable=unused-argument
-def exception_handler(module, ex, errors, exit_args, one_name):
+def exception_handler(module, ex, errors, exit_args, single_host):
     msg = str(ex)
     if "already contains" in msg \
        or "does not contain" in msg:
@@ -1468,7 +1470,7 @@ def main():
 
         changed = ansible_module.execute_ipa_commands(
             commands, result_handler, exception_handler,
-            exit_args=exit_args, one_name=len(names) == 1)
+            exit_args=exit_args, single_host=hosts is None)
 
     # Done
 

--- a/tests/host/test_host_random.yml
+++ b/tests/host/test_host_random.yml
@@ -49,6 +49,26 @@
       - "{{ host1_fqdn }}"
       state: absent
 
+  - name: Host "{{ host1_fqdn }}" is present with random password using hosts parameter
+    ipahost:
+      ipaadmin_password: SomeADMINpassword
+      hosts:
+      - name: "{{ host1_fqdn }}"
+        random: yes
+        force: yes
+      update_password: on_create
+    register: ipahost
+    failed_when: not ipahost.changed or
+                 ipahost.host[host1_fqdn].randompassword is not defined or
+                 ipahost.failed
+
+  - name: Host "{{ host1_fqdn }}" absent
+    ipahost:
+      ipaadmin_password: SomeADMINpassword
+      name:
+      - "{{ host1_fqdn }}"
+      state: absent
+
   - name: Hosts "{{ host1_fqdn }}" and "{{ host2_fqdn }}" present with random password
     ipahost:
       ipaadmin_password: SomeADMINpassword


### PR DESCRIPTION
The way how randompasswords are returned by the ipahost module depends so far on the number of hosts that are handled by the module.

This is unexpected if for example a json file is provided with the hosts parameter. As it might be unknown how many hosts are in the json file, this behaviour is unexpected. The return should not vary in this case.

This chamge makes the return simply depend on the use of the hosts paramater. As soon as this parameter is used, the return will always be:

"host": { "\<the host\>": { "randompassword": "\<the host random password\>" } }

In the simply case with one host it will be still

"host": { "randompassword": "\<the host random password\>" }

This change for ipahost is related to the ipauser PR #1053.