### PR TITLE
test_pwpolicy: minlength parameter can be reset with empty string now

### DIFF
--- a/tests/pwpolicy/test_pwpolicy.yml
+++ b/tests/pwpolicy/test_pwpolicy.yml
@@ -176,21 +176,10 @@
       minlength: ""
     register: result
     failed_when:
-        result.changed or
         (result.failed and not
-            ("an internal error has occurred" in result.msg or
-             "int() argument must be" in result.msg))
-    when: ipa_version is version("4.9", ">=")
-
-  - name: Ensure minlength is not cleared due to FreeIPA issue
-    ipapwpolicy:
-      ipaadmin_password: SomeADMINpassword
-      ipaapi_context: "{{ ipa_context | default(omit) }}"
-      name: ops
-      minlength: ""
-    register: result
-    failed_when: not result.changed or result.failed
-    when: ipa_version is version("4.7", "<")
+         ("an internal error has occurred" in result.msg or
+          "int() argument must be" in result.msg))
+        or (not result.failed and not result.changed)
 
   - name: Execute tests if ipa_version >= 4.9.0
     when: ipa_version is version("4.9", ">=")


### PR DESCRIPTION
The reset of the minlength parameter failed with an internal error so far. This has been fixed in IPA and therefore requires to fix the test in ansible-freeipa also.

Related: https://pagure.io/freeipa/issue/9297