### PR TITLE
Make Git ignore temporary and output files.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,11 @@
 *.pyc
 *.retry
+*.swp
+
+# collection files
+freeipa-ansible_freeipa*.tar.gz
+redhat-rhel_idm*.tar.gz
+importer_result.json
 
 # ignore virtual environments
 /.tox/


### PR DESCRIPTION
Ignore vim .swp files and files generated by creating ansible-freeipa collection (freeipa-*.tar.gz and importer_result.json), when checking repository status.