### PR TITLE
add freeipa default module group

### DIFF
--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,5 +1,6 @@
 ---
 requires_ansible: ">=2.9"
+# added funktionality for feature request #1070
 action_groups:
   freeipa:
   - ipaadmin_principal

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,2 +1,8 @@
 ---
 requires_ansible: ">=2.9"
+action_groups:
+  freeipa:
+  - ipaadmin_principal
+  - ipaadmin_password
+  - ipaapi_context
+  - ipaapi_ldap_cache


### PR DESCRIPTION
FR add default_module groups #1070

this will allow users to use:
```
  module_defaults:
    group/freeipa.ansible.freeipa:
      ipaadmin_principal: "{{ ipaadmin_principal }}"
      ipaadmin_password: "{{ ipaadmin_password}}"
      ipaapi_context: "{{ ipaapi_context }}"
      ipaapi_ldap_cache: "{{ ipaapi_ldap_cache }}"
```
this way you can set that once in your playbook and not prove those on every single module that you want to use