### PR TITLE
Remove dependency on 'virtualenv'

### DIFF
--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -11,7 +11,5 @@ jobs:
       - uses: actions/checkout@v3.1.0
         with:
           fetch-depth: 0
-      - name: Install virtualenv using pip
-        run: pip install virtualenv
       - name: Run ansible-test
         run: bash tests/sanity/sanity.sh

--- a/tests/sanity/sanity.sh
+++ b/tests/sanity/sanity.sh
@@ -8,7 +8,7 @@ ANSIBLE_COLLECTION=freeipa-ansible_freeipa
 
 use_docker=$(docker -v >/dev/null 2>&1 && echo "True" || echo "False")
 
-virtualenv "$VENV"
+python -m venv "$VENV"
 # shellcheck disable=SC1091
 source "$VENV"/bin/activate
 


### PR DESCRIPTION
'virtualenv' is an external dependency with the same purpose of Python's 'venv' module. This patch removes the external dependency in favor of the readily available package.