### PR TITLE
doc: Differentiate location meaning between host and server

### DIFF
--- a/README-host.md
+++ b/README-host.md
@@ -335,7 +335,7 @@ Variable | Description | Required
 -------- | ----------- | --------
 `description` | The host description. | no
 `locality` | Host locality (e.g. "Baltimore, MD"). | no
-`location` \| `ns_host_location` | Host location (e.g. "Lab 2"). | no
+`location` \| `ns_host_location` | Host physical location hint (e.g. "Lab 2"). | no
 `platform` \| `ns_hardware_platform` | Host hardware platform (e.g. "Lenovo T61"). | no
 `os` \| `ns_os_version` | Host operating system and version (e.g. "Fedora 9"). | no
 `password` \| `user_password` \| `userpassword` | Password used in bulk enrollment for absent or not enrolled hosts. | no

--- a/README-server.md
+++ b/README-server.md
@@ -249,14 +249,14 @@ Variable | Description | Required
 `ipaapi_context` | The context in which the module will execute. Executing in a server context is preferred. If not provided context will be determined by the execution environment. Valid values are `server` and `client`. | no
 `ipaapi_ldap_cache` | Use LDAP cache for IPA connection. The bool setting defaults to yes. (bool) | no
 `name` \| `cn` | The list of server name strings. | yes
-`location` \| `ipalocation_location` | The server location string. Only in state: present. "" for location reset. | no
-`service_weight` \| `ipaserviceweight` | Weight for server services. Type Values 0 to 65535, -1 for weight reset. Only in state: present. (int) | no
-`hidden` | Set hidden state of a server. Only in state: present. (bool) | no
-`no_members` | Suppress processing of membership attributes. Only in state: present. (bool) | no
-`delete_continue` \| `continue` | Continuous mode: Don't stop on errors. Only in state: absent. (bool) | no
-`ignore_last_of_role` | Skip a check whether the last CA master or DNS server is removed. Only in state: absent. (bool) | no
-`ignore_topology_disconnect` | Ignore topology connectivity problems after removal. Only in state: absent. (bool) | no
-`force` | Force server removal even if it does not exist. Will always result in changed. Only in state: absent. (bool) | no
+`location` \| `ipalocation_location` | The server DNS location. Only available with 'state: present'. Use "" for location reset. | no
+`service_weight` \| `ipaserviceweight` | Weight for server services. Type Values 0 to 65535, -1 for weight reset. Only available with 'state: present'. (int) | no
+`hidden` | Set hidden state of a server. Only available with 'state: present'. (bool) | no
+`no_members` | Suppress processing of membership attributes. Only avialable with 'state: present'. (bool) | no
+`delete_continue` \| `continue` | Continuous mode: Don't stop on errors. Only available with 'state: absent'. (bool) | no
+`ignore_last_of_role` | Skip a check whether the last CA master or DNS server is removed. Only available with 'state: absent'. (bool) | no
+`ignore_topology_disconnect` | Ignore topology connectivity problems after removal. Only available with 'state: absent'. (bool) | no
+`force` | Force server removal even if it does not exist. Will always result in changed. Only available with 'state: absent'. (bool) | no
 `state` | The state to ensure. It can be one of `present`, `absent`, default: `present`. `present` is only working with existing servers. | no
 
 

--- a/plugins/modules/ipahost.py
+++ b/plugins/modules/ipahost.py
@@ -63,7 +63,7 @@ options:
         type: str
         required: false
       location:
-        description: Host location (e.g. "Lab 2")
+        description: Host physical location hist (e.g. "Lab 2")
         type: str
         aliases: ["ns_host_location"]
         required: false

--- a/plugins/modules/ipaserver.py
+++ b/plugins/modules/ipaserver.py
@@ -45,9 +45,9 @@ options:
     aliases: ["cn"]
   location:
     description: |
-      The server location string.
-      "" for location reset.
-      Only in state: present.
+      The server DNS location.
+      Only available with 'state: present'.
+      Use "" for location reset.
     type: str
     required: false
     aliases: ["ipalocation_location"]
@@ -55,46 +55,46 @@ options:
     description: |
       Weight for server services
       Values 0 to 65535, -1 for weight reset.
-      Only in state: present.
+      Only available with 'state: present'.
     required: false
     type: int
     aliases: ["ipaserviceweight"]
   hidden:
     description: |
       Set hidden state of a server.
-      Only in state: present.
+      Only available with 'state: present'.
     required: false
     type: bool
   no_members:
     description: |
       Suppress processing of membership attributes
-      Only in state: present.
+      Only available with 'state: present'.
     required: false
     type: bool
   delete_continue:
     description: |
       Continuous mode: Don't stop on errors.
-      Only in state: absent.
+      Only available with 'state: absent'.
     required: false
     type: bool
     aliases: ["continue"]
   ignore_last_of_role:
     description: |
       Skip a check whether the last CA master or DNS server is removed.
-      Only in state: absent.
+      Only available with 'state: absent'.
     required: false
     type: bool
   ignore_topology_disconnect:
     description: |
       Ignore topology connectivity problems after removal.
-      Only in state: absent.
+      Only available with 'state: absent'.
     required: false
     type: bool
   force:
     description: |
       Force server removal even if it does not exist.
       Will always result in changed.
-      Only in state: absent.
+      Only available with 'state: absent'.
     required: false
     type: bool
   state:


### PR DESCRIPTION
Host location and server location have very different meanings in IPA. ipahost uses 'location' as an optional hint to where the host may be physically located, ipaserever uses location to identify which DNS location the server is part of.

This change updates documentation to make attribute description more clear. Surrounding text have been changed to match text style as used in other plugins.

This patch is related to: https://github.com/freeipa/freeipa/pull/6840