### PR TITLE
ipa{server,replica,client}: Add parameter to support to install packages only

### DIFF
--- a/roles/ipaserver/README.md
+++ b/roles/ipaserver/README.md
@@ -359,6 +359,7 @@ Special Variables
 Variable | Description | Required
 -------- | ----------- | --------
 `ipaserver_install_packages` | The bool value defines if the needed packages are installed on the node. (bool, default: true) | no
+`ipaserver_install_packages_only` | The bool value defines if the deployment will continue after the needed packages are installed on the node. (bool, default: true) | no
 `ipaserver_setup_firewalld` | The value defines if the needed services will automatically be opened in the firewall managed by firewalld. (bool, default: true) | no
 `ipaserver_firewalld_zone` | The value defines the firewall zone that will be used. This needs to be an existing runtime and permanent zone. (string) | no
 `ipaserver_external_cert_files_from_controller` | Files containing the IPA CA certificates and the external CA certificate chains on the controller that will be copied to the ipaserver host to `/root` folder. (list of string) | no

--- a/roles/ipaserver/defaults/main.yml
+++ b/roles/ipaserver/defaults/main.yml
@@ -34,6 +34,7 @@ ipaserver_enable_compat: no
 ipaserver_setup_ca: yes
 ### packages ###
 ipaserver_install_packages: yes
+ipaserver_install_packages_only: false
 ### firewalld ###
 ipaserver_setup_firewalld: yes
 

--- a/roles/ipaserver/tasks/install.yml
+++ b/roles/ipaserver/tasks/install.yml
@@ -29,7 +29,8 @@
 
 
 - name: Install - Firewall configuration
-  when: ipaserver_setup_firewalld | bool
+  when: ipaserver_setup_firewalld | bool and
+        not ipaserver_install_packages_only
   block:
   - name: Firewalld service - Ensure that firewalld is running
     ansible.builtin.systemd:
@@ -55,7 +56,8 @@
 - name: Copy external certs
   ansible.builtin.include_tasks: "{{ role_path }}/tasks/copy_external_cert.yml"
   with_items: "{{ ipaserver_external_cert_files_from_controller }}"
-  when: ipaserver_external_cert_files_from_controller is defined and
+  when: not ipaserver_install_packages_only | bool and
+        ipaserver_external_cert_files_from_controller is defined and
         ipaserver_external_cert_files_from_controller|length > 0 and
         not ipaserver_external_cert_files is defined
 
@@ -128,10 +130,12 @@
     secondary_rid_base: "{{ ipaserver_secondary_rid_base | default(omit) }}"
 
     ### additional ###
+  when: not ipaserver_install_packages_only | bool
   register: result_ipaserver_test
 
 - name: Install - Deploy server
-  when: not ansible_check_mode and not
+  when: not ansible_check_mode and
+        not ipaserver_install_packages_only | bool and not
         (not result_ipaserver_test.changed and
          (result_ipaserver_test.client_already_configured is defined or
           result_ipaserver_test.server_already_configured is defined))


### PR DESCRIPTION
**ipaserver: New parameter ipaserver_install_packages_only**

The bool value defines if the deployment will continue after the needed packages are installed on the node.

This is useful if images are generated with the packages installed to speed up deployment.

Fixes: #1086 (Proposal: Add 'installation_only' flag to roles)