### PR TITLE
Increase msg size

### DIFF
--- a/tests/utils.py
+++ b/tests/utils.py
@@ -197,7 +197,7 @@ def run_playbook(playbook, allow_failures=False):
 
     # Need to get the last bytes of msg otherwise Azure
     #   will cut it out.
-    assert result.returncode == 0, assert_msg[-2500:]
+    assert result.returncode == 0, assert_msg[-5000:]
 
     return result
 


### PR DESCRIPTION
The message size of 2500 characters is not enough to provide enough information for some test case failures. Doubling the size will provide more information to evaluate test failure.