### PR TITLE
ipaserver: Do not enable random serial numbers by default

### DIFF
--- a/roles/ipaserver/defaults/main.yml
+++ b/roles/ipaserver/defaults/main.yml
@@ -11,7 +11,7 @@ ipaserver_no_hbac_allow: no
 ipaserver_no_pkinit: no
 ipaserver_no_ui_redirect: no
 ipaserver_mem_check: yes
-ipaserver_random_serial_numbers: true
+ipaserver_random_serial_numbers: false
 ### ssl certificate ###
 ### client ###
 ipaclient_mkhomedir: no


### PR DESCRIPTION
ipaserver_random_serial_numbers was enabled by default in roles/ipaserver/defaults/main.yml. This should not be the default and also resulted in issues in all IPA versions that do not support RSN.

The parameter now defaults to false.