### PR TITLE
utils/run-tests.sh: Install Ansible collections on virtual environment

### DIFF
--- a/utils/run-tests.sh
+++ b/utils/run-tests.sh
@@ -259,15 +259,16 @@ then
     log info "Installing Ansible: ${ANSIBLE_VERSION}"
     pip install --quiet "${ANSIBLE_VERSION}"
     log debug "Ansible version: $(ansible --version | sed -n "1p")${RST}"
-    if [ -n "${ANSIBLE_COLLECTIONS}" ]
-    then
-        log warn "Installed collections will not be removed after execution."
-        log none "Installing: Ansible Collection ${ANSIBLE_COLLECTIONS}"
-        # shellcheck disable=SC2086
-        quiet ansible-galaxy collection install ${ANSIBLE_COLLECTIONS} || die "Failed to install Ansible collections."
-    fi
 else
    log info "Using current virtual environment."
+fi
+
+if [ -n "${ANSIBLE_COLLECTIONS}" ]
+then
+    log warn "Installed collections will not be removed after execution."
+    log none "Installing: Ansible Collection ${ANSIBLE_COLLECTIONS}"
+    # shellcheck disable=SC2086
+    quiet ansible-galaxy collection install ${ANSIBLE_COLLECTIONS} || die "Failed to install Ansible collections."
 fi
 
 # Ansible configuration


### PR DESCRIPTION
When runing tests using 'utils/run-tests.sh' from inside an existing Python virtual environment the Ansible collections are not installed due to the order of execution of the script. On a machine that does not have the 'containers.*' collection the test fails as there is no container connector available.

This patch moves the section that installs Ansible collections to run after the virtual environment is configured, and then install the collections (usually, only 'containers.podman'), allowing the tests to be executed.