### PR TITLE
ipauser: Do not try to modify user when not changing password

### DIFF
--- a/plugins/modules/ipauser.py
+++ b/plugins/modules/ipauser.py
@@ -1449,6 +1449,10 @@ def main():
                                 del args["userpassword"]
                             if "random" in args:
                                 del args["random"]
+                        # if using "random:false" password should not be
+                        # generated.
+                        if not args.get("random", True):
+                            del args["random"]
                         if "noprivate" in args:
                             del args["noprivate"]
 

--- a/tests/user/test_user.yml
+++ b/tests/user/test_user.yml
@@ -87,6 +87,17 @@
     register: result
     failed_when: not result.changed or result.failed
 
+  - name: Ensure user presence with 'random:false'
+    ipauser:
+      ipaadmin_password: SomeADMINpassword
+      ipaapi_context: "{{ ipa_context | default(omit) }}"
+      name: pinky
+      first: pinky
+      last: Acme
+      random: false
+    register: result
+    failed_when: result.changed or result.failed
+
   - name: Set street, again
     ipauser:
       ipaadmin_password: SomeADMINpassword


### PR DESCRIPTION
If a playbook to ensure the existence of a user contains 'random:false' and 'update_password: always' is executed twice, the second execution will raise an exception due to "No modifications to perform", as there is actually nothing to modify.

The fix for the issue is to remove 'random' if it is not set to true, as setting it to 'false' would have no effect on the user object.

Related: https://issues.redhat.com/browse/RHEL-4934