### PR TITLE
upstream CI: Fix test selection for CheckPR pipeline.

### DIFF
--- a/tests/azure/templates/fast_tests.yml
+++ b/tests/azure/templates/fast_tests.yml
@@ -13,28 +13,10 @@ jobs:
 - template: playbook_fast.yml
   parameters:
     group_number: 1
-    number_of_groups: 3
+    number_of_groups: 1
     build_number: ${{ parameters.build_number }}
     scenario: ${{ parameters.scenario }}
     ansible_version: ${{ parameters.ansible_version }}
-    python_version: '< 3.12'
-
-- template: playbook_fast.yml
-  parameters:
-    group_number: 2
-    number_of_groups: 3
-    build_number: ${{ parameters.build_number }}
-    scenario: ${{ parameters.scenario }}
-    ansible_version: ${{ parameters.ansible_version }}
-    python_version: '< 3.12'
-
-- template: playbook_fast.yml
-  parameters:
-    group_number: 3
-    number_of_groups: 3
-    build_number: ${{ parameters.build_number }}
-    scenario: ${{ parameters.scenario }}
-    ansible_version: ${{ parameters.ansible_version }}z
     python_version: '< 3.12'
 
 # - template: pytest_tests.yml

--- a/tests/azure/templates/galaxy_script.yml
+++ b/tests/azure/templates/galaxy_script.yml
@@ -67,6 +67,7 @@ jobs:
         --color=yes \
         --splits=${{ parameters.number_of_groups }} \
         --group=${{ parameters.group_number }} \
+        --randomly-seed=$(date "+%Y%m%d") \
         --junit-xml=TEST-results-group-${{ parameters.group_number }}.xml
     displayName: Run playbook tests
     env:

--- a/tests/azure/templates/playbook_fast.yml
+++ b/tests/azure/templates/playbook_fast.yml
@@ -72,6 +72,7 @@ jobs:
         --suppress-no-test-exit-code \
         --splits=${{ parameters.number_of_groups }} \
         --group=${{ parameters.group_number }} \
+        --randomly-seed=$(date "+%Y%m%d") \
         --junit-xml=TEST-results-group-${{ parameters.group_number }}.xml
       then
         [ $? -eq 5 ] && true || false

--- a/tests/azure/templates/playbook_tests.yml
+++ b/tests/azure/templates/playbook_tests.yml
@@ -69,6 +69,7 @@ jobs:
         --color=yes \
         --splits=${{ parameters.number_of_groups }} \
         --group=${{ parameters.group_number }} \
+        --randomly-seed=$(date "+%Y%m%d") \
         --junit-xml=TEST-results-group-${{ parameters.group_number }}.xml
     displayName: Run playbook tests
     env:


### PR DESCRIPTION
This PR fixes issues related to test selection in upstream CI:

* `CheckPR`:
    * Fixed test selection script.
    * Use a single job to run the tests

* Other pipelines:
    * Use the same random seed to randomly choose the tests to run on each group, ensuring all tests are executed.