### PR TITLE
ipaclient: Properly name automount_location var and add documentation

### DIFF
--- a/roles/ipaclient/README.md
+++ b/roles/ipaclient/README.md
@@ -201,6 +201,7 @@ Variable | Description | Required
 `ipasssd_preserve_sssd` | The bool value defines if the old SSSD configuration will be preserved if it is not possible to merge it with a new one. `ipasssd_preserve_sssd` defaults to `no`. | no
 `ipaclient_request_cert` | The bool value defines if the certificate for the machine wil be requested. The certificate will be stored in /etc/ipa/nssdb under the nickname "Local IPA host". . `ipaclient_request_cert` defaults to `no`. The option is deprecated and will be removed in a future release. | no
 `ipaclient_keytab` | The string value contains the path on the node of a backup host keytab from a previous enrollment. | no
+`ipaclient_automount_location` | Automount location | no
 
 
 Server Variables

--- a/roles/ipaclient/tasks/install.yml
+++ b/roles/ipaclient/tasks/install.yml
@@ -397,7 +397,7 @@
       ipaclient_setup_automount:
         servers: "{{ result_ipaclient_test.servers }}"
         sssd: "{{ result_ipaclient_test.sssd }}"
-        automount_location: "{{ ipaautomount_location | default(omit) }}"
+        automount_location: "{{ ipaclient_automount_location | default(omit) }}"
 
     - name: Install - Configure firefox
       ipaclient_setup_firefox:


### PR DESCRIPTION
The ipaclient_automount_location variable was badly named as ipaautomount_location. Additionally it was not documented in the role README file.

Fixes: #1166 (.. automount-location to the ipa-client role)