### PR TITLE
upstream CI: Pin Python version to 3.11 

### DIFF
--- a/tests/azure/templates/fast_tests.yml
+++ b/tests/azure/templates/fast_tests.yml
@@ -17,6 +17,7 @@ jobs:
     build_number: ${{ parameters.build_number }}
     scenario: ${{ parameters.scenario }}
     ansible_version: ${{ parameters.ansible_version }}
+    python_version: '< 3.12'
 
 - template: playbook_fast.yml
   parameters:
@@ -25,6 +26,7 @@ jobs:
     build_number: ${{ parameters.build_number }}
     scenario: ${{ parameters.scenario }}
     ansible_version: ${{ parameters.ansible_version }}
+    python_version: '< 3.12'
 
 - template: playbook_fast.yml
   parameters:
@@ -33,9 +35,11 @@ jobs:
     build_number: ${{ parameters.build_number }}
     scenario: ${{ parameters.scenario }}
     ansible_version: ${{ parameters.ansible_version }}z
+    python_version: '< 3.12'
 
 # - template: pytest_tests.yml
 #   parameters:
 #     build_number: ${{ parameters.build_number }}
 #     scenario: ${{ parameters.scenario }}
 #     ansible_version: ${{ parameters.ansible_version }}
+#     python_version: '< 3.12'

--- a/tests/azure/templates/galaxy_tests.yml
+++ b/tests/azure/templates/galaxy_tests.yml
@@ -17,6 +17,7 @@ jobs:
     build_number: ${{ parameters.build_number }}
     scenario: ${{ parameters.scenario }}
     ansible_version: ${{ parameters.ansible_version }}
+    python_version: '< 3.12'
 
 - template: galaxy_script.yml
   parameters:
@@ -25,6 +26,7 @@ jobs:
     build_number: ${{ parameters.build_number }}
     scenario: ${{ parameters.scenario }}
     ansible_version: ${{ parameters.ansible_version }}
+    python_version: '< 3.12'
 
 - template: galaxy_script.yml
   parameters:
@@ -33,6 +35,7 @@ jobs:
     build_number: ${{ parameters.build_number }}
     scenario: ${{ parameters.scenario }}
     ansible_version: ${{ parameters.ansible_version }}
+    python_version: '< 3.12'
 
 # Temporarily disable due to issues with ansible docker plugin.
 #- template: galaxy_pytest_script.yml
@@ -40,3 +43,4 @@ jobs:
 #    build_number: ${{ parameters.build_number }}
 #    scenario: ${{ parameters.scenario }}
 #    ansible_version: ${{ parameters.ansible_version }}
+#    python_version: '< 3.12'

--- a/tests/azure/templates/group_tests.yml
+++ b/tests/azure/templates/group_tests.yml
@@ -17,6 +17,7 @@ jobs:
     build_number: ${{ parameters.build_number }}
     scenario: ${{ parameters.scenario }}
     ansible_version: ${{ parameters.ansible_version }}
+    python_version: '< 3.12'
 
 - template: playbook_tests.yml
   parameters:
@@ -25,6 +26,7 @@ jobs:
     build_number: ${{ parameters.build_number }}
     scenario: ${{ parameters.scenario }}
     ansible_version: ${{ parameters.ansible_version }}
+    python_version: '< 3.12'
 
 - template: playbook_tests.yml
   parameters:
@@ -33,6 +35,7 @@ jobs:
     build_number: ${{ parameters.build_number }}
     scenario: ${{ parameters.scenario }}
     ansible_version: ${{ parameters.ansible_version }}
+    python_version: '< 3.12'
 
 # Temporarily disabled due to ansible docker plugin issue.
 #- template: pytest_tests.yml
@@ -40,3 +43,4 @@ jobs:
 #    build_number: ${{ parameters.build_number }}
 #    scenario: ${{ parameters.scenario }}
 #    ansible_version: ${{ parameters.ansible_version }}
+#    python_version: '< 3.12'


### PR DESCRIPTION
After Azure updated available Python to version 3.12, test image preparation started to fail.

The fix is to pin python version to the latest is the 3.11 series until we can run tests with Python 3.12. 

Note that only the first commit should be applied ([55b8729](https://github.com/freeipa/ansible-freeipa/pull/1157/commits/55b8729c5270a4a6ab4ca6668b1e2e7d7b6afa10)). Other commits come from PR #1148 and are present only to fix test selection.