### PR TITLE
ci: Increase verbosity for Ansible playbook runs

### DIFF
--- a/tests/azure/templates/galaxy_pytest_script.yml
+++ b/tests/azure/templates/galaxy_pytest_script.yml
@@ -56,6 +56,7 @@ jobs:
     env:
       IPA_SERVER_HOST: ${{ parameters.scenario }}
       RUN_TESTS_IN_DOCKER: true
+      IPA_VERBOSITY: "-vvv"
 
   - task: PublishTestResults@2
     inputs:

--- a/tests/azure/templates/galaxy_script.yml
+++ b/tests/azure/templates/galaxy_script.yml
@@ -76,6 +76,7 @@ jobs:
       IPA_DISABLED_TESTS: ${{ variables.ipa_disabled_tests }}
       IPA_ENABLED_MODULES: ${{ variables.ipa_enabled_modules }}
       IPA_ENABLED_TESTS: ${{ variables.ipa_enabled_tests }}
+      IPA_VERBOSITY: "-vvv"
 
   - task: PublishTestResults@2
     inputs:

--- a/tests/azure/templates/playbook_fast.yml
+++ b/tests/azure/templates/playbook_fast.yml
@@ -82,6 +82,7 @@ jobs:
       RUN_TESTS_IN_DOCKER: true
       IPA_DISABLED_MODULES: ${{ variables.ipa_disabled_modules }}
       IPA_DISABLED_TESTS: ${{ variables.ipa_disabled_tests }}
+      IPA_VERBOSITY: "-vvv"
 
   - task: PublishTestResults@2
     inputs:

--- a/tests/azure/templates/playbook_tests.yml
+++ b/tests/azure/templates/playbook_tests.yml
@@ -78,6 +78,7 @@ jobs:
       IPA_DISABLED_TESTS: ${{ variables.ipa_disabled_tests }}
       IPA_ENABLED_MODULES: ${{ variables.ipa_enabled_modules }}
       IPA_ENABLED_TESTS: ${{ variables.ipa_enabled_tests }}
+      IPA_VERBOSITY: "-vvv"
 
   - task: PublishTestResults@2
     inputs:

--- a/tests/azure/templates/pytest_tests.yml
+++ b/tests/azure/templates/pytest_tests.yml
@@ -66,6 +66,7 @@ jobs:
       IPA_DISABLED_TESTS: ${{ variables.ipa_disabled_tests }}
       IPA_ENABLED_MODULES: ${{ variables.ipa_enabled_modules }}
       IPA_ENABLED_TESTS: ${{ variables.ipa_enabled_tests }}
+      IPA_VERBOSITY: "-vvv"
 
   - task: PublishTestResults@2
     inputs:


### PR DESCRIPTION
Some test failures requires more information than just the playbook simple output. By increasing verbosity, the used parameters and the failed line will be visible in the test error report, making it easier to identify, reproduce and fix the issue.