### PR TITLE
tests/azure: Install molecule-plguins to get docker driver

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -105,7 +105,7 @@ It's also possible to run the tests in a container.
 Before setting up a container you will need to install molecule framework:
 
 ```
-pip install molecule[docker]>=3
+pip install molecule-plugins[docker]
 ```
 
 Now you can start a test container using the following command:

--- a/tests/azure/templates/build_container.yml
+++ b/tests/azure/templates/build_container.yml
@@ -22,7 +22,7 @@ jobs:
     retryCountOnTaskFailure: 5
     displayName: Install tools
 
-  - script: pip install molecule[docker]
+  - script: pip install molecule-plugins[docker]
     retryCountOnTaskFailure: 5
     displayName: Install molecule
 

--- a/tests/azure/templates/galaxy_pytest_script.yml
+++ b/tests/azure/templates/galaxy_pytest_script.yml
@@ -23,7 +23,7 @@ jobs:
 
   - script: |
       pip install \
-        "molecule[docker]>=3" \
+        "molecule-plugins[docker]" \
         "ansible${{ parameters.ansible_version }}"
     retryCountOnTaskFailure: 5
     displayName: Install molecule and Ansible

--- a/tests/azure/templates/galaxy_script.yml
+++ b/tests/azure/templates/galaxy_script.yml
@@ -33,7 +33,7 @@ jobs:
 
   - script: |
       pip install \
-        "molecule[docker]>=3" \
+        "molecule-plugins[docker]" \
         "ansible${{ parameters.ansible_version }}"
     retryCountOnTaskFailure: 5
     displayName: Install molecule and Ansible

--- a/tests/azure/templates/playbook_fast.yml
+++ b/tests/azure/templates/playbook_fast.yml
@@ -32,7 +32,7 @@ jobs:
 
   - script: |
       pip install \
-        "molecule[docker]>=3" \
+        "molecule-plugins[docker]" \
         "ansible${{ parameters.ansible_version }}"
     retryCountOnTaskFailure: 5
     displayName: Install molecule and Ansible

--- a/tests/azure/templates/playbook_tests.yml
+++ b/tests/azure/templates/playbook_tests.yml
@@ -32,7 +32,7 @@ jobs:
 
   - script: |
       pip install \
-        "molecule[docker]>=3" \
+        "molecule-plugins[docker]" \
         "ansible${{ parameters.ansible_version }}"
     retryCountOnTaskFailure: 5
     displayName: Install molecule and Ansible

--- a/tests/azure/templates/pytest_tests.yml
+++ b/tests/azure/templates/pytest_tests.yml
@@ -26,7 +26,7 @@ jobs:
 
   - script: |
       pip install \
-        "molecule[docker]>=3" \
+        "molecule-plugins[docker]" \
         "ansible${{ parameters.ansible_version }}"
     retryCountOnTaskFailure: 5
     displayName: Install molecule and Ansible


### PR DESCRIPTION
The docker driver is not part of molecule 5.0.0 anymore. molecule-plugins need to be installed to get the driver.