### PR TITLE
Update ansible-lint and pylint versions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,7 +16,7 @@ jobs:
           python-version: "3.x"
       - name: Run ansible-lint
         run: |
-          pip install "ansible-core >=2.15,<2.16" 'ansible-lint<6.21'
+          pip install "ansible-core>=2.16,<2.17" 'ansible-lint>=6.21'
           utils/build-galaxy-release.sh -ki
           cd .galaxy-build
           ansible-lint --profile production --exclude tests/integration/ --exclude tests/unit/ --parseable --nocolor
@@ -76,7 +76,7 @@ jobs:
           python-version: "3.x"
       - name: Run pylint
         run: |
-            pip install pylint==2.17.2
+            pip install 'pylint>=3.0'
             pylint plugins roles --disable=import-error
 
   shellcheck:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 ---
 repos:
 - repo: https://github.com/ansible/ansible-lint.git
-  rev: v6.17.2
+  rev: v6.22.0
   hooks:
   - id: ansible-lint
     always_run: false
@@ -34,7 +34,7 @@ repos:
   hooks:
   - id: pydocstyle
 - repo: https://github.com/pycqa/pylint
-  rev: v2.17.2
+  rev: v3.0.2
   hooks:
   - id: pylint
     args:


### PR DESCRIPTION
ansible-lint 6.21+ and pylint 3.0+ will be required for Ansible collections to be approved on Ansible Galaxy.

This patch updates pre-commit and upstream linters to use the required versions.