### PR TITLE
Updated supported distros

### DIFF
--- a/roles/ipabackup/README.md
+++ b/roles/ipabackup/README.md
@@ -33,6 +33,7 @@ Supported Distributions
 -----------------------
 
 * RHEL/CentOS 7.6+
+* CentOS Stream 8+
 * Fedora 26+
 * Ubuntu 16.04 and 18.04
 

--- a/roles/ipaclient/README.md
+++ b/roles/ipaclient/README.md
@@ -24,8 +24,10 @@ Supported Distributions
 -----------------------
 
 * RHEL/CentOS 7.4+
+* CentOS Stream 8+
 * Fedora 26+
 * Ubuntu
+* Debian
 
 
 Requirements

--- a/roles/ipareplica/README.md
+++ b/roles/ipareplica/README.md
@@ -27,6 +27,7 @@ Supported Distributions
 -----------------------
 
 * RHEL/CentOS 7.6+
+* CentOS Stream 8+
 * Fedora 26+
 * Ubuntu 16.04 and 18.04
 

--- a/roles/ipaserver/README.md
+++ b/roles/ipaserver/README.md
@@ -24,6 +24,7 @@ Supported Distributions
 -----------------------
 
 * RHEL/CentOS 7.6+
+* CentOS Stream 8+
 * Fedora 26+
 * Ubuntu 16.04 and 18.04
 

--- a/roles/ipasmartcard_client/README.md
+++ b/roles/ipasmartcard_client/README.md
@@ -24,6 +24,7 @@ Supported Distributions
 -----------------------
 
 * RHEL/CentOS 7.6+
+* CentOS Stream 8+
 * Fedora 26+
 
 

--- a/roles/ipasmartcard_server/README.md
+++ b/roles/ipasmartcard_server/README.md
@@ -26,6 +26,7 @@ Supported Distributions
 -----------------------
 
 * RHEL/CentOS 7.6+
+* CentOS Stream 8+
 * Fedora 26+
 
 


### PR DESCRIPTION
Updated all roles README files to add supported distros, as CentOS Stream is supported (both 8 and 9) and also Debian clients.