### PR TITLE
tests/azure/templates/build_container.yml: Quote requests with version

### DIFF
--- a/tests/azure/templates/build_container.yml
+++ b/tests/azure/templates/build_container.yml
@@ -22,7 +22,7 @@ jobs:
     retryCountOnTaskFailure: 5
     displayName: Install tools
 
-  - script: pip install molecule-plugins[docker] requests<2.29
+  - script: pip install molecule-plugins[docker] "requests<2.29"
     retryCountOnTaskFailure: 5
     displayName: Install molecule
 


### PR DESCRIPTION
The version requirement for requests need to be quoted not to lead into a pip install command issue.

This is related to PR #1089 (Pin requests to < 2.29 temporarily)