### PR TITLE
Gather required facts if relevant keys in ansible_facts are missing

### DIFF
--- a/roles/ipaclient/tasks/main.yml
+++ b/roles/ipaclient/tasks/main.yml
@@ -1,6 +1,14 @@
 ---
 # tasks file for ipaclient
 
+- name: Gather facts
+  ansible.builtin.setup:
+    gather_subset: min
+  when: ansible_facts.distribution is not defined or
+        ansible_facts.distribution_version is not defined or
+        ansible_facts.distribution_major_version is not defined or
+        ansible_facts.os_family is not defined
+
 - name: Import variables specific to distribution
   ansible.builtin.include_vars: "{{ item }}"
   with_first_found:

--- a/roles/ipareplica/tasks/main.yml
+++ b/roles/ipareplica/tasks/main.yml
@@ -1,6 +1,14 @@
 ---
 # tasks file for ipareplica
 
+- name: Gather facts
+  ansible.builtin.setup:
+    gather_subset: min
+  when: ansible_facts.distribution is not defined or
+        ansible_facts.distribution_version is not defined or
+        ansible_facts.distribution_major_version is not defined or
+        ansible_facts.os_family is not defined
+
 - name: Import variables specific to distribution
   ansible.builtin.include_vars: "{{ item }}"
   with_first_found:

--- a/roles/ipaserver/tasks/main.yml
+++ b/roles/ipaserver/tasks/main.yml
@@ -1,6 +1,14 @@
 ---
 # tasks file for ipaserver
 
+- name: Gather facts
+  ansible.builtin.setup:
+    gather_subset: min
+  when: ansible_facts.distribution is not defined or
+        ansible_facts.distribution_version is not defined or
+        ansible_facts.distribution_major_version is not defined or
+        ansible_facts.os_family is not defined
+
 - name: Import variables specific to distribution
   ansible.builtin.include_vars: "{{ item }}"
   with_first_found:

--- a/roles/ipasmartcard_client/tasks/main.yml
+++ b/roles/ipasmartcard_client/tasks/main.yml
@@ -6,6 +6,14 @@
     msg: "Uninstalling smartcard for IPA is not supported"
   when: state|default('present') == 'absent'
 
+- name: Gather facts
+  ansible.builtin.setup:
+    gather_subset: min
+  when: ansible_facts.distribution is not defined or
+        ansible_facts.distribution_version is not defined or
+        ansible_facts.distribution_major_version is not defined or
+        ansible_facts.os_family is not defined
+
 - name: Import variables specific to distribution
   ansible.builtin.include_vars: "{{ item }}"
   with_first_found:

--- a/roles/ipasmartcard_server/tasks/main.yml
+++ b/roles/ipasmartcard_server/tasks/main.yml
@@ -6,6 +6,14 @@
     msg: "Uninstalling smartcard for IPA is not supported"
   when: state|default('present') == 'absent'
 
+- name: Gather facts
+  ansible.builtin.setup:
+    gather_subset: min
+  when: ansible_facts.distribution is not defined or
+        ansible_facts.distribution_version is not defined or
+        ansible_facts.distribution_major_version is not defined or
+        ansible_facts.os_family is not defined
+
 - name: Import variables specific to distribution
   ansible.builtin.include_vars: "{{ item }}"
   with_first_found:


### PR DESCRIPTION
This adds an additional tasks to gather relevant facts if the corresponding keys (i.e. `distribution`, `distribution_version`, `distribution_major_version`, `os_family`) are not already present in the `ansible_facts` dict.

Since the documentation does not mention that fact gathering is required before using certain roles, this prevents errors such as https://github.com/freeipa/ansible-freeipa/issues/962

One could also add `when: ansible_facts_fqdn is not defined ...`.  
However, this is not always required (e.g. when using the role `ipaclient` only `tasks/install.yml` uses `ansible_facts.fqdn`) and `ansible_facts.fqdn` will always be preset after using `ansible.builtin.setup` with `gather_subset: min`.