### PR TITLE
Pin requests to < 2.29 temporarily

### DIFF
--- a/tests/azure/templates/build_container.yml
+++ b/tests/azure/templates/build_container.yml
@@ -22,7 +22,7 @@ jobs:
     retryCountOnTaskFailure: 5
     displayName: Install tools
 
-  - script: pip install molecule-plugins[docker]
+  - script: pip install molecule-plugins[docker] requests<2.29
     retryCountOnTaskFailure: 5
     displayName: Install molecule
 

--- a/tests/azure/templates/galaxy_pytest_script.yml
+++ b/tests/azure/templates/galaxy_pytest_script.yml
@@ -24,6 +24,7 @@ jobs:
   - script: |
       pip install \
         "molecule-plugins[docker]" \
+        "requests<2.29" \
         "ansible${{ parameters.ansible_version }}"
     retryCountOnTaskFailure: 5
     displayName: Install molecule and Ansible

--- a/tests/azure/templates/galaxy_script.yml
+++ b/tests/azure/templates/galaxy_script.yml
@@ -34,6 +34,7 @@ jobs:
   - script: |
       pip install \
         "molecule-plugins[docker]" \
+        "requests<2.29" \
         "ansible${{ parameters.ansible_version }}"
     retryCountOnTaskFailure: 5
     displayName: Install molecule and Ansible

--- a/tests/azure/templates/playbook_fast.yml
+++ b/tests/azure/templates/playbook_fast.yml
@@ -33,6 +33,7 @@ jobs:
   - script: |
       pip install \
         "molecule-plugins[docker]" \
+        "requests<2.29" \
         "ansible${{ parameters.ansible_version }}"
     retryCountOnTaskFailure: 5
     displayName: Install molecule and Ansible

--- a/tests/azure/templates/playbook_tests.yml
+++ b/tests/azure/templates/playbook_tests.yml
@@ -33,6 +33,7 @@ jobs:
   - script: |
       pip install \
         "molecule-plugins[docker]" \
+        "requests<2.29" \
         "ansible${{ parameters.ansible_version }}"
     retryCountOnTaskFailure: 5
     displayName: Install molecule and Ansible

--- a/tests/azure/templates/pytest_tests.yml
+++ b/tests/azure/templates/pytest_tests.yml
@@ -27,6 +27,7 @@ jobs:
   - script: |
       pip install \
         "molecule-plugins[docker]" \
+        "requests<2.29" \
         "ansible${{ parameters.ansible_version }}"
     retryCountOnTaskFailure: 5
     displayName: Install molecule and Ansible


### PR DESCRIPTION
Due to https://github.com/docker/docker-py/issues/3113 requests need to be pinned below 2.29 as a temporary solution.