### PR TITLE
pwpolicy test: Fix maxsequence test

### DIFF
--- a/tests/pwpolicy/test_pwpolicy.yml
+++ b/tests/pwpolicy/test_pwpolicy.yml
@@ -223,7 +223,7 @@
       ipapwpolicy:
         ipaadmin_password: SomeADMINpassword
         ipaapi_context: "{{ ipa_context | default(omit) }}"
-        maxrepeat: 4
+        maxsequence: 4
       register: result
       failed_when: not result.changed or result.failed
 
@@ -231,7 +231,7 @@
       ipapwpolicy:
         ipaadmin_password: SomeADMINpassword
         ipaapi_context: "{{ ipa_context | default(omit) }}"
-        maxrepeat: 4
+        maxsequence: 4
       register: result
       failed_when: result.changed or result.failed
 
@@ -239,7 +239,7 @@
       ipapwpolicy:
         ipaadmin_password: SomeADMINpassword
         ipaapi_context: "{{ ipa_context | default(omit) }}"
-        maxrepeat: 0
+        maxsequence: 0
       register: result
       failed_when: not result.changed or result.failed
 


### PR DESCRIPTION
The maxsequence test was testing maxrepeat. Therefore the typo reported with https://github.com/freeipa/ansible-freeipa/pull/1081 was never seen.

The test has been fixed.