### PR TITLE
upstream CI: Disable ansible-lint var-naming check

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -35,6 +35,7 @@ skip_list:
   - yaml   # yamllint should be executed separately.
   - experimental   # Do not run any experimental tests
   - name[template] # Allow Jinja templating inside task names
+  - var-naming
 
 use_default_rules: true
 


### PR DESCRIPTION
Latest ansible-lint version (6.16.1) started to raise an error when variable names from within roles are not prefixed with  the role name. Error: var-naming[no-role-prefix].

As Ansible sanity check does not enforce this, it will be disabled, for now on ansible-freeipa's upstream CI.

A future effort to reduce the checks that are not being evaluated should be done as preparation for future Ansible Galaxy and Automation Hub requirements.