### PR TITLE
Do not use "del os.environ" as the variable might not exist

### DIFF
--- a/plugins/module_utils/ansible_freeipa_module.py
+++ b/plugins/module_utils/ansible_freeipa_module.py
@@ -226,7 +226,7 @@ def temp_kdestroy(ccache_dir, ccache_name):
     """Destroy temporary ticket and remove temporary ccache."""
     if ccache_name is not None:
         run([paths.KDESTROY, '-c', ccache_name], raiseonerr=False)
-        del os.environ['KRB5CCNAME']
+        os.environ.pop('KRB5CCNAME', None)
     if ccache_dir is not None:
         shutil.rmtree(ccache_dir, ignore_errors=True)
 

--- a/roles/ipaclient/library/ipaclient_fix_ca.py
+++ b/roles/ipaclient/library/ipaclient_fix_ca.py
@@ -132,7 +132,7 @@ def main():
             else:
                 get_ca_certs(fstore, options, servers[0], basedn, realm)
             changed = True
-            del os.environ['KRB5_CONFIG']
+            os.environ.pop('KRB5_CONFIG', None)
         except errors.FileError as e:
             module.fail_json(msg='%s' % e)
         except Exception as e:

--- a/roles/ipaclient/library/ipaclient_get_otp.py
+++ b/roles/ipaclient/library/ipaclient_get_otp.py
@@ -123,7 +123,7 @@ def temp_kdestroy(ccache_dir, ccache_name):
     """Destroy temporary ticket and remove temporary ccache."""
     if ccache_name is not None:
         run([paths.KDESTROY, '-c', ccache_name], raiseonerr=False)
-        del os.environ['KRB5CCNAME']
+        os.environ.pop('KRB5CCNAME', None)
     if ccache_dir is not None:
         shutil.rmtree(ccache_dir, ignore_errors=True)
 

--- a/roles/ipaclient/library/ipaclient_join.py
+++ b/roles/ipaclient/library/ipaclient_join.py
@@ -272,7 +272,7 @@ def main():
                 get_ca_cert(fstore, options, servers[0], basedn)
             else:
                 get_ca_certs(fstore, options, servers[0], basedn, realm)
-            del os.environ['KRB5_CONFIG']
+            os.environ.pop('KRB5_CONFIG', None)
         except errors.FileError as e:
             module.fail_json(msg='%s' % e)
         except Exception as e:

--- a/roles/ipareplica/library/ipareplica_prepare.py
+++ b/roles/ipareplica/library/ipareplica_prepare.py
@@ -669,7 +669,7 @@ def main():
                 raise errors.ACIError(info="Not authorized")
 
             if installer._ccache is None:
-                del os.environ['KRB5CCNAME']
+                os.environ.pop('KRB5CCNAME', None)
             else:
                 os.environ['KRB5CCNAME'] = installer._ccache
 
@@ -873,7 +873,7 @@ def main():
         if add_to_ipaservers:
             # use user's credentials when the server host is not ipaservers
             if installer._ccache is None:
-                del os.environ['KRB5CCNAME']
+                os.environ.pop('KRB5CCNAME', None)
             else:
                 os.environ['KRB5CCNAME'] = installer._ccache
 

--- a/roles/ipaserver/library/ipaserver_get_connected_server.py
+++ b/roles/ipaserver/library/ipaserver_get_connected_server.py
@@ -108,7 +108,7 @@ def temp_kdestroy(ccache_dir, ccache_name):
     """Destroy temporary ticket and remove temporary ccache."""
     if ccache_name is not None:
         run([paths.KDESTROY, '-c', ccache_name], raiseonerr=False)
-        del os.environ['KRB5CCNAME']
+        os.environ.pop('KRB5CCNAME', None)
     if ccache_dir is not None:
         shutil.rmtree(ccache_dir, ignore_errors=True)
 


### PR DESCRIPTION
The use of del os.environ assumes that the environment variable exists. If the variable does not exist, this call will result in a traceback. The solution is to use os.environ.pop(VARIABLE, None) instead.

This is the ansible-freeipa fix for https://pagure.io/freeipa/issue/9446 (Nightly test failure for replica installation with --setup-ca)