### PR TITLE
utils/ansible-freeipa.spec.in: Add ref for idoverridegroup management

### DIFF
--- a/utils/ansible-freeipa.spec.in
+++ b/utils/ansible-freeipa.spec.in
@@ -48,6 +48,7 @@ Features
 - Modules for hbacsvcgroup management
 - Modules for host management
 - Modules for hostgroup management
+- Modules for idoverridegroup management
 - Modules for idoverrideuser management
 - Modules for idrange management
 - Modules for idview management


### PR DESCRIPTION
The idoverridegroup management reference has been added to the description.