### PR TITLE
Bump Ansible version to 2.13

### DIFF
--- a/README-automember.md
+++ b/README-automember.md
@@ -22,7 +22,7 @@ Requirements
 ------------
 
 **Controller**
-* Ansible version: 2.8+
+* Ansible version: 2.13+
 
 **Node**
 * Supported FreeIPA version (see above)

--- a/README-automountkey.md
+++ b/README-automountkey.md
@@ -21,7 +21,7 @@ FreeIPA versions 4.4.0 and up are supported by the ipaautomountkey module.
 Requirements
 ------------
 **Controller**
-* Ansible version: 2.8+
+* Ansible version: 2.13+
 
 **Node**
 * Supported FreeIPA version (see above)

--- a/README-automountlocation.md
+++ b/README-automountlocation.md
@@ -21,7 +21,7 @@ FreeIPA versions 4.4.0 and up are supported by the ipaautomountlocation module.
 Requirements
 ------------
 **Controller**
-* Ansible version: 2.8+
+* Ansible version: 2.13+
 
 **Node**
 * Supported FreeIPA version (see above)

--- a/README-automountmap.md
+++ b/README-automountmap.md
@@ -21,7 +21,7 @@ FreeIPA versions 4.4.0 and up are supported by the ipaautomountmap module.
 Requirements
 ------------
 **Controller**
-* Ansible version: 2.8+
+* Ansible version: 2.13+
 
 **Node**
 * Supported FreeIPA version (see above)

--- a/README-cert.md
+++ b/README-cert.md
@@ -25,7 +25,7 @@ Requirements
 ------------
 
 **Controller**
-* Ansible version: 2.8+
+* Ansible version: 2.13+
 * Some tool to generate a certificate signing request (CSR) might be needed, like `openssl`.
 
 **Node**

--- a/README-config.md
+++ b/README-config.md
@@ -25,7 +25,7 @@ Requirements
 ------------
 
 **Controller**
-* Ansible version: 2.8+
+* Ansible version: 2.13+
 
 **Node**
 * Supported FreeIPA version (see above)

--- a/README-delegation.md
+++ b/README-delegation.md
@@ -23,7 +23,7 @@ Requirements
 ------------
 
 **Controller**
-* Ansible version: 2.8+
+* Ansible version: 2.13+
 
 **Node**
 * Supported FreeIPA version (see above)

--- a/README-dnsconfig.md
+++ b/README-dnsconfig.md
@@ -22,7 +22,7 @@ Requirements
 ------------
 
 **Controller**
-* Ansible version: 2.8+
+* Ansible version: 2.13+
 
 **Node**
 * Supported FreeIPA version (see above)

--- a/README-dnsforwardzone.md
+++ b/README-dnsforwardzone.md
@@ -21,7 +21,7 @@ FreeIPA versions 4.4.0 and up are supported by the ipadnsforwardzone module.
 Requirements
 ------------
 **Controller**
-* Ansible version: 2.8+
+* Ansible version: 2.13+
 
 **Node**
 * Supported FreeIPA version (see above)

--- a/README-dnsrecord.md
+++ b/README-dnsrecord.md
@@ -22,7 +22,7 @@ Requirements
 ------------
 
 **Controller**
-* Ansible version: 2.8+
+* Ansible version: 2.13+
 
 **Node**
 * Supported FreeIPA version (see above)

--- a/README-dnszone.md
+++ b/README-dnszone.md
@@ -23,7 +23,7 @@ Requirements
 ------------
 
 **Controller**
-* Ansible version: 2.8+
+* Ansible version: 2.13+
 
 
 **Node**

--- a/README-group.md
+++ b/README-group.md
@@ -29,7 +29,7 @@ Requirements
 ------------
 
 **Controller**
-* Ansible version: 2.8+
+* Ansible version: 2.13+
 
 **Node**
 * Supported FreeIPA version (see above)

--- a/README-hbacrule.md
+++ b/README-hbacrule.md
@@ -22,7 +22,7 @@ Requirements
 ------------
 
 **Controller**
-* Ansible version: 2.8+
+* Ansible version: 2.13+
 
 **Node**
 * Supported FreeIPA version (see above)

--- a/README-hbacsvc.md
+++ b/README-hbacsvc.md
@@ -22,7 +22,7 @@ Requirements
 ------------
 
 **Controller**
-* Ansible version: 2.8+
+* Ansible version: 2.13+
 
 **Node**
 * Supported FreeIPA version (see above)

--- a/README-hbacsvcgroup.md
+++ b/README-hbacsvcgroup.md
@@ -22,7 +22,7 @@ Requirements
 ------------
 
 **Controller**
-* Ansible version: 2.8+
+* Ansible version: 2.13+
 
 **Node**
 * Supported FreeIPA version (see above)

--- a/README-host.md
+++ b/README-host.md
@@ -24,7 +24,7 @@ Requirements
 ------------
 
 **Controller**
-* Ansible version: 2.8+
+* Ansible version: 2.13+
 
 **Node**
 * Supported FreeIPA version (see above)

--- a/README-hostgroup.md
+++ b/README-hostgroup.md
@@ -26,7 +26,7 @@ Requirements
 ------------
 
 **Controller**
-* Ansible version: 2.8+
+* Ansible version: 2.13+
 
 **Node**
 * Supported FreeIPA version (see above)

--- a/README-idrange.md
+++ b/README-idrange.md
@@ -37,7 +37,7 @@ Requirements
 ------------
 
 **Controller**
-* Ansible version: 2.8+
+* Ansible version: 2.13+
 
 **Node**
 * Supported FreeIPA version (see above)

--- a/README-location.md
+++ b/README-location.md
@@ -22,7 +22,7 @@ Requirements
 ------------
 
 **Controller**
-* Ansible version: 2.8+
+* Ansible version: 2.13+
 
 **Node**
 * Supported FreeIPA version (see above)

--- a/README-netgroup.md
+++ b/README-netgroup.md
@@ -22,7 +22,7 @@ Requirements
 ------------
 
 **Controller**
-* Ansible version: 2.8+
+* Ansible version: 2.13+
 
 **Node**
 * Supported FreeIPA version (see above)

--- a/README-permission.md
+++ b/README-permission.md
@@ -22,7 +22,7 @@ Requirements
 ------------
 
 **Controller**
-* Ansible version: 2.8+
+* Ansible version: 2.13+
 
 **Node**
 * Supported FreeIPA version (see above)

--- a/README-privilege.md
+++ b/README-privilege.md
@@ -22,7 +22,7 @@ Requirements
 ------------
 
 **Controller**
-* Ansible version: 2.8+
+* Ansible version: 2.13+
 
 **Node**
 * Supported FreeIPA version (see above)

--- a/README-pwpolicy.md
+++ b/README-pwpolicy.md
@@ -22,7 +22,7 @@ Requirements
 ------------
 
 **Controller**
-* Ansible version: 2.8+
+* Ansible version: 2.13+
 
 **Node**
 * Supported FreeIPA version (see above)

--- a/README-role.md
+++ b/README-role.md
@@ -25,7 +25,7 @@ Requirements
 ------------
 
 **Controller**
-* Ansible version: 2.8+
+* Ansible version: 2.13+
 
 **Node**
 * Supported FreeIPA version (see above)

--- a/README-selfservice.md
+++ b/README-selfservice.md
@@ -23,7 +23,7 @@ Requirements
 ------------
 
 **Controller**
-* Ansible version: 2.8+
+* Ansible version: 2.13+
 
 **Node**
 * Supported FreeIPA version (see above)

--- a/README-server.md
+++ b/README-server.md
@@ -22,7 +22,7 @@ Requirements
 ------------
 
 **Controller**
-* Ansible version: 2.8+
+* Ansible version: 2.13+
 
 **Node**
 * Supported FreeIPA version (see above)

--- a/README-service.md
+++ b/README-service.md
@@ -25,7 +25,7 @@ Requirements
 ------------
 
 **Controller**
-* Ansible version: 2.8+
+* Ansible version: 2.13+
 
 **Node**
 * Supported FReeIPA version (see above)

--- a/README-servicedelegationrule.md
+++ b/README-servicedelegationrule.md
@@ -24,7 +24,7 @@ Requirements
 ------------
 
 **Controller**
-* Ansible version: 2.8+
+* Ansible version: 2.13+
 
 **Node**
 * Supported FreeIPA version (see above)

--- a/README-servicedelegationtarget.md
+++ b/README-servicedelegationtarget.md
@@ -24,7 +24,7 @@ Requirements
 ------------
 
 **Controller**
-* Ansible version: 2.8+
+* Ansible version: 2.13+
 
 **Node**
 * Supported FreeIPA version (see above)

--- a/README-sudocmd.md
+++ b/README-sudocmd.md
@@ -24,7 +24,7 @@ Requirements
 ------------
 
 **Controller**
-* Ansible version: 2.8+
+* Ansible version: 2.13+
 
 **Node**
 * Supported FreeIPA version (see above)

--- a/README-sudocmdgroup.md
+++ b/README-sudocmdgroup.md
@@ -24,7 +24,7 @@ Requirements
 ------------
 
 **Controller**
-* Ansible version: 2.8+
+* Ansible version: 2.13+
 
 **Node**
 * Supported FreeIPA version (see above)

--- a/README-sudorule.md
+++ b/README-sudorule.md
@@ -22,7 +22,7 @@ Requirements
 ------------
 
 **Controller**
-* Ansible version: 2.8+
+* Ansible version: 2.13+
 
 **Node**
 * Supported FreeIPA version (see above)

--- a/README-topology.md
+++ b/README-topology.md
@@ -22,7 +22,7 @@ Requirements
 ------------
 
 **Controller**
-* Ansible version: 2.8+
+* Ansible version: 2.13+
 
 **Node**
 * Supported FreeIPA version (see above)

--- a/README-trust.md
+++ b/README-trust.md
@@ -21,7 +21,7 @@ Requirements
 
 **Controller**
 
-* Ansible version: 2.8+
+* Ansible version: 2.13+
 
 **Node**
 

--- a/README-user.md
+++ b/README-user.md
@@ -24,7 +24,7 @@ Requirements
 ------------
 
 **Controller**
-* Ansible version: 2.8+
+* Ansible version: 2.13+
 
 **Node**
 * Supported FreeIPA version (see above)

--- a/README-vault.md
+++ b/README-vault.md
@@ -24,7 +24,7 @@ Requirements
 ------------
 
 **Controller**
-* Ansible version: 2.8+
+* Ansible version: 2.13+
 
 **Node**
 * Supported FreeIPA version (see above)

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Requirements
 ------------
 
 **Controller**
-* Ansible version: 2.8+ (ansible-freeipa is an Ansible Collection)
+* Ansible version: 2.13+
 
 **Node**
 * Supported FreeIPA version (see above)
@@ -130,17 +130,7 @@ This command will get the whole collection from galaxy:
 ansible-galaxy collection install freeipa.ansible_freeipa
 ```
 
-Installing collections using the ansible-galaxy command is only supported with ansible 2.9+.
-
-The mazer tool can be used for to install the collection for ansible 2.8:
-
-```bash
-mazer install freeipa.ansible_freeipa
-```
-
 Ansible galaxy does not support the use of dash ('-') in a name and is automatically replacing this with an underscore ('\_'). Therefore the name is `ansible_freeipa`. The ansible_freeipa collection will be placed in the directory `~/.ansible/collections/ansible_collections/freeipa/ansible_freeipa` where it will be automatically be found for this user.
-
-The needed adaptions of collection prefixes for `modules` and `module_utils` will be done with ansible-freeipa release `0.1.6` for galaxy.
 
 
 Ansible inventory file

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,2 +1,2 @@
 ---
-requires_ansible: ">=2.9"
+requires_ansible: ">=2.13"

--- a/roles/ipabackup/README.md
+++ b/roles/ipabackup/README.md
@@ -42,7 +42,7 @@ Requirements
 ------------
 
 **Controller**
-* Ansible version: 2.8+
+* Ansible version: 2.13+
 
 **Node**
 * Supported FreeIPA version (see above)

--- a/roles/ipabackup/meta/main.yml
+++ b/roles/ipabackup/meta/main.yml
@@ -6,7 +6,7 @@ galaxy_info:
   description: A role to backup and restore an IPA server
   company: Red Hat, Inc
   license: GPLv3
-  min_ansible_version: "2.8"
+  min_ansible_version: "2.13"
   platforms:
   - name: Fedora
     versions:

--- a/roles/ipaclient/README.md
+++ b/roles/ipaclient/README.md
@@ -34,7 +34,7 @@ Requirements
 ------------
 
 **Controller**
-* Ansible version: 2.8+
+* Ansible version: 2.13+
 
 **Node**
 * Supported FreeIPA version (see above)

--- a/roles/ipaclient/meta/main.yml
+++ b/roles/ipaclient/meta/main.yml
@@ -6,7 +6,7 @@ galaxy_info:
   description: A role to join a machine to an IPA domain
   company: Red Hat, Inc
   license: GPLv3
-  min_ansible_version: "2.8"
+  min_ansible_version: "2.13"
   platforms:
   - name: Fedora
     versions:

--- a/roles/ipareplica/README.md
+++ b/roles/ipareplica/README.md
@@ -36,7 +36,7 @@ Requirements
 ------------
 
 **Controller**
-* Ansible version: 2.8+
+* Ansible version: 2.13+
 
 **Node**
 * Supported FreeIPA version (see above)

--- a/roles/ipareplica/meta/main.yml
+++ b/roles/ipareplica/meta/main.yml
@@ -6,7 +6,7 @@ galaxy_info:
   description: A role to setup an IPA domain replica
   company: Red Hat, Inc
   license: GPLv3
-  min_ansible_version: "2.8"
+  min_ansible_version: "2.13"
   platforms:
   - name: Fedora
     versions:

--- a/roles/ipaserver/README.md
+++ b/roles/ipaserver/README.md
@@ -33,7 +33,7 @@ Requirements
 ------------
 
 **Controller**
-* Ansible version: 2.8+
+* Ansible version: 2.13+
 
 **Node**
 * Supported FreeIPA version (see above)

--- a/roles/ipaserver/meta/main.yml
+++ b/roles/ipaserver/meta/main.yml
@@ -6,7 +6,7 @@ galaxy_info:
   description: A role to setup an iPA domain server
   company: Red Hat, Inc
   license: GPLv3
-  min_ansible_version: "2.8"
+  min_ansible_version: "2.13"
   platforms:
   - name: Fedora
     versions:

--- a/roles/ipasmartcard_client/README.md
+++ b/roles/ipasmartcard_client/README.md
@@ -32,7 +32,7 @@ Requirements
 ------------
 
 **Controller**
-* Ansible version: 2.8+
+* Ansible version: 2.13+
 
 **Node**
 * Supported FreeIPA version (see above)

--- a/roles/ipasmartcard_client/meta/main.yml
+++ b/roles/ipasmartcard_client/meta/main.yml
@@ -6,7 +6,7 @@ galaxy_info:
   description: A role to setup IPA server(s) for Smart Card authentication
   company: Red Hat, Inc
   license: GPLv3
-  min_ansible_version: "2.8"
+  min_ansible_version: "2.13"
   platforms:
   - name: Fedora
     versions:

--- a/roles/ipasmartcard_server/README.md
+++ b/roles/ipasmartcard_server/README.md
@@ -34,7 +34,7 @@ Requirements
 ------------
 
 **Controller**
-* Ansible version: 2.8+
+* Ansible version: 2.13+
 
 **Node**
 * Supported FreeIPA version (see above)

--- a/roles/ipasmartcard_server/meta/main.yml
+++ b/roles/ipasmartcard_server/meta/main.yml
@@ -6,7 +6,7 @@ galaxy_info:
   description: A role to setup IPA server(s) for Smart Card authentication
   company: Red Hat, Inc
   license: GPLv3
-  min_ansible_version: "2.8"
+  min_ansible_version: "2.13"
   platforms:
   - name: Fedora
     versions:

--- a/utils/ansible-freeipa.spec.in
+++ b/utils/ansible-freeipa.spec.in
@@ -84,7 +84,7 @@ Supported Distributions
 Requirements
 
   Controller
-  - Ansible version: 2.8+ (ansible-freeipa is an Ansible Collection)
+  - Ansible version: 2.13+
   - /usr/bin/kinit is required on the controller if a one time password (OTP)
     is used
 

--- a/utils/templates/README-module+member.md.in
+++ b/utils/templates/README-module+member.md.in
@@ -22,7 +22,7 @@ Requirements
 ------------
 
 **Controller**
-* Ansible version: 2.8+
+* Ansible version: 2.13+
 
 **Node**
 * Supported FreeIPA version (see above)

--- a/utils/templates/README-module.md.in
+++ b/utils/templates/README-module.md.in
@@ -22,7 +22,7 @@ Requirements
 ------------
 
 **Controller**
-* Ansible version: 2.8+
+* Ansible version: 2.13+
 
 **Node**
 * Supported FreeIPA version (see above)


### PR DESCRIPTION
Bump ansible-freeipa collection minimum version to Ansible 2.13.

Please, see individual commits for details.