### PR TITLE
Bump linter versions.

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -76,7 +76,7 @@ jobs:
           python-version: "3.x"
       - name: Run pylint
         run: |
-            pip install pylint==2.14.4 wrapt==1.14.0
+            pip install pylint==2.17.2
             pylint plugins roles --disable=import-error
 
   shellcheck:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
     pass_filenames: true
     files: \.(yaml|yml)$
     exclude: /env[^/]*.(yaml|yml)$
-    entry: >-
+    entry: |-
         env
         ANSIBLE_LIBRARY=./plugins/modules
         ANSIBLE_MODULE_UTILS=./plugins/module_utils
@@ -21,12 +21,12 @@ repos:
           --parseable
           --nocolor
 - repo: https://github.com/adrienverge/yamllint.git
-  rev: v1.28.0
+  rev: v1.32.0
   hooks:
   - id: yamllint
     files: \.(yaml|yml)$
 - repo: https://github.com/pycqa/flake8
-  rev: 5.0.3
+  rev: 6.0.0
   hooks:
   - id: flake8
 - repo: https://github.com/pycqa/pydocstyle
@@ -34,7 +34,7 @@ repos:
   hooks:
   - id: pydocstyle
 - repo: https://github.com/pycqa/pylint
-  rev: v2.14.4
+  rev: v2.17.2
   hooks:
   - id: pylint
     args:

--- a/plugins/modules/ipaautomountkey.py
+++ b/plugins/modules/ipaautomountkey.py
@@ -121,8 +121,7 @@ class AutomountKey(IPAAnsibleModule):
             resp = self.ipa_command("automountkey_show", location, args)
         except ipalib_errors.NotFound:
             return None
-        else:
-            return resp.get("result")
+        return resp.get("result")
 
     def check_ipa_params(self):
         invalid = []

--- a/plugins/modules/ipaautomountlocation.py
+++ b/plugins/modules/ipaautomountlocation.py
@@ -92,8 +92,7 @@ class AutomountLocation(IPAAnsibleModule):
             )
         except ipalib_errors.NotFound:
             return None
-        else:
-            return response.get("result", None)
+        return response.get("result", None)
 
     def check_ipa_params(self):
         if len(self.params_get("name")) == 0:

--- a/plugins/modules/ipaautomountmap.py
+++ b/plugins/modules/ipaautomountmap.py
@@ -126,8 +126,7 @@ class AutomountMap(IPAAnsibleModule):
             )
         except Exception:  # pylint: disable=broad-except
             return None
-        else:
-            return response["result"]
+        return response["result"]
 
     def get_indirect_map_keys(self, location, name):
         """Check if 'name' is an indirect map for 'parentmap'."""

--- a/plugins/modules/ipaconfig.py
+++ b/plugins/modules/ipaconfig.py
@@ -476,7 +476,7 @@ def main():
     params = {}
     for x in field_map:
         val = ansible_module.params_get(
-            x, allow_empty_string=(x in allow_empty_string))
+            x, allow_empty_string=x in allow_empty_string)
 
         if val is not None:
             params[field_map.get(x, x)] = val
@@ -619,7 +619,7 @@ def main():
                         # boolean values, so we need to convert it to str
                         # for comparison.
                         # See: https://github.com/freeipa/freeipa/pull/6294
-                        exit_args[k] = (str(value[0]).upper() == "TRUE")
+                        exit_args[k] = str(value[0]).upper() == "TRUE"
                     else:
                         if arg_type not in type_map:
                             raise ValueError(

--- a/plugins/modules/ipaconfig.py
+++ b/plugins/modules/ipaconfig.py
@@ -358,8 +358,7 @@ def get_netbios_name(module):
         _result = module.ipa_command_no_name("trustconfig_show", {"all": True})
     except Exception:  # pylint: disable=broad-except
         return None
-    else:
-        return _result["result"]["ipantflatname"][0]
+    return _result["result"]["ipantflatname"][0]
 
 
 def is_enable_sid(module):

--- a/plugins/modules/ipadelegation.py
+++ b/plugins/modules/ipadelegation.py
@@ -134,8 +134,7 @@ def find_delegation(module, name):
     except Exception:  # pylint: disable=broad-except
         # An exception is raised if delegation name is not found.
         return None
-    else:
-        return _result["result"]
+    return _result["result"]
 
 
 def gen_args(permission, attribute, membergroup, group):

--- a/plugins/modules/ipadnsforwardzone.py
+++ b/plugins/modules/ipadnsforwardzone.py
@@ -258,7 +258,7 @@ def main():
         invalid = [
             "forwarders", "forwardpolicy", "skip_overlap_check", "permission"
         ]
-        wants_enable = (state == "enabled")
+        wants_enable = state == "enabled"
 
     if operation == "del":
         invalid = [

--- a/plugins/modules/ipadnsrecord.py
+++ b/plugins/modules/ipadnsrecord.py
@@ -1453,7 +1453,7 @@ def define_commands_for_present_state(module, zone_name, entry, res_find):
     else:
         # Create reverse records for existing records
         for ipv in ['a', 'aaaa']:
-            record = ('%srecord' % ipv)
+            record = '%srecord' % ipv
             if record in args and ('%s_extra_create_reverse' % ipv) in args:
                 cmds = create_reverse_ip_record(
                     module, zone_name, name, args[record])

--- a/plugins/modules/ipaidrange.py
+++ b/plugins/modules/ipaidrange.py
@@ -157,8 +157,7 @@ def find_idrange(module, name):
     except Exception:  # pylint: disable=broad-except
         # An exception is raised if idrange name is not found.
         return None
-    else:
-        return _result["result"]
+    return _result["result"]
 
 
 def gen_args(

--- a/plugins/modules/ipaidview.py
+++ b/plugins/modules/ipaidview.py
@@ -141,8 +141,7 @@ def find_idview(module, name):
     except Exception:  # pylint: disable=broad-except
         # An exception is raised if idview name is not found.
         return None
-    else:
-        return _result["result"]
+    return _result["result"]
 
 
 def gen_args(description, domain_resolution_order):

--- a/plugins/modules/ipalocation.py
+++ b/plugins/modules/ipalocation.py
@@ -86,8 +86,7 @@ def find_location(module, name):
     except Exception:  # pylint: disable=broad-except
         # An exception is raised if location name is not found.
         return None
-    else:
-        return _result["result"]
+    return _result["result"]
 
 
 def gen_args(description):

--- a/plugins/modules/ipapermission.py
+++ b/plugins/modules/ipapermission.py
@@ -164,8 +164,7 @@ def find_permission(module, name):
     except Exception:  # pylint: disable=broad-except
         # An exception is raised if permission name is not found.
         return None
-    else:
-        return _result["result"]
+    return _result["result"]
 
 
 def gen_args(right, attrs, bindtype, subtree,

--- a/plugins/modules/ipaprivilege.py
+++ b/plugins/modules/ipaprivilege.py
@@ -138,8 +138,7 @@ def find_privilege(module, name):
     except Exception:  # pylint: disable=broad-except
         # An exception is raised if privilege name is not found.
         return None
-    else:
-        return _result["result"]
+    return _result["result"]
 
 
 def main():

--- a/plugins/modules/iparole.py
+++ b/plugins/modules/iparole.py
@@ -143,8 +143,7 @@ def find_role(module, name):
     except Exception:  # pylint: disable=broad-except
         # An exception is raised if role name is not found.
         return None
-    else:
-        return _result["result"]
+    return _result["result"]
 
 
 def gen_args(module):

--- a/plugins/modules/ipaselfservice.py
+++ b/plugins/modules/ipaselfservice.py
@@ -123,8 +123,7 @@ def find_selfservice(module, name):
     except Exception:  # pylint: disable=broad-except
         # An exception is raised if selfservice name is not found.
         return None
-    else:
-        return _result["result"]
+    return _result["result"]
 
 
 def gen_args(permission, attribute):

--- a/plugins/modules/ipaserver.py
+++ b/plugins/modules/ipaserver.py
@@ -202,8 +202,7 @@ def find_server(module, name):
     except Exception:  # pylint: disable=broad-except
         # An exception is raised if server name is not found.
         return None
-    else:
-        return _result["result"]
+    return _result["result"]
 
 
 def server_role_status(module, name):
@@ -218,8 +217,7 @@ def server_role_status(module, name):
     except Exception:  # pylint: disable=broad-except
         # An exception is raised if server name is not found.
         return None
-    else:
-        return _result["result"][0]
+    return _result["result"][0]
 
 
 def gen_args(location, service_weight, no_members, delete_continue,

--- a/plugins/modules/ipaservice.py
+++ b/plugins/modules/ipaservice.py
@@ -414,15 +414,15 @@ def gen_args(pac_type, auth_ind, skip_host_check, force, requires_pre_auth,
     if auth_ind is not None:
         _args['krbprincipalauthind'] = auth_ind
     if skip_host_check is not None:
-        _args['skip_host_check'] = (skip_host_check)
+        _args['skip_host_check'] = skip_host_check
     if force is not None:
-        _args['force'] = (force)
+        _args['force'] = force
     if requires_pre_auth is not None:
-        _args['ipakrbrequirespreauth'] = (requires_pre_auth)
+        _args['ipakrbrequirespreauth'] = requires_pre_auth
     if ok_as_delegate is not None:
-        _args['ipakrbokasdelegate'] = (ok_as_delegate)
+        _args['ipakrbokasdelegate'] = ok_as_delegate
     if ok_to_auth_as_delegate is not None:
-        _args['ipakrboktoauthasdelegate'] = (ok_to_auth_as_delegate)
+        _args['ipakrboktoauthasdelegate'] = ok_to_auth_as_delegate
 
     return _args
 
@@ -433,9 +433,9 @@ def gen_args_smb(netbiosname, ok_as_delegate, ok_to_auth_as_delegate):
     if netbiosname is not None:
         _args['ipantflatname'] = netbiosname
     if ok_as_delegate is not None:
-        _args['ipakrbokasdelegate'] = (ok_as_delegate)
+        _args['ipakrbokasdelegate'] = ok_as_delegate
     if ok_to_auth_as_delegate is not None:
-        _args['ipakrboktoauthasdelegate'] = (ok_to_auth_as_delegate)
+        _args['ipakrboktoauthasdelegate'] = ok_to_auth_as_delegate
 
     return _args
 

--- a/plugins/modules/ipaservicedelegationrule.py
+++ b/plugins/modules/ipaservicedelegationrule.py
@@ -145,8 +145,7 @@ def find_servicedelegationrule(module, name):
     except Exception:  # pylint: disable=broad-except
         # An exception is raised if servicedelegationrule name is not found.
         return None
-    else:
-        return _result["result"]
+    return _result["result"]
 
 
 def check_targets(module, targets):

--- a/plugins/modules/ipaservicedelegationtarget.py
+++ b/plugins/modules/ipaservicedelegationtarget.py
@@ -121,8 +121,7 @@ def find_servicedelegationtarget(module, name):
     except Exception:  # pylint: disable=broad-except
         # An exception is raised if servicedelegationtarget name is not found.
         return None
-    else:
-        return _result["result"]
+    return _result["result"]
 
 
 def main():

--- a/plugins/modules/ipasudocmdgroup.py
+++ b/plugins/modules/ipasudocmdgroup.py
@@ -122,8 +122,7 @@ def find_sudocmdgroup(module, name):
         _result = module.ipa_command("sudocmdgroup_show", name, args)
     except ipalib_errors.NotFound:
         return None
-    else:
-        return _result["result"]
+    return _result["result"]
 
 
 def gen_args(description, nomembers):

--- a/plugins/modules/ipavault.py
+++ b/plugins/modules/ipavault.py
@@ -977,12 +977,14 @@ def main():
                     changed = 'Archived data into' in result['summary']
                 elif command == 'vault_retrieve':
                     if 'result' not in result:
+                        # pylint: disable=W0012,broad-exception-raised
                         raise Exception("No result obtained.")
                     if "data" in result["result"]:
                         data_return = exit_args.setdefault("vault", {})
                         data_return["data"] = result["result"]["data"]
                     else:
                         if not datafile_out:
+                            # pylint: disable=W0012,broad-exception-raised
                             raise Exception("No data retrieved.")
                     changed = False
                 else:
@@ -993,7 +995,7 @@ def main():
                         changed = True
             except ipalib_errors.EmptyModlist:
                 result = {}
-            except Exception as exception:
+            except Exception as exception:  # pylint: disable=broad-except
                 ansible_module.fail_json(
                     msg="%s: %s: %s" % (command, name, str(exception)))
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,10 +1,10 @@
 -r requirements-tests.txt
 ipdb==0.13.4
 pre-commit==2.20.0
-flake8==5.0.3
-flake8-bugbear==22.10.27
-pylint==2.14.4
-wrapt == 1.14.0
-pydocstyle==6.0.0
-yamllint==1.28.0
+flake8==6.0.0
+flake8-bugbear
+pylint==2.17.2
+wrapt==1.14.1
+pydocstyle==6.3.0
+yamllint==1.32.0
 ansible-lint

--- a/roles/ipaclient/module_utils/ansible_ipa_client.py
+++ b/roles/ipaclient/module_utils/ansible_ipa_client.py
@@ -307,8 +307,7 @@ try:
 
     else:
         # IPA version < 4.4
-
-        raise Exception("freeipa version '%s' is too old" % VERSION)
+        raise RuntimeError("freeipa version '%s' is too old" % VERSION)
 
 except ImportError as _err:
     ANSIBLE_IPA_CLIENT_MODULE_IMPORT_ERROR = str(_err)

--- a/roles/ipareplica/module_utils/ansible_ipa_replica.py
+++ b/roles/ipareplica/module_utils/ansible_ipa_replica.py
@@ -171,8 +171,7 @@ try:
 
     else:
         # IPA version < 4.6
-
-        raise Exception("freeipa version '%s' is too old" % VERSION)
+        raise RuntimeError("freeipa version '%s' is too old" % VERSION)
 
 except ImportError as _err:
     ANSIBLE_IPA_REPLICA_MODULE_IMPORT_ERROR = str(_err)

--- a/roles/ipaserver/module_utils/ansible_ipa_server.py
+++ b/roles/ipaserver/module_utils/ansible_ipa_server.py
@@ -212,8 +212,7 @@ try:
 
     else:
         # IPA version < 4.5
-
-        raise Exception("freeipa version '%s' is too old" % VERSION)
+        raise RuntimeError("freeipa version '%s' is too old" % VERSION)
 
 except ImportError as _err:
     ANSIBLE_IPA_SERVER_MODULE_IMPORT_ERROR = str(_err)

--- a/setup.cfg
+++ b/setup.cfg
@@ -55,7 +55,8 @@ disable =
     broad-except,
     too-many-branches,
     too-many-locals,
-    fixme
+    fixme,
+    use-dict-literal
 
 [pylint.BASIC]
 good-names =

--- a/tests/pytests/conftest.py
+++ b/tests/pytests/conftest.py
@@ -31,7 +31,7 @@ def set_env_if_not_set(envvar, value):
         os.environ[envvar] = value
 
 
-def pytest_configure(config):
+def pytest_configure(config):  # pylint: disable=unused-argument
     test_dir = os.getenv("TWD")
     if not test_dir:
         return

--- a/utils/facts.py
+++ b/utils/facts.py
@@ -1,10 +1,10 @@
 import os
 
 
-def get_roles(dir):
+def get_roles(directory):
     roles = []
 
-    _rolesdir = "%s/roles/" % dir
+    _rolesdir = "%s/roles/" % directory
     for _role in os.listdir(_rolesdir):
         _roledir = "%s/%s" % (_rolesdir, _role)
         if not os.path.isdir(_roledir) or \
@@ -16,19 +16,19 @@ def get_roles(dir):
     return sorted(roles)
 
 
-def get_modules(dir):
+def get_modules(directory):
     management_modules = []
     roles_modules = []
 
-    for root, _dirs, files in os.walk(dir):
-        if not root.startswith("%s/plugins/" % dir) and \
-           not root.startswith("%s/roles/" % dir):
+    for root, _dirs, files in os.walk(directory):
+        if not root.startswith("%s/plugins/" % directory) and \
+           not root.startswith("%s/roles/" % directory):
             continue
         for _file in files:
             if _file.endswith(".py"):
-                if root == "%s/plugins/modules" % dir:
+                if root == "%s/plugins/modules" % directory:
                     management_modules.append(_file[:-3])
-                elif root.startswith("%s/roles/" % dir):
+                elif root.startswith("%s/roles/" % directory):
                     if root.endswith("/library"):
                         roles_modules.append(_file[:-3])
 

--- a/utils/get_test_modules.py
+++ b/utils/get_test_modules.py
@@ -62,8 +62,7 @@ def get_plugins_from_playbook(playbook):
             return []
         except yaml.parser.ParserError:  # If not a YAML/JSON file.
             return []
-        else:
-            return data if data else []
+        return data if data else []
 
     data = load_playbook(playbook)
     task_blocks = [t.get("tasks", []) if "tasks" in t else [] for t in data]

--- a/utils/templates/ipamodule+member.py.in
+++ b/utils/templates/ipamodule+member.py.in
@@ -127,8 +127,7 @@ def find_$name(module, name):
     except Exception:  # pylint: disable=broad-except
         # An exception is raised if $name name is not found.
         return None
-    else:
-        return _result["result"]
+    return _result["result"]
 
 
 def gen_args(PARAMETER1):

--- a/utils/templates/ipamodule.py.in
+++ b/utils/templates/ipamodule.py.in
@@ -103,8 +103,7 @@ def find_$name(module, name):
     except Exception:  # pylint: disable=broad-except
         # An exception is raised if $name name is not found.
         return None
-    else:
-        return _result["result"]
+    return _result["result"]
 
 
 def gen_args(PARAMETER1, PARAMETER2):


### PR DESCRIPTION
In recent pylint versions more checks are being triggered by current ansible-freeipa code. This PR fixes or disables all new warnings found with:

- pylint 2.17.4
- astroid 2.15.6
- Python 3.11.4

The linter versions are updated for development requirements, pre-commit checks and upstream CI.

Details can be found on the individual commit messages. 