### PR TITLE
Ensure CI runs against the oldest supported Ansible versions.

### DIFF
--- a/tests/azure/azure-pipelines.yml
+++ b/tests/azure/azure-pipelines.yml
@@ -20,6 +20,17 @@ stages:
 
 # Fedora
 
+- stage: Fedora_Ansible_min_supported
+  dependsOn: []
+  jobs:
+  - template: templates/group_tests.yml
+    parameters:
+      build_number: $(Build.BuildNumber)
+      scenario: fedora-latest
+      ansible_version: "-core <2.14"
+
+# Fedora
+
 - stage: Fedora_Latest
   dependsOn: []
   jobs:

--- a/tests/azure/nightly.yml
+++ b/tests/azure/nightly.yml
@@ -16,6 +16,15 @@ stages:
 
 # Fedora
 
+- stage: FedoraLatest_Ansible_Core_2_9
+  dependsOn: []
+  jobs:
+  - template: templates/group_tests.yml
+    parameters:
+      build_number: $(Build.BuildNumber)
+      scenario: fedora-latest
+      ansible_version: "<2.10"
+
 - stage: FedoraLatest_Ansible_Core_2_13
   dependsOn: []
   jobs:
@@ -92,6 +101,15 @@ stages:
 
 # Fedora Rawhide
 
+- stage: FedoraRawhide_Ansible_Core_2_9
+  dependsOn: []
+  jobs:
+  - template: templates/group_tests.yml
+    parameters:
+      build_number: $(Build.BuildNumber)
+      scenario: fedora-rawhide
+      ansible_version: "<2.10"
+
 - stage: FedoraRawhide_Ansible_Core_2_13
   dependsOn: []
   jobs:
@@ -129,6 +147,15 @@ stages:
       ansible_version: ""
 
 # CentoOS 9 Stream
+
+- stage: c9s_Ansible_Core_2_9
+  dependsOn: []
+  jobs:
+  - template: templates/group_tests.yml
+    parameters:
+      build_number: $(Build.BuildNumber)
+      scenario: c9s
+      ansible_version: "-core <2.9"
 
 - stage: c9s_Ansible_Core_2_13
   dependsOn: []
@@ -168,6 +195,15 @@ stages:
 
 # CentOS 8 Stream
 
+- stage: c8s_Ansible_Core_2_9
+  dependsOn: []
+  jobs:
+  - template: templates/group_tests.yml
+    parameters:
+      build_number: $(Build.BuildNumber)
+      scenario: c8s
+      ansible_version: "<2.10"
+
 - stage: c8s_Ansible_Core_2_13
   dependsOn: []
   jobs:
@@ -205,6 +241,15 @@ stages:
       ansible_version: ""
 
 # CentOS 7
+
+- stage: CentOS7_Ansible_Core_2_9
+  dependsOn: []
+  jobs:
+  - template: templates/group_tests.yml
+    parameters:
+      build_number: $(Build.BuildNumber)
+      scenario: centos-7
+      ansible_version: "<2.10"
 
 - stage: CentOS7_Ansible_Core_2_13
   dependsOn: []


### PR DESCRIPTION
Currently, ansible-freeipa's minimum supported ansible-core version is version 2.13, as it is the current minimum supported upstream ansible-core version. This patch changes upstream CI to run PR checks against this ansible-core version.

Also, it was announced that Ansible 2.9 will have some support for a year, or so, and this PR adds nightly testing against this version of Ansible, to check weather ansible-freeipa can still be used with this version or not.