### PR TITLE
upstream ci: Increase timeout for PR tests

### DIFF
--- a/tests/azure/templates/playbook_fast.yml
+++ b/tests/azure/templates/playbook_fast.yml
@@ -21,7 +21,7 @@ parameters:
 jobs:
 - job: Test_Group${{ parameters.group_number }}
   displayName: Run playbook tests ${{ parameters.scenario }} (${{ parameters.group_number }}/${{ parameters.number_of_groups }})
-  timeoutInMinutes: 240
+  timeoutInMinutes: 360
   variables:
   - template: variables.yaml
   - template: variables_${{ parameters.scenario }}.yaml


### PR DESCRIPTION
After the change for a single job to run PR tests, and if there is any
change to ansible_module_utils, all the playbook tests are executed,
and the result is a failure due to timeout.

This PR increases the timeout so that a PR with changes to
ansible_module_utils can have the tests executed.