### PR TITLE
ipaserver: Update README with detailed Ubuntu support

### DIFF
--- a/roles/ipabackup/README.md
+++ b/roles/ipabackup/README.md
@@ -34,7 +34,7 @@ Supported Distributions
 
 * RHEL/CentOS 7.6+
 * Fedora 26+
-* Ubuntu
+* Ubuntu 16.04 and 18.04
 
 
 Requirements

--- a/roles/ipareplica/README.md
+++ b/roles/ipareplica/README.md
@@ -28,7 +28,7 @@ Supported Distributions
 
 * RHEL/CentOS 7.6+
 * Fedora 26+
-* Ubuntu
+* Ubuntu 16.04 and 18.04
 
 
 Requirements

--- a/roles/ipaserver/README.md
+++ b/roles/ipaserver/README.md
@@ -25,7 +25,7 @@ Supported Distributions
 
 * RHEL/CentOS 7.6+
 * Fedora 26+
-* Ubuntu
+* Ubuntu 16.04 and 18.04
 
 
 Requirements


### PR DESCRIPTION
Ubuntu does not have a FreeIPA server package since version 20.04. As versions 16.04 (Xenial Xerus) and 18.04 (Bionic Beaver) will be supported by Canonical until 2026 and 2028, repectively, we should keep existing support for both versions in the ipaserver and ipabackup roles until them.

This patch changes documentation to reflect that only those versions are supported.