### PR TITLE
ipauser: Add support for renaming users

### DIFF
--- a/README-user.md
+++ b/README-user.md
@@ -279,7 +279,6 @@ Example playbook to disable a user:
 
 This can also be done as an alternative with the `users` variable containing only names.
 
-
 Example playbook to enable users:
 
 ```yaml
@@ -298,6 +297,22 @@ Example playbook to enable users:
 
 This can also be done as an alternative with the `users` variable containing only names.
 
+Example playbook to rename users:
+
+```yaml
+---
+- name: Playbook to handle users
+  hosts: ipaserver
+  become: true
+
+  tasks:
+  # Rename user pinky to reddy
+  - ipauser:
+      ipaadmin_password: SomeADMINpassword
+      name: pinky
+      rename: reddy
+      state: enabled
+```
 
 Example playbook to unlock users:
 
@@ -401,7 +416,7 @@ Variable | Description | Required
 `update_password` | Set password for a user in present state only on creation or always. It can be one of `always` or `on_create` and defaults to `always`. | no
 `preserve` | Delete a user, keeping the entry available for future use. (bool)  | no
 `action` | Work on user or member level. It can be on of `member` or `user` and defaults to `user`. | no
-`state` | The state to ensure. It can be one of `present`, `absent`, `enabled`, `disabled`, `unlocked` or `undeleted`, default: `present`. Only `names` or `users` with only `name` set are allowed if state is not `present`. | yes
+`state` | The state to ensure. It can be one of `present`, `absent`, `enabled`, `disabled`, `renamed`, `unlocked` or `undeleted`, default: `present`. Only `names` or `users` with only `name` set are allowed if state is not `present`. | yes
 
 
 
@@ -458,8 +473,8 @@ Variable | Description | Required
 `smb_profile_path:` \| `ipantprofilepath` | SMB profile path, in UNC format. Requires FreeIPA version 4.8.0+. | no 
 `smb_home_dir` \| `ipanthomedirectory` | SMB Home Directory, in UNC format. Requires FreeIPA version 4.8.0+.  | no 
 `smb_home_drive` \| `ipanthomedirectorydrive` | SMB Home Directory Drive, a single upercase letter (A-Z) followed by a colon (:), for example "U:". Requires FreeIPA version 4.8.0+. | no 
+`rename` \| `new_name` | Rename the user object to the new name string. Only usable with `state: renamed`. | no
 `nomembers` | Suppress processing of membership attributes. (bool) | no
-
 
 
 Return Values
@@ -477,5 +492,5 @@ Variable | Description | Returned When
 Authors
 =======
 
-Thomas Woerner
-Rafael Jeffman
+- Thomas Woerner
+- Rafael Jeffman

--- a/tests/user/test_user.yml
+++ b/tests/user/test_user.yml
@@ -9,7 +9,7 @@
     ipauser:
       ipaadmin_password: SomeADMINpassword
       ipaapi_context: "{{ ipa_context | default(omit) }}"
-      name: manager1,manager2,manager3,pinky,pinky2,igagarin
+      name: manager1,manager2,manager3,pinky,pinky2,igagarin,reddy
       state: absent
 
   - name: User manager1 present
@@ -351,6 +351,46 @@
       state: enabled
     register: result
     failed_when: result.changed or result.failed
+
+  - name: Rename user pinky to reddy
+    ipauser:
+      ipaadmin_password: SomeADMINpassword
+      ipaapi_context: "{{ ipa_context | default(omit) }}"
+      name: pinky
+      rename: reddy
+      state: renamed
+    register: result
+    failed_when: not result.changed or result.failed
+
+  - name: Rename user pinky to reddy, again
+    ipauser:
+      ipaadmin_password: SomeADMINpassword
+      ipaapi_context: "{{ ipa_context | default(omit) }}"
+      name: pinky
+      rename: reddy
+      state: renamed
+    register: result
+    failed_when: not result.failed or "No user 'pinky'" not in result.msg
+
+  - name: Rename user reddy to reddy
+    ipauser:
+      ipaadmin_password: SomeADMINpassword
+      ipaapi_context: "{{ ipa_context | default(omit) }}"
+      name: reddy
+      rename: reddy
+      state: renamed
+    register: result
+    failed_when: result.changed or result.failed
+
+  - name: Rename user reddy back to pinky
+    ipauser:
+      ipaadmin_password: SomeADMINpassword
+      ipaapi_context: "{{ ipa_context | default(omit) }}"
+      name: reddy
+      rename: pinky
+      state: renamed
+    register: result
+    failed_when: not result.changed or result.failed
 
   - name: User pinky absent and preserved for future exclusion.
     ipauser:

--- a/tests/user/test_users.yml
+++ b/tests/user/test_users.yml
@@ -8,6 +8,12 @@
   - name: Remove test users
     ipauser:
       ipaadmin_password: SomeADMINpassword
+      name: manager1,manager2,manager3,pinky,pinky2,mod1,mod2
+      state: absent
+
+  - name: Remove test users
+    ipauser:
+      ipaadmin_password: SomeADMINpassword
       name: user1,user2,user3,user4,user5,user6,user7,user8,user9,user10
       state: absent
 
@@ -48,7 +54,7 @@
     register: result
     failed_when: not result.changed or result.failed
 
-  - name: Users user1..10 present
+  - name: Users user1..10 present, again
     ipauser:
       ipaadmin_password: SomeADMINpassword
       users:
@@ -84,6 +90,42 @@
         last: Last
     register: result
     failed_when: result.changed or result.failed
+
+  - name: Rename users user1 and user2 to mod1 and mod1
+    ipauser:
+      ipaadmin_password: SomeADMINpassword
+      users:
+        - name: user1
+          rename: mod1
+        - name: user2
+          rename: mod2
+      state: renamed
+    register: result
+    failed_when: not result.changed or result.failed
+
+  - name: Rename users mod1 and mod2 to the same name
+    ipauser:
+      ipaadmin_password: SomeADMINpassword
+      users:
+        - name: mod1
+          rename: mod1
+        - name: mod2
+          rename: mod2
+      state: renamed
+    register: result
+    failed_when: result.changed or result.failed
+
+  - name: Rename users mod1 and mod2 back to user1 and user2
+    ipauser:
+      ipaadmin_password: SomeADMINpassword
+      users:
+        - name: mod1
+          rename: user1
+        - name: mod2
+          rename: user2
+      state: renamed
+    register: result
+    failed_when: not result.changed or result.failed
 
   # failed_when: not result.failed has been added as this test needs to
   # fail because two users with the same name should be added in the same


### PR DESCRIPTION
FreeIPA suports renaming user objects with the CLI parameter "rename", and this parameter was missing in ansible-freeipa ipauser module.

This patch adds support for a new state 'renamed' and the 'rename' parameter.

Tests were updated to cope with the changes.

Related to RHBZ#2234379, RHBZ#2234380

Fixes #1103