### PR TITLE
ipareplica: Support inventory groups.ipaserver

### DIFF
--- a/roles/ipareplica/tasks/install.yml
+++ b/roles/ipareplica/tasks/install.yml
@@ -57,6 +57,11 @@
     ipareplica_servers: "{{ groups['ipaservers'] | list }}"
   when: groups.ipaservers is defined and ipareplica_servers is not defined
 
+- name: Install - Set ipareplica_servers from cluster inventory
+  ansible.builtin.set_fact:
+    ipareplica_servers: "{{ groups['ipaserver'] | list }}"
+  when: ipareplica_servers is not defined and groups.ipaserver is defined
+
 - name: Install - Set default principal if no keytab is given
   ansible.builtin.set_fact:
     ipaadmin_principal: admin


### PR DESCRIPTION
Altough most of ansible-freeipa documentation and playbooks use 'ipaserver' as the group for the first server deployed for a realm, the ipareplica role only supported the use of groups["ipaservers"] as an alternative to set ipareplica_servers.

Also supporting groups.ipaserver, as already supported by the ipaclient role, make ansible-freeipa playbooks more consistent and current documentation and examples easier to follow when deploying a cluster with a server and a replica.