### PR TITLE
ipacert: Fix revocation example playbook on README

### DIFF
--- a/README-cert.md
+++ b/README-cert.md
@@ -77,6 +77,23 @@ Example playbook to revoke an existing certificate:
     ipacert:
       ipaadmin_password: SomeADMINpassword
       serial_number: 123456789
+      reason: 5
+      state: revoked
+```
+
+When revoking a certificate a mnemonic can also be used to set the revocation reason:
+
+```yaml
+---
+- name: Revoke certificate
+  hosts: ipaserver
+
+  tasks:
+  - name Revoke a certificate
+    ipacert:
+      ipaadmin_password: SomeADMINpassword
+      serial_number: 123456789
+      reason: cessationOfOperation
       state: revoked
 ```
 


### PR DESCRIPTION
The revocation example playbook on README was wrong as it didn't have a 'reason' set, and the parameter must be used with 'state: revoked'.

This patch fixes the example and adds a new example using a reason mnemonic instead of a reason number.

Fixes #1132 