### PR TITLE
roles/ipaserver: Allow deployments with random serial numbers

### DIFF
--- a/roles/ipaserver/README.md
+++ b/roles/ipaserver/README.md
@@ -168,6 +168,22 @@ Server installation step 2: Copy `<ipaserver hostname>-chain.crt` to the IPA ser
 
 The files can also be copied automatically: Set `ipaserver_copy_csr_to_controller` to true in the server installation step 1 and set `ipaserver_external_cert_files_from_controller` to point to the `chain.crt` file in the server installation step 2.
 
+Since version 4.10, FreeIPA supports creating certificates using random serial numbers. Random serial numbers is a global and permanent setting, that can only be activated while deploying the first server of the domain. Replicas will inherit this setting automatically. An example of an inventory file to deploy a server with random serial numbers enabled is:
+
+```ini
+[ipaserver]
+ipaserver.example.com
+
+[ipaserver:vars]
+ipaserver_domain=example.com
+ipaserver_realm=EXAMPLE.COM
+ipaadmin_password=MySecretPassword123
+ipadm_password=MySecretPassword234
+ipaserver_random_serial_number=true
+```
+
+By setting the variable in the inventory file, the same ipaserver deployment playbook, shown before, can be used.
+
 
 Example inventory file to remove a server from the domain:
 
@@ -263,6 +279,7 @@ Variable | Description | Required
 `ipaserver_no_ui_redirect` | Do not automatically redirect to the Web UI. (bool) | no
 `ipaserver_dirsrv_config_file` | The path to LDIF file that will be used to modify configuration of dse.ldif during installation. (string) | no
 `ipaserver_pki_config_override` | Path to ini file with config overrides. This is only usable with recent FreeIPA versions. (string) | no
+`ipaserver_random_serial_numbers` | Enable use of random serial numbers for certificates. Requires FreeIPA version 4.10 or later. (boolean) | no
 
 SSL certificate Variables
 -------------------------

--- a/roles/ipaserver/defaults/main.yml
+++ b/roles/ipaserver/defaults/main.yml
@@ -11,6 +11,7 @@ ipaserver_no_hbac_allow: no
 ipaserver_no_pkinit: no
 ipaserver_no_ui_redirect: no
 ipaserver_mem_check: yes
+ipaserver_random_serial_numbers: true
 ### ssl certificate ###
 ### client ###
 ipaclient_mkhomedir: no

--- a/roles/ipaserver/module_utils/ansible_ipa_server.py
+++ b/roles/ipaserver/module_utils/ansible_ipa_server.py
@@ -44,7 +44,7 @@ __all__ = ["IPAChangeConf", "certmonger", "sysrestore", "root_logger",
            "check_available_memory", "getargspec", "get_min_idstart",
            "paths", "api", "ipautil", "adtrust_imported", "NUM_VERSION",
            "time_service", "kra_imported", "dsinstance", "IPA_PYTHON_VERSION",
-           "NUM_VERSION"]
+           "NUM_VERSION", "SerialNumber"]
 
 import sys
 import logging
@@ -202,6 +202,13 @@ try:
             from ipaserver.install.server.install import get_min_idstart
         except ImportError:
             get_min_idstart = None
+
+        # SerialNumber is defined in versions 4.10 and later and is
+        # used by Random Serian Number v3.
+        try:
+            from ipalib.parameters import SerialNumber
+        except ImportError:
+            SerialNumber = None
 
     else:
         # IPA version < 4.5

--- a/roles/ipaserver/tasks/install.yml
+++ b/roles/ipaserver/tasks/install.yml
@@ -108,6 +108,7 @@
     external_cert_files: "{{ ipaserver_external_cert_files | default(omit) }}"
     subject_base: "{{ ipaserver_subject_base | default(omit) }}"
     ca_subject: "{{ ipaserver_ca_subject | default(omit) }}"
+    random_serial_numbers: "{{ ipaserver_random_serial_numbers | default(omit) }}"
     # ca_signing_algorithm
     ### dns ###
     allow_zone_overlap: "{{ ipaserver_allow_zone_overlap }}"
@@ -199,7 +200,7 @@
       ### additional ###
       setup_ca: "{{ result_ipaserver_test.setup_ca }}"
       sid_generation_always: "{{ result_ipaserver_test.sid_generation_always }}"
-      random_serial_numbers: no
+      random_serial_numbers: "{{ result_ipaserver_test.random_serial_numbers }}"
       _hostname_overridden: "{{ result_ipaserver_test._hostname_overridden }}"
     register: result_ipaserver_prepare
 


### PR DESCRIPTION
Since FreeIPA version 4.10 it is possible to deploy servers that use Random Serial Number v3 support for certificates.

This patch exposes the 'random_serial_numbers' parameter, as 'ipaserver_random_serial_numbers', allowing a user to have random serial numbers enabled for the domain.

The use of random serial numbers is allowed on new installations only.