### PR TITLE
upstream CI: Update ansible-core version

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -5,23 +5,6 @@ on:
   - pull_request
 jobs:
   check_docs_oldest_supported:
-    name: Check Ansible Documentation with ansible-core 2.12.
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3.1.0
-        with:
-          fetch-depth: 0
-      - uses: actions/setup-python@v4.3.0
-        with:
-          python-version: '3.x'
-      - name: Install Ansible 2.12
-        run: |
-          python -m pip install "ansible-core >=2.12,<2.13"
-      - name: Run ansible-doc-test
-        run: |
-          ANSIBLE_LIBRARY="." ANSIBLE_DOC_FRAGMENT_PLUGINS="." python utils/ansible-doc-test -v roles plugins
-
-  check_docs_previous:
     name: Check Ansible Documentation with ansible-core 2.13.
     runs-on: ubuntu-latest
     steps:
@@ -38,7 +21,7 @@ jobs:
         run: |
           ANSIBLE_LIBRARY="." ANSIBLE_DOC_FRAGMENT_PLUGINS="." python utils/ansible-doc-test -v roles plugins
 
-  check_docs_current:
+  check_docs_previous:
     name: Check Ansible Documentation with ansible-core 2.14.
     runs-on: ubuntu-latest
     steps:
@@ -51,6 +34,23 @@ jobs:
       - name: Install Ansible 2.14
         run: |
           python -m pip install "ansible-core >=2.14,<2.15"
+      - name: Run ansible-doc-test
+        run: |
+          ANSIBLE_LIBRARY="." ANSIBLE_DOC_FRAGMENT_PLUGINS="." python utils/ansible-doc-test -v roles plugins
+
+  check_docs_current:
+    name: Check Ansible Documentation with ansible-core 2.15.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3.1.0
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v4.3.0
+        with:
+          python-version: '3.x'
+      - name: Install Ansible 2.15
+        run: |
+          python -m pip install "ansible-core >=2.15,<2.16"
       - name: Run ansible-doc-test
         run: |
           ANSIBLE_LIBRARY="." ANSIBLE_DOC_FRAGMENT_PLUGINS="." python utils/ansible-doc-test -v roles plugins

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,7 +16,7 @@ jobs:
           python-version: "3.x"
       - name: Run ansible-lint
         run: |
-          pip install "ansible-core >=2.14,<2.15" ansible-lint
+          pip install "ansible-core >=2.15,<2.16" ansible-lint
           utils/build-galaxy-release.sh -ki
           cd .galaxy-build
           ansible-lint

--- a/tests/azure/azure-pipelines.yml
+++ b/tests/azure/azure-pipelines.yml
@@ -27,7 +27,7 @@ stages:
     parameters:
       build_number: $(Build.BuildNumber)
       scenario: fedora-latest
-      ansible_version: "-core >=2.13,<2.14"
+      ansible_version: "-core >=2.14,<2.15"
 
 # Galaxy on Fedora
 
@@ -38,7 +38,7 @@ stages:
     parameters:
       build_number: $(Build.BuildNumber)
       scenario: fedora-latest
-      ansible_version: "-core >=2.13,<2.14"
+      ansible_version: "-core >=2.14,<2.15"
 
 # CentOS 9 Stream
 
@@ -49,7 +49,7 @@ stages:
     parameters:
       build_number: $(Build.BuildNumber)
       scenario: c9s
-      ansible_version: "-core >=2.13,<2.14"
+      ansible_version: "-core >=2.14,<2.15"
 
 # CentOS 8 Stream
 
@@ -60,7 +60,7 @@ stages:
     parameters:
       build_number: $(Build.BuildNumber)
       scenario: c8s
-      ansible_version: "-core >=2.13,<2.14"
+      ansible_version: "-core >=2.14,<2.15"
 
 # CentOS 7
 
@@ -71,4 +71,4 @@ stages:
     parameters:
       build_number: $(Build.BuildNumber)
       scenario: centos-7
-      ansible_version: "-core >=2.13,<2.14"
+      ansible_version: "-core >=2.14,<2.15"

--- a/tests/azure/nightly.yml
+++ b/tests/azure/nightly.yml
@@ -16,15 +16,6 @@ stages:
 
 # Fedora
 
-- stage: FedoraLatest_Ansible_Core_2_12
-  dependsOn: []
-  jobs:
-  - template: templates/group_tests.yml
-    parameters:
-      build_number: $(Build.BuildNumber)
-      scenario: fedora-latest
-      ansible_version: "-core >=2.12,<2.13"
-
 - stage: FedoraLatest_Ansible_Core_2_13
   dependsOn: []
   jobs:
@@ -43,6 +34,15 @@ stages:
       scenario: fedora-latest
       ansible_version: "-core >=2.14,<2.15"
 
+- stage: FedoraLatest_Ansible_Core_2_15
+  dependsOn: []
+  jobs:
+  - template: templates/group_tests.yml
+    parameters:
+      build_number: $(Build.BuildNumber)
+      scenario: fedora-latest
+      ansible_version: "-core >=2.15,<2.16"
+
 - stage: FedoraLatest_Ansible_latest
   dependsOn: []
   jobs:
@@ -53,15 +53,6 @@ stages:
       ansible_version: ""
 
 # Galaxy on Fedora
-
-- stage: Galaxy_FedoraLatest_Ansible_Core_2_12
-  dependsOn: []
-  jobs:
-  - template: templates/galaxy_tests.yml
-    parameters:
-      build_number: $(Build.BuildNumber)
-      scenario: fedora-latest
-      ansible_version: "-core >=2.12,<2.13"
 
 - stage: Galaxy_FedoraLatest_Ansible_Core_2_13
   dependsOn: []
@@ -81,6 +72,15 @@ stages:
       scenario: fedora-latest
       ansible_version: "-core >=2.14,<2.15"
 
+- stage: Galaxy_FedoraLatest_Ansible_Core_2_15
+  dependsOn: []
+  jobs:
+  - template: templates/galaxy_tests.yml
+    parameters:
+      build_number: $(Build.BuildNumber)
+      scenario: fedora-latest
+      ansible_version: "-core >=2.15,<2.16"
+
 - stage: Galaxy_FedoraLatest_Ansible_latest
   dependsOn: []
   jobs:
@@ -91,15 +91,6 @@ stages:
       ansible_version: ""
 
 # Fedora Rawhide
-
-- stage: FedoraRawhide_Ansible_Core_2_12
-  dependsOn: []
-  jobs:
-  - template: templates/group_tests.yml
-    parameters:
-      build_number: $(Build.BuildNumber)
-      scenario: fedora-rawhide
-      ansible_version: "-core >=2.12,<2.13"
 
 - stage: FedoraRawhide_Ansible_Core_2_13
   dependsOn: []
@@ -119,6 +110,15 @@ stages:
       scenario: fedora-rawhide
       ansible_version: "-core >=2.14,<2.15"
 
+- stage: FedoraRawhide_Ansible_Core_2_15
+  dependsOn: []
+  jobs:
+  - template: templates/group_tests.yml
+    parameters:
+      build_number: $(Build.BuildNumber)
+      scenario: fedora-rawhide
+      ansible_version: "-core >=2.15,<2.16"
+
 - stage: FedoraRawhide_Ansible_latest
   dependsOn: []
   jobs:
@@ -129,15 +129,6 @@ stages:
       ansible_version: ""
 
 # CentoOS 9 Stream
-
-- stage: c9s_Ansible_Core_2_12
-  dependsOn: []
-  jobs:
-  - template: templates/group_tests.yml
-    parameters:
-      build_number: $(Build.BuildNumber)
-      scenario: c9s
-      ansible_version: "-core >=2.12,<2.13"
 
 - stage: c9s_Ansible_Core_2_13
   dependsOn: []
@@ -157,6 +148,15 @@ stages:
       scenario: c9s
       ansible_version: "-core >=2.14,<2.15"
 
+- stage: c9s_Ansible_Core_2_15
+  dependsOn: []
+  jobs:
+  - template: templates/group_tests.yml
+    parameters:
+      build_number: $(Build.BuildNumber)
+      scenario: c9s
+      ansible_version: "-core >=2.15,<2.16"
+
 - stage: c9s_Ansible_latest
   dependsOn: []
   jobs:
@@ -167,15 +167,6 @@ stages:
       ansible_version: ""
 
 # CentOS 8 Stream
-
-- stage: c8s_Ansible_Core_2_12
-  dependsOn: []
-  jobs:
-  - template: templates/group_tests.yml
-    parameters:
-      build_number: $(Build.BuildNumber)
-      scenario: c8s
-      ansible_version: "-core >=2.12,<2.13"
 
 - stage: c8s_Ansible_Core_2_13
   dependsOn: []
@@ -195,6 +186,15 @@ stages:
       scenario: c8s
       ansible_version: "-core >=2.14,<2.15"
 
+- stage: c8s_Ansible_Core_2_15
+  dependsOn: []
+  jobs:
+  - template: templates/group_tests.yml
+    parameters:
+      build_number: $(Build.BuildNumber)
+      scenario: c8s
+      ansible_version: "-core >=2.15,<2.16"
+
 - stage: c8s_Ansible_latest
   dependsOn: []
   jobs:
@@ -205,15 +205,6 @@ stages:
       ansible_version: ""
 
 # CentOS 7
-
-- stage: CentOS7_Ansible_Core_2_12
-  dependsOn: []
-  jobs:
-  - template: templates/group_tests.yml
-    parameters:
-      build_number: $(Build.BuildNumber)
-      scenario: centos-7
-      ansible_version: "-core >=2.12,<2.13"
 
 - stage: CentOS7_Ansible_Core_2_13
   dependsOn: []
@@ -232,6 +223,15 @@ stages:
       build_number: $(Build.BuildNumber)
       scenario: centos-7
       ansible_version: "-core >=2.14,<2.15"
+
+- stage: CentOS7_Ansible_Core_2_15
+  dependsOn: []
+  jobs:
+  - template: templates/group_tests.yml
+    parameters:
+      build_number: $(Build.BuildNumber)
+      scenario: centos-7
+      ansible_version: "-core >=2.15,<2.16"
 
 - stage: CentOS7_Ansible_latest
   dependsOn: []

--- a/tests/azure/pr-pipeline.yml
+++ b/tests/azure/pr-pipeline.yml
@@ -16,7 +16,7 @@ stages:
     parameters:
       build_number: $(Build.BuildNumber)
       scenario: fedora-latest
-      ansible_version: "-core >=2.12,<2.13"
+      ansible_version: "-core >=2.14,<2.15"
 
 # Galaxy on Fedora
 
@@ -27,7 +27,7 @@ stages:
     parameters:
       build_number: $(Build.BuildNumber)
       scenario: fedora-latest
-      ansible_version: "-core >=2.12,<2.13"
+      ansible_version: "-core >=2.14,<2.15"
 
 # CentOS 9 Stream
 
@@ -38,7 +38,7 @@ stages:
     parameters:
       build_number: $(Build.BuildNumber)
       scenario: c9s
-      ansible_version: "-core >=2.13,<2.14"
+      ansible_version: "-core >=2.14,<2.15"
 
 # CentOS 8 Stream
 
@@ -49,7 +49,7 @@ stages:
     parameters:
       build_number: $(Build.BuildNumber)
       scenario: c8s
-      ansible_version: "-core >=2.13,<2.14"
+      ansible_version: "-core >=2.14,<2.15"
 
 # CentOS 7
 
@@ -60,7 +60,7 @@ stages:
     parameters:
       build_number: $(Build.BuildNumber)
       scenario: centos-7
-      ansible_version: "-core >=2.13,<2.14"
+      ansible_version: "-core >=2.14,<2.15"
 
 # Rawhide
 
@@ -71,4 +71,4 @@ stages:
     parameters:
       build_number: $(Build.BuildNumber)
       scenario: fedora-rawhide
-      ansible_version: "-core >=2.13,<2.14"
+      ansible_version: "-core >=2.14,<2.15"

--- a/utils/run-tests.sh
+++ b/utils/run-tests.sh
@@ -162,7 +162,7 @@ list_images() {
 
 # Defaults
 
-ANSIBLE_VERSION=${ANSIBLE_VERSION:-'ansible-core>=2.12,<2.13'}
+ANSIBLE_VERSION=${ANSIBLE_VERSION:-'ansible-core'}
 verbose=""
 FORCE_ENV="N"
 CONTINUE_ON_ERROR=""


### PR DESCRIPTION
ansible-core 2.15 has been released on May 15th, 2023, and version 2.12 has reached EOL on May 22nd, 2023.

This patch updates the ansible-core versions used on upstream CI tests to reflect Ansible's new releases.