### PR TITLE
Ansible lint fixes

### DIFF
--- a/plugins/modules/ipanetgroup.py
+++ b/plugins/modules/ipanetgroup.py
@@ -93,10 +93,12 @@ options:
   action:
     description: Work on netgroup or member level
     required: false
+    type: str
     default: netgroup
     choices: ["member", "netgroup"]
   state:
     description: The state to ensure.
+    type: str
     choices: ["present", "absent"]
     default: present
 author:

--- a/plugins/modules/ipapwpolicy.py
+++ b/plugins/modules/ipapwpolicy.py
@@ -275,7 +275,7 @@ def main():
                              default=None),
             dictcheck=dict(type="str", aliases=["ipapwdictcheck"],
                            default=None),
-            usercheck=dict(type="str", aliases=["ipapwusercheck"],
+            usercheck=dict(type="str", aliases=["ipapwdusercheck"],
                            default=None),
             gracelimit=dict(type="str", aliases=["passwordgracelimit"],
                             default=None),

--- a/roles/ipaclient/library/ipaclient_configure_dns_resolver.py
+++ b/roles/ipaclient/library/ipaclient_configure_dns_resolver.py
@@ -266,10 +266,8 @@ def unconfigure_dns_resolver(fstore=None):
 def main():
     module = AnsibleModule(
         argument_spec=dict(
-            nameservers=dict(type="list", elements="str", aliases=["cn"],
-                             required=False),
-            searchdomains=dict(type="list", elements="str", aliases=["cn"],
-                               required=False),
+            nameservers=dict(type="list", elements="str", required=False),
+            searchdomains=dict(type="list", elements="str", required=False),
             state=dict(type="str", default="present",
                        choices=["present", "absent"]),
         ),

--- a/roles/ipareplica/tasks/install.yml
+++ b/roles/ipareplica/tasks/install.yml
@@ -759,13 +759,12 @@
         "{{ result_ipareplica_prepare.config_master_host_name }}"
     register: result_ipareplica_enable_ipa
 
+  always:
   - name: Install - Cleanup root IPA cache
     ansible.builtin.file:
       path: "/root/.ipa_cache"
       state: absent
-    when: result_ipareplica_enable_ipa.changed
 
-  always:
   - name: Cleanup temporary files
     ansible.builtin.file:
       path: "{{ item }}"

--- a/roles/ipaserver/tasks/install.yml
+++ b/roles/ipaserver/tasks/install.yml
@@ -446,12 +446,6 @@
         setup_ca: "{{ result_ipaserver_test.setup_ca }}"
       register: result_ipaserver_enable_ipa
 
-    - name: Install - Cleanup root IPA cache
-      ansible.builtin.file:
-        path: "/root/.ipa_cache"
-        state: absent
-      when: result_ipaserver_enable_ipa.changed
-
     - name: Install - Configure firewalld
       ansible.builtin.command: >
         firewall-cmd
@@ -480,6 +474,11 @@
       when: ipaserver_setup_firewalld | bool
 
   always:
+  - name: Install - Cleanup root IPA cache
+    ansible.builtin.file:
+      path: "/root/.ipa_cache"
+      state: absent
+
   - name: Cleanup temporary files
     ansible.builtin.file:
       path: "{{ item }}"

--- a/tests/config/test_config_sid.yml
+++ b/tests/config/test_config_sid.yml
@@ -30,7 +30,7 @@
       check_mode: yes
       register: sid_disabled
 
-    - name: Ensure netbios_name can't be changed without SID enabled.
+    - name: Ensure netbios_name can't be changed without SID enabled.  # noqa 503
       ipaconfig:
         ipaadmin_password: SomeADMINpassword
         ipaapi_context: "{{ ipa_context | default(omit) }}"
@@ -39,7 +39,7 @@
       failed_when: not result.failed and "SID generation must be enabled" in result.msg
       when: sid_disabled.changed
 
-    - name: Ensure SIDs can't be changed without SID enabled.
+    - name: Ensure SIDs can't be changed without SID enabled.  # noqa 503
       ipaconfig:
         ipaadmin_password: SomeADMINpassword
         ipaapi_context: "{{ ipa_context | default(omit) }}"


### PR DESCRIPTION
The latest ansible-lint is failing with new errors again. Here are the fixes:

ipanetgroup: Missing type for action and state DOCUMENTATION section
    
    The types for the parameters action and state have been missing in the
    DOCUMENTATION section of the module.

ipapwpolicy: The alias for usercheck in argument_spec had typo
    
    The alias for usercheck in argument_spec was "ipapwusercheck" instead of
    "ipapwdusercheck".

ipaclient_configure_dns_resolver: Removed bad aliases
    
    The parameters nameservers and searchdomains had both the alias "cn".
    Both aliases have been removed.

ipareplica/server: Always cleanup root IPA cache
    
    The cleanup of the root IPA cache was depending on the result of the
    ipaserver_enable_ipa and ipareplica_enable_ipa tasks. Instead of
    "when: something.changed" a handler should be used instead. As
    "/root/.ipa_cache" should be removed always (same in command line) the
    removal of the file has been moded into the always section and does not
    need a when anymore.

tests/config/test_config_sid: Mark tasks as noqa 503
    
    The latest ansible-lint failes for the tasks that are using
    "when: sid_disabled.changed" with the error
    "Tasks that run when changed should likely be handlers.". As
    these tasks are tests and it would not make sense to use handlers here,
    the tasks have been marked as noqa 503.