### PR TITLE
upstream CI: Pin ansible-lint version to 6.20 series

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,7 +16,7 @@ jobs:
           python-version: "3.x"
       - name: Run ansible-lint
         run: |
-          pip install "ansible-core >=2.15,<2.16" ansible-lint
+          pip install "ansible-core >=2.15,<2.16" 'ansible-lint<6.21'
           utils/build-galaxy-release.sh -ki
           cd .galaxy-build
           ansible-lint --profile production --exclude tests/integration/ --exclude tests/unit/ --parseable --nocolor


### PR DESCRIPTION
The release version 6.21.0 of ansible-lint introduced a bug that breaks the reporting of 'warning' messages. [1]

This patch pins ansible-lint version to the latest one in the 6.20 series, so that it can still be used to check pull requests.

[1]: https://github.com/ansible/ansible-lint/issues/3853