### PR TITLE
upstream ci: pin ansible-compat for molecule

### DIFF
--- a/tests/azure/templates/build_container.yml
+++ b/tests/azure/templates/build_container.yml
@@ -18,7 +18,8 @@ jobs:
     inputs:
       versionSpec: '${{ parameters.python_version }}'
 
-  - script: python -m pip install --upgrade pip setuptools wheel ansible
+  # 'ansible-compat<4' is required due to https://github.com/ansible-community/molecule/issues/3903
+  - script: python -m pip install --upgrade pip setuptools wheel ansible-core "ansible-compat<4"
     retryCountOnTaskFailure: 5
     displayName: Install tools
 

--- a/tests/azure/templates/galaxy_pytest_script.yml
+++ b/tests/azure/templates/galaxy_pytest_script.yml
@@ -21,10 +21,12 @@ jobs:
     inputs:
       versionSpec: '${{ parameters.python_version }}'
 
+  # 'ansible-compat<4' is required due to https://github.com/ansible-community/molecule/issues/3903
   - script: |
       pip install \
         "molecule-plugins[docker]" \
-        "ansible${{ parameters.ansible_version }}"
+        "ansible${{ parameters.ansible_version }}" \
+        "ansible-compat<4"
     retryCountOnTaskFailure: 5
     displayName: Install molecule and Ansible
 

--- a/tests/azure/templates/galaxy_script.yml
+++ b/tests/azure/templates/galaxy_script.yml
@@ -31,10 +31,12 @@ jobs:
     inputs:
       versionSpec: '${{ parameters.python_version }}'
 
+  # 'ansible-compat<4' is required due to https://github.com/ansible-community/molecule/issues/3903
   - script: |
       pip install \
         "molecule-plugins[docker]" \
-        "ansible${{ parameters.ansible_version }}"
+        "ansible${{ parameters.ansible_version }}" \
+        "ansible-compat<4"
     retryCountOnTaskFailure: 5
     displayName: Install molecule and Ansible
 

--- a/tests/azure/templates/playbook_fast.yml
+++ b/tests/azure/templates/playbook_fast.yml
@@ -30,10 +30,12 @@ jobs:
     inputs:
       versionSpec: '${{ parameters.python_version }}'
 
+  # 'ansible-compat<4' is required due to https://github.com/ansible-community/molecule/issues/3903
   - script: |
       pip install \
         "molecule-plugins[docker]" \
-        "ansible${{ parameters.ansible_version }}"
+        "ansible${{ parameters.ansible_version }}" \
+        "ansible-compat<4"
     retryCountOnTaskFailure: 5
     displayName: Install molecule and Ansible
 

--- a/tests/azure/templates/playbook_tests.yml
+++ b/tests/azure/templates/playbook_tests.yml
@@ -30,10 +30,12 @@ jobs:
     inputs:
       versionSpec: '${{ parameters.python_version }}'
 
+  # 'ansible-compat<4' is required due to https://github.com/ansible-community/molecule/issues/3903
   - script: |
       pip install \
         "molecule-plugins[docker]" \
-        "ansible${{ parameters.ansible_version }}"
+        "ansible${{ parameters.ansible_version }}" \
+        "ansible-compat<4"
     retryCountOnTaskFailure: 5
     displayName: Install molecule and Ansible
 

--- a/tests/azure/templates/pytest_tests.yml
+++ b/tests/azure/templates/pytest_tests.yml
@@ -24,10 +24,12 @@ jobs:
     inputs:
       versionSpec: '${{ parameters.python_version }}'
 
+  # 'ansible-compat<4' is required due to https://github.com/ansible-community/molecule/issues/3903
   - script: |
       pip install \
         "molecule-plugins[docker]" \
-        "ansible${{ parameters.ansible_version }}"
+        "ansible${{ parameters.ansible_version }}" \
+        "ansible-compat<4"
     retryCountOnTaskFailure: 5
     displayName: Install molecule and Ansible
 

--- a/tests/azure/templates/pytest_tests.yml
+++ b/tests/azure/templates/pytest_tests.yml
@@ -33,7 +33,7 @@ jobs:
     retryCountOnTaskFailure: 5
     displayName: Install molecule and Ansible
 
-  - script: ansible-galaxy collection install community.docker ansible.posix
+  - script: ansible-galaxy collection install ansible.posix
     retryCountOnTaskFailure: 5
     displayName: Install Ansible collections
 


### PR DESCRIPTION
Due to an issue introduced on newer ansible-compat and molecule (see https://github.com/ansible-community/molecule/issues/3903), ansible-compat needs to be pinned to an older version.