### PR TITLE
ipagroup: Add support for renaming groups

### DIFF
--- a/README-group.md
+++ b/README-group.md
@@ -130,6 +130,45 @@ And ensure the presence of the groups with this example playbook:
       groups: "{{ groups }}"
 ```
 
+Example playbook to rename a group:
+
+```yaml
+---
+- name: Playbook to rename a single group
+  hosts: ipaserver
+  become: false
+  gather_facts: false
+
+  tasks:
+  - name: Rename group appops to webops
+    ipagroup:
+      ipaadmin_password: SomeADMINpassword
+      name: appops
+      rename: webops
+      state: renamed
+```
+
+Several groups can also be renamed with a single task, as in the example playbook:
+
+```yaml
+---
+- name: Playbook to rename multiple groups
+  hosts: ipaserver
+  become: false
+  gather_facts: false
+
+  tasks:
+  - name Rename group1 to newgroup1 and group2 to newgroup2
+    ipagroup:
+      ipaadmin_password: SomeADMINpassword
+      groups:
+      - name: group1
+        rename: newgroup1
+      - name: group2
+        rename: newgroup2
+      state: renamed
+```
+
 Example playbook to add users to a group:
 
 ```yaml
@@ -262,11 +301,13 @@ Variable | Description | Required
 `membermanager_group` | List of member manager groups assigned to this group. Only usable with IPA versions 4.8.4 and up. | no
 `externalmember` \| `ipaexternalmember`  \| `external_member`| List of members of a trusted domain in DOM\\name or name@domain form. | no
 `idoverrideuser` | List of user ID overrides to manage. Only usable with IPA versions 4.8.7 and up.| no
+`rename` \| `new_name` | Rename the user object to the new name string. Only usable with `state: renamed`. | no
 `action` | Work on group or member level. It can be on of `member` or `group` and defaults to `group`. | no
-`state` | The state to ensure. It can be one of `present` or `absent`, default: `present`. | yes
+`state` | The state to ensure. It can be one of `present`, `absent` or `renamed`, default: `present`. | yes
 
 
 Authors
 =======
 
-Thomas Woerner
+- Thomas Woerner
+- Rafael Jeffman

--- a/tests/group/test_group.yml
+++ b/tests/group/test_group.yml
@@ -3,6 +3,13 @@
   hosts: "{{ ipa_test_host | default('ipaserver') }}"
   become: true
   gather_facts: true
+  module_defaults:
+    ipauser:
+      ipaadmin_password: SomeADMINpassword
+      ipaapi_context: "{{ ipa_context | default(omit) }}"
+    ipagroup:
+      ipaadmin_password: SomeADMINpassword
+      ipaapi_context: "{{ ipa_context | default(omit) }}"
 
   tasks:
   # setup
@@ -19,15 +26,11 @@
 
   - name: Ensure users user1, user2 and user3 are absent
     ipauser:
-      ipaadmin_password: SomeADMINpassword
-      ipaapi_context: "{{ ipa_context | default(omit) }}"
       name: user1,user2,user3
       state: absent
 
   - name: Ensure group group3, group2 and group1 are absent
     ipagroup:
-      ipaadmin_password: SomeADMINpassword
-      ipaapi_context: "{{ ipa_context | default(omit) }}"
       name: group3,group2,group1
       state: absent
 
@@ -35,8 +38,6 @@
 
   - name: Ensure users user1..user3 are present
     ipauser:
-      ipaadmin_password: SomeADMINpassword
-      ipaapi_context: "{{ ipa_context | default(omit) }}"
       users:
       - name: user1
         first: user1
@@ -54,56 +55,42 @@
 
   - name: Ensure group1 is present
     ipagroup:
-      ipaadmin_password: SomeADMINpassword
-      ipaapi_context: "{{ ipa_context | default(omit) }}"
       name: group1
     register: result
     failed_when: not result.changed or result.failed
 
   - name: Ensure group1 is present again
     ipagroup:
-      ipaadmin_password: SomeADMINpassword
-      ipaapi_context: "{{ ipa_context | default(omit) }}"
       name: group1
     register: result
     failed_when: result.changed or result.failed
 
   - name: Ensure group2 is present
     ipagroup:
-      ipaadmin_password: SomeADMINpassword
-      ipaapi_context: "{{ ipa_context | default(omit) }}"
       name: group2
     register: result
     failed_when: not result.changed or result.failed
 
   - name: Ensure group2 is present again
     ipagroup:
-      ipaadmin_password: SomeADMINpassword
-      ipaapi_context: "{{ ipa_context | default(omit) }}"
       name: group2
     register: result
     failed_when: result.changed or result.failed
 
   - name: Ensure group3 is present
     ipagroup:
-      ipaadmin_password: SomeADMINpassword
-      ipaapi_context: "{{ ipa_context | default(omit) }}"
       name: group3
     register: result
     failed_when: not result.changed or result.failed
 
   - name: Ensure group3 is present again
     ipagroup:
-      ipaadmin_password: SomeADMINpassword
-      ipaapi_context: "{{ ipa_context | default(omit) }}"
       name: group3
     register: result
     failed_when: result.changed or result.failed
 
   - name: Ensure groups group2 and group3 are present in group group1
     ipagroup:
-      ipaadmin_password: SomeADMINpassword
-      ipaapi_context: "{{ ipa_context | default(omit) }}"
       name: group1
       group:
       - group2
@@ -114,8 +101,6 @@
 
   - name: Ensure groups group2 and group3 are present in group group1 again
     ipagroup:
-      ipaadmin_password: SomeADMINpassword
-      ipaapi_context: "{{ ipa_context | default(omit) }}"
       name: group1
       group:
       - group2
@@ -126,8 +111,6 @@
 
   - name: Ensure group3 ia present in group group1
     ipagroup:
-      ipaadmin_password: SomeADMINpassword
-      ipaapi_context: "{{ ipa_context | default(omit) }}"
       name: group1
       group:
       - group3
@@ -143,8 +126,6 @@
 
     - name: Ensure service "{{ 'HTTP/' + fqdn_at_domain }}" is present in group group1
       ipagroup:
-        ipaadmin_password: SomeADMINpassword
-        ipaapi_context: "{{ ipa_context | default(omit) }}"
         name: group1
         service:
         - "{{ 'HTTP/' + fqdn_at_domain }}"
@@ -154,8 +135,6 @@
 
     - name: Ensure service "{{ 'HTTP/' + fqdn_at_domain }}" is present in group group1, again
       ipagroup:
-        ipaadmin_password: SomeADMINpassword
-        ipaapi_context: "{{ ipa_context | default(omit) }}"
         name: group1
         service:
         - "{{ 'HTTP/' + fqdn_at_domain }}"
@@ -165,8 +144,6 @@
 
     - name: Ensure service "{{ 'ldap/' + fqdn_at_domain }}" is present in group group1
       ipagroup:
-        ipaadmin_password: SomeADMINpassword
-        ipaapi_context: "{{ ipa_context | default(omit) }}"
         name: group1
         service:
         - "{{ 'ldap/' + fqdn_at_domain }}"
@@ -176,8 +153,6 @@
 
     - name: Ensure service "{{ 'ldap/' + fqdn_at_domain }}" is present in group group1, again
       ipagroup:
-        ipaadmin_password: SomeADMINpassword
-        ipaapi_context: "{{ ipa_context | default(omit) }}"
         name: group1
         service:
         - "{{ 'ldap/' + fqdn_at_domain }}"
@@ -187,8 +162,6 @@
 
     - name: Ensure service "{{ 'HTTP/' + fqdn_at_domain }}" is absent in group group1
       ipagroup:
-        ipaadmin_password: SomeADMINpassword
-        ipaapi_context: "{{ ipa_context | default(omit) }}"
         name: group1
         service:
         - "{{ 'HTTP/' + fqdn_at_domain }}"
@@ -199,8 +172,6 @@
 
     - name: Ensure service "{{ 'HTTP/' + fqdn_at_domain }}" is absent in group group1, again
       ipagroup:
-        ipaadmin_password: SomeADMINpassword
-        ipaapi_context: "{{ ipa_context | default(omit) }}"
         name: group1
         service:
         - "{{ 'HTTP/' + fqdn_at_domain }}"
@@ -211,8 +182,6 @@
 
     - name: Ensure service "{{ 'ldap/' + fqdn_at_domain }}" is absent in group group1
       ipagroup:
-        ipaadmin_password: SomeADMINpassword
-        ipaapi_context: "{{ ipa_context | default(omit) }}"
         name: group1
         service:
         - "{{ 'ldap/' + fqdn_at_domain }}"
@@ -223,8 +192,6 @@
 
     - name: Ensure service "{{ 'ldap/' + fqdn_at_domain }}" is absent in group group1, again
       ipagroup:
-        ipaadmin_password: SomeADMINpassword
-        ipaapi_context: "{{ ipa_context | default(omit) }}"
         name: group1
         service:
         - "{{ 'ldap/' + fqdn_at_domain }}"
@@ -235,8 +202,6 @@
 
     - name: Ensure services are present in group group1
       ipagroup:
-        ipaadmin_password: SomeADMINpassword
-        ipaapi_context: "{{ ipa_context | default(omit) }}"
         name: group1
         service:
         - "{{ 'HTTP/' + fqdn_at_domain }}"
@@ -247,8 +212,6 @@
 
     - name: Ensure services are present in group group1, again
       ipagroup:
-        ipaadmin_password: SomeADMINpassword
-        ipaapi_context: "{{ ipa_context | default(omit) }}"
         name: group1
         service:
         - "{{ 'http/' + fqdn_at_domain }}"
@@ -259,8 +222,6 @@
 
     - name: Ensure services are absent in group group1
       ipagroup:
-        ipaadmin_password: SomeADMINpassword
-        ipaapi_context: "{{ ipa_context | default(omit) }}"
         name: group1
         service:
         - "{{ 'HTTP/' + fqdn_at_domain }}"
@@ -272,8 +233,6 @@
 
     - name: Ensure services are absent in group group1, again
       ipagroup:
-        ipaadmin_password: SomeADMINpassword
-        ipaapi_context: "{{ ipa_context | default(omit) }}"
         name: group1
         service:
         - "{{ 'HTTP/' + fqdn_at_domain }}"
@@ -287,8 +246,6 @@
 
   - name: Ensure users user1, user2 and user3 are present in group group1
     ipagroup:
-      ipaadmin_password: SomeADMINpassword
-      ipaapi_context: "{{ ipa_context | default(omit) }}"
       name: group1
       user:
       - user1
@@ -300,8 +257,6 @@
 
   - name: Ensure users user1, user2 and user3 are present in group group1 again
     ipagroup:
-      ipaadmin_password: SomeADMINpassword
-      ipaapi_context: "{{ ipa_context | default(omit) }}"
       name: group1
       user:
       - user1
@@ -312,8 +267,6 @@
     failed_when: result.changed or result.failed
 
   #- ipagroup:
-  #    ipaadmin_password: SomeADMINpassword
-  #    ipaapi_context: "{{ ipa_context | default(omit) }}"
   #    name: group1
   #    user:
   #    - user7
@@ -321,8 +274,6 @@
 
   - name: Ensure user user7 is absent in group group1
     ipagroup:
-      ipaadmin_password: SomeADMINpassword
-      ipaapi_context: "{{ ipa_context | default(omit) }}"
       name: group1
       user:
       - user7
@@ -333,8 +284,6 @@
 
   - name: Ensure group group4 is absent
     ipagroup:
-      ipaadmin_password: SomeADMINpassword
-      ipaapi_context: "{{ ipa_context | default(omit) }}"
       name: group4
       state: absent
     register: result
@@ -342,8 +291,6 @@
 
   - name: Ensure groups group3, group2, and group1 are absent
     ipagroup:
-      ipaadmin_password: SomeADMINpassword
-      ipaapi_context: "{{ ipa_context | default(omit) }}"
       name: group3,group2,group1
       state: absent
     register: result
@@ -351,16 +298,12 @@
 
   - name: Ensure group group1 is present
     ipagroup:
-      ipaadmin_password: SomeADMINpassword
-      ipaapi_context: "{{ ipa_context | default(omit) }}"
       name: group1
     register: result
     failed_when: not result.changed or result.failed
 
   - name: Ensure users user1, user2 are present in group group1
     ipagroup:
-      ipaadmin_password: SomeADMINpassword
-      ipaapi_context: "{{ ipa_context | default(omit) }}"
       name: group1
       user:
       - user1
@@ -371,8 +314,6 @@
 
   - name: Ensure users user1, user2 and user3 are present in group group1
     ipagroup:
-      ipaadmin_password: SomeADMINpassword
-      ipaapi_context: "{{ ipa_context | default(omit) }}"
       name: group1
       user:
       - user1
@@ -384,8 +325,6 @@
 
   - name: Ensure users user1, user2 are present in group group1, again
     ipagroup:
-      ipaadmin_password: SomeADMINpassword
-      ipaapi_context: "{{ ipa_context | default(omit) }}"
       name: group1
       user:
       - user1
@@ -396,8 +335,6 @@
 
   - name: Ensure users user1, user2 and user3 are present in group group1, again
     ipagroup:
-      ipaadmin_password: SomeADMINpassword
-      ipaapi_context: "{{ ipa_context | default(omit) }}"
       name: group1
       user:
       - user1
@@ -409,8 +346,6 @@
 
   - name: Ensure group group1 is absent
     ipagroup:
-      ipaadmin_password: SomeADMINpassword
-      ipaapi_context: "{{ ipa_context | default(omit) }}"
       name: group1
       state: absent
     register: result
@@ -418,8 +353,6 @@
 
   - name: Ensure group group1 with users user1, user2 is present
     ipagroup:
-      ipaadmin_password: SomeADMINpassword
-      ipaapi_context: "{{ ipa_context | default(omit) }}"
       name: group1
       user:
       - user1
@@ -429,8 +362,6 @@
 
   - name: Ensure group group1 with users user1, user2 and user3 is present
     ipagroup:
-      ipaadmin_password: SomeADMINpassword
-      ipaapi_context: "{{ ipa_context | default(omit) }}"
       name: group1
       user:
       - user1
@@ -441,8 +372,6 @@
 
   - name: Ensure group group1 with users user1, user2 and user3 is present, again
     ipagroup:
-      ipaadmin_password: SomeADMINpassword
-      ipaapi_context: "{{ ipa_context | default(omit) }}"
       name: group1
       user:
       - user1
@@ -454,8 +383,6 @@
 
   - name: Ensure only users user1, user2 are present in group group1
     ipagroup:
-      ipaadmin_password: SomeADMINpassword
-      ipaapi_context: "{{ ipa_context | default(omit) }}"
       name: group1
       user:
       - user1
@@ -467,8 +394,6 @@
 
   - name: Ensure group group3, group2 and group1 are absent
     ipagroup:
-      ipaadmin_password: SomeADMINpassword
-      ipaapi_context: "{{ ipa_context | default(omit) }}"
       name: group3,group2,group1
       state: absent
     register: result
@@ -476,8 +401,6 @@
 
   - name: Ensure users user1, user2 and user3 are absent
     ipauser:
-      ipaadmin_password: SomeADMINpassword
-      ipaapi_context: "{{ ipa_context | default(omit) }}"
       name: user1,user2,user3
       state: absent
     register: result

--- a/tests/group/test_group.yml
+++ b/tests/group/test_group.yml
@@ -31,7 +31,7 @@
 
   - name: Ensure group group3, group2 and group1 are absent
     ipagroup:
-      name: group3,group2,group1
+      name: groupren,group3,group2,group1
       state: absent
 
   # CREATE TEST ITEMS
@@ -64,6 +64,38 @@
       name: group1
     register: result
     failed_when: result.changed or result.failed
+
+  - name: Rename group1 to groupren
+    ipagroup:
+      name: group1
+      rename: groupren
+      state: renamed
+    register: result
+    failed_when: not result.changed or result.failed
+
+  - name: Rename group1 to groupren
+    ipagroup:
+      name: group1
+      rename: groupren
+      state: renamed
+    register: result
+    failed_when: not result.failed or "No group 'group1'" not in result.msg
+
+  - name: Rename group groupren to groupren
+    ipagroup:
+      name: groupren
+      rename: groupren
+      state: renamed
+    register: result
+    failed_when: result.changed or result.failed
+
+  - name: Rename group groupren back to group1
+    ipagroup:
+      name: groupren
+      rename: group1
+      state: renamed
+    register: result
+    failed_when: not result.changed or result.failed
 
   - name: Ensure group2 is present
     ipagroup:

--- a/tests/group/test_groups.yml
+++ b/tests/group/test_groups.yml
@@ -19,7 +19,7 @@
   - name: Remove test groups
     ipagroup:
       ipaadmin_password: SomeADMINpassword
-      name: group1,group2,group3,group4,group5,group6,group7,group8,group9,group10
+      name: group1,group2,group3,group4,group5,group6,group7,group8,group9,group10,newgroup1,newgroup2
       state: absent
 
   - name: Remove test users
@@ -130,10 +130,53 @@
     register: result
     failed_when: result.changed or not result.failed or "Only one group can be added at a time using 'name'." not in result.msg
 
+  - name: Ensure group1 and group2 exist
+    ipagroup:
+      ipaadmin_password: SomeADMINpassword
+      groups:
+        - name: group1
+        - name: group2
+
+  - name: Rename group1 and group2 to newgroup1 and newgroup2, respectively
+    ipagroup:
+      ipaadmin_password: SomeADMINpassword
+      groups:
+        - name: group1
+          rename: newgroup1
+        - name: group2
+          rename: newgroup2
+      state: renamed
+    register: result
+    failed_when: not result.changed or result.failed
+
+  - name: Rename newgroup1 and newgroup2 to the same name
+    ipagroup:
+      ipaadmin_password: SomeADMINpassword
+      groups:
+        - name: newgroup1
+          rename: newgroup1
+        - name: newgroup2
+          rename: newgroup2
+      state: renamed
+    register: result
+    failed_when: result.changed or result.failed
+
+  - name: Rename newgroup1 and newgroup2 back to group1 and group2, respectively
+    ipagroup:
+      ipaadmin_password: SomeADMINpassword
+      groups:
+        - name: newgroup1
+          rename: group1
+        - name: newgroup2
+          rename: group2
+      state: renamed
+    register: result
+    failed_when: not result.changed or result.failed
+
   - name: Remove test groups
     ipagroup:
       ipaadmin_password: SomeADMINpassword
-      name: group1,group2,group3,group4,group5,group6,group7,group8,group9,group10
+      name: group1,group2,group3,group4,group5,group6,group7,group8,group9,group10,newgroup1,newgroup2
       state: absent
 
   - name: Remove test users


### PR DESCRIPTION
FreeIPA suports renaming groupobjects with the CLI parameter "rename",
and this parameter was missing in ansible-freeipa ipagroup module.

This patch adds support for a new state 'renamed' and the 'rename'
parameter.
    
Tests were updated to cope with the changes.

Fixes #1103