### PR TITLE
Singular to plural on random serial numbers setting

### DIFF
--- a/roles/ipaserver/README.md
+++ b/roles/ipaserver/README.md
@@ -179,7 +179,7 @@ ipaserver_domain=example.com
 ipaserver_realm=EXAMPLE.COM
 ipaadmin_password=MySecretPassword123
 ipadm_password=MySecretPassword234
-ipaserver_random_serial_number=true
+ipaserver_random_serial_numbers=true
 ```
 
 By setting the variable in the inventory file, the same ipaserver deployment playbook, shown before, can be used.


### PR DESCRIPTION
The setting was in singular in the example while being documented in plural form.