### PR TITLE
ipagroup: Fix ensuring external group group members (without trust-ad)

### DIFF
--- a/plugins/modules/ipagroup.py
+++ b/plugins/modules/ipagroup.py
@@ -593,10 +593,12 @@ def main():
                 del_member_args["service"] = service_del
 
             if is_external_group(res_find):
-                add_member_args["ipaexternalmember"] = \
-                    externalmember_add
-                del_member_args["ipaexternalmember"] = \
-                    externalmember_del
+                if len(externalmember_add) > 0:
+                    add_member_args["ipaexternalmember"] = \
+                        externalmember_add
+                if len(externalmember_del) > 0:
+                    del_member_args["ipaexternalmember"] = \
+                        externalmember_del
             elif externalmember or external:
                 ansible_module.fail_json(
                     msg="Cannot add external members to a "

--- a/tests/group/test_group_external_group_members_no_trust.yml
+++ b/tests/group/test_group_external_group_members_no_trust.yml
@@ -1,0 +1,81 @@
+---
+- name: Test external group group members (without trust-ad installed)
+  hosts: ipaserver
+  become: true
+
+  tasks:
+  - name: Ensure external test groups are absent
+    ipagroup:
+      ipaadmin_password: SomeADMINpassword
+      name:
+      - externaltestgroup01
+      - externaltestgroup02
+      state: absent
+
+  - name: Create external test group 01
+    ipagroup:
+      ipaadmin_password: SomeADMINpassword
+      name: externaltestgroup01
+      external: true
+    register: result
+    failed_when: result.failed or not result.changed
+
+  - name: Create external test group 02
+    ipagroup:
+      ipaadmin_password: SomeADMINpassword
+      name: externaltestgroup02
+      external: true
+    register: result
+    failed_when: result.failed or not result.changed
+
+  - name: Ensure externaltestgroup02 is a member of externaltestgroup01
+    ipagroup:
+      ipaadmin_password: SomeADMINpassword
+      name: externaltestgroup01
+      action: member
+      group:
+      - externaltestgroup02
+    register: result
+    failed_when: result.failed or not result.changed
+
+  - name: Ensure externaltestgroup02 is a member of externaltestgroup01, again
+    ipagroup:
+      ipaadmin_password: SomeADMINpassword
+      name: externaltestgroup01
+      action: member
+      group:
+      - externaltestgroup02
+    register: result
+    failed_when: result.failed or result.changed
+
+  - name: Ensure externaltestgroup02 is not a member of externaltestgroup01
+    ipagroup:
+      ipaadmin_password: SomeADMINpassword
+      name: externaltestgroup01
+      action: member
+      group:
+      - externaltestgroup02
+      state: absent
+    register: result
+    failed_when: result.failed or not result.changed
+
+  - name: Ensure externaltestgroup02 is not a member of externaltestgroup01, again
+    ipagroup:
+      ipaadmin_password: SomeADMINpassword
+      name: externaltestgroup01
+      action: member
+      group:
+      - externaltestgroup02
+      state: absent
+    register: result
+    failed_when: result.failed or result.changed
+
+  - name: Ensure external test groups are absent
+    ipagroup:
+      ipaadmin_password: SomeADMINpassword
+      name:
+      - externaltestgroup01
+      - externaltestgroup02
+      state: absent
+    register: result
+    failed_when: result.failed or not result.changed


### PR DESCRIPTION
Due to an API misbehaviour in FreeIPA, ipaexternalmembers need to be
treated differently than other group members parameters. Even an empty
array triggers all tests for external members, including the check for
installed dcerpc bindings.

Therefore ipagroup module has been changed to not set ipaexternalmember
to an empty list if there are no external members to be added or
removed.
