### PR TITLE
Update authtypes authind

### DIFF
--- a/plugins/modules/ipaconfig.py
+++ b/plugins/modules/ipaconfig.py
@@ -160,7 +160,8 @@ options:
         required: false
         type: list
         elements: str
-        choices: ["password", "radius", "otp", "disabled", ""]
+        choices: ["password", "radius", "otp", "pkinit", "hardened", "idp",
+                  "disabled", ""]
         aliases: ["ipauserauthtype"]
     ca_renewal_master_server:
         description: Renewal master for IPA certificate authority.
@@ -425,6 +426,7 @@ def main():
                           choices=["MS-PAC", "PAD", "nfs:NONE", ""]),
             user_auth_type=dict(type="list", elements="str", required=False,
                                 choices=["password", "radius", "otp",
+                                         "pkinit", "hardened", "idp",
                                          "disabled", ""],
                                 aliases=["ipauserauthtype"]),
             ca_renewal_master_server=dict(type="str", required=False),
@@ -525,6 +527,15 @@ def main():
         result = config_show(ansible_module)
 
         if params:
+            # Verify ipauserauthtype(s)
+            if "ipauserauthtype" in params and params["ipauserauthtype"]:
+                _invalid = ansible_module.ipa_command_invalid_param_choices(
+                    "config_mod", "ipauserauthtype", params["ipauserauthtype"])
+                if _invalid:
+                    ansible_module.fail_json(
+                        msg="The use of userauthtype '%s' is not "
+                        "supported by your IPA version" % "','".join(_invalid))
+
             enable_sid = params.get("enable_sid")
             sid_is_enabled = has_enable_sid and is_enable_sid(ansible_module)
 


### PR DESCRIPTION
**ansible_freeipa_module: New ipa_command_invalid_param_choices method**

New IPAAnsibleModule.ipa_command_invalid_param_choices method to return
invalid parameter choices for an IPA command.

This is needed to verify for example if userauthtype and authind are
supporting the idp value.

**ipaconfig: Add choices pkinit, hardened and idp to user_auth_type**

The parameter user_auth_type has been updated in FreeIPA. The choices
pkinit, hardened and idp have been missing and are now added.

An additional check was added to verify that the values of the
user_auth_type list are valid for the used IPA version.

**ipahost: Add choice idp to auth_ind**

The parameter auth_ind has been updated in FreeIPA. The choice
idp have been missing and is now added.

An additional check was added to verify that the values of the
auth_ind list are valid for the used IPA version.

**ipaservice: Add choice idp to auth_ind**

The parameter auth_ind has been updated in FreeIPA. The choice
idp have been missing and is now added.

An additional check was added to verify that the values of the
auth_ind list are valid for the used IPA version.

**ipauser: Add choices pkinit, hardened and idp to user_auth_type**

The parameter user_auth_type has been updated in FreeIPA. The choices
pkinit, hardened and idp have been missing and are now added.

An additional check was added to verify that the values of the
user_auth_type list are valid for the used IPA version.