### PR TITLE
ipareplica role: Remove usage of undefined parameters.

### DIFF
--- a/roles/ipareplica/tasks/install.yml
+++ b/roles/ipareplica/tasks/install.yml
@@ -255,10 +255,6 @@
       dirsrv_cert_files: "{{ ipareplica_dirsrv_cert_files | default([]) }}"
       ### client ###
       force_join: "{{ ipaclient_force_join }}"
-      ### ad trust ###
-      netbios_name: "{{ ipareplica_netbios_name | default(omit) }}"
-      rid_base: "{{ ipareplica_rid_base | default(omit) }}"
-      secondary_rid_base: "{{ ipareplica_secondary_rid_base | default(omit) }}"
       ### additional ###
       server: "{{ result_ipareplica_test.server }}"
       ccache: "{{ result_ipareplica_prepare.ccache }}"
@@ -297,10 +293,6 @@
       dirsrv_cert_files: "{{ ipareplica_dirsrv_cert_files | default([]) }}"
       ### client ###
       force_join: "{{ ipaclient_force_join }}"
-      ### ad trust ###
-      netbios_name: "{{ ipareplica_netbios_name | default(omit) }}"
-      rid_base: "{{ ipareplica_rid_base | default(omit) }}"
-      secondary_rid_base: "{{ ipareplica_secondary_rid_base | default(omit) }}"
       ### additional ###
       server: "{{ result_ipareplica_test.server }}"
       ccache: "{{ result_ipareplica_prepare.ccache }}"
@@ -339,10 +331,6 @@
       dirsrv_cert_files: "{{ ipareplica_dirsrv_cert_files | default([]) }}"
       ### client ###
       force_join: "{{ ipaclient_force_join }}"
-      ### ad trust ###
-      netbios_name: "{{ ipareplica_netbios_name | default(omit) }}"
-      rid_base: "{{ ipareplica_rid_base | default(omit) }}"
-      secondary_rid_base: "{{ ipareplica_secondary_rid_base | default(omit) }}"
       ### additional ###
       server: "{{ result_ipareplica_test.server }}"
       config_master_host_name:
@@ -397,10 +385,6 @@
       dirsrv_cert_files: "{{ ipareplica_dirsrv_cert_files | default([]) }}"
       ### client ###
       force_join: "{{ ipaclient_force_join }}"
-      ### ad trust ###
-      netbios_name: "{{ ipareplica_netbios_name | default(omit) }}"
-      rid_base: "{{ ipareplica_rid_base | default(omit) }}"
-      secondary_rid_base: "{{ ipareplica_secondary_rid_base | default(omit) }}"
       ### additional ###
       server: "{{ result_ipareplica_test.server }}"
       config_master_host_name:
@@ -481,10 +465,6 @@
       dirsrv_cert_files: "{{ ipareplica_dirsrv_cert_files | default([]) }}"
       ### client ###
       force_join: "{{ ipaclient_force_join }}"
-      ### ad trust ###
-      netbios_name: "{{ ipareplica_netbios_name | default(omit) }}"
-      rid_base: "{{ ipareplica_rid_base | default(omit) }}"
-      secondary_rid_base: "{{ ipareplica_secondary_rid_base | default(omit) }}"
       ### additional ###
       server: "{{ result_ipareplica_test.server }}"
       config_master_host_name:


### PR DESCRIPTION
Some ipareplica role had a few module calls with parameters set like 'some_argument | default(omit)' that were not actually available in such modules. If a user provided 'some_argument', the paramater would then be passed to the module and ipareplica deployment would fail.

By removing the parameters from the 'install' task, ipareplica deployment works even if the variables are set by the user.

Fixes #1061 