### PR TITLE
Don't allow the FQDN to match the domain on server installs

### DIFF
--- a/roles/ipareplica/library/ipareplica_test.py
+++ b/roles/ipareplica/library/ipareplica_test.py
@@ -521,6 +521,11 @@ def main():
             ansible_module.fail_json(
                 msg="NTP configuration cannot be updated during promotion")
 
+    # host_name an domain_name must be different at this point.
+    if options.host_name.lower() == options.domain_name.lower():
+        ansible_module.fail_json(
+            msg="hostname cannot be the same as the domain name")
+
     # done #
 
     ansible_module.exit_json(

--- a/roles/ipaserver/library/ipaserver_test.py
+++ b/roles/ipaserver/library/ipaserver_test.py
@@ -1055,6 +1055,11 @@ def main():
 
     domain_name = domain_name.lower()
 
+    # Both host_name and domain_name are lowercase at this point.
+    if host_name == domain_name:
+        ansible_module.fail_json(
+            msg="hostname cannot be the same as the domain name")
+
     if not options.realm_name:
         realm_name = domain_name.upper()
     else:


### PR DESCRIPTION
If server FQDN matches the domain name, the installation will succeed, but DNS records will not work. If 'setup_dns: true' is used, there will be no A record for the host, only a NS record, and the PTR record will point to the domain name.

Based on: https://github.com/freeipa/freeipa/pull/6853
Related to: https://pagure.io/freeipa/issue/9003