### PR TITLE
Bump minimum ansible-lint version to 6.22

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,7 +16,7 @@ jobs:
           python-version: "3.x"
       - name: Run ansible-lint
         run: |
-          pip install "ansible-core>=2.16,<2.17" 'ansible-lint>=6.21'
+          pip install "ansible-core>=2.16,<2.17" 'ansible-lint>=6.22'
           utils/build-galaxy-release.sh -ki
           cd .galaxy-build
           ansible-lint --profile production --exclude tests/integration/ --exclude tests/unit/ --parseable --nocolor

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,4 +7,4 @@ pylint==2.17.2
 wrapt==1.14.1
 pydocstyle==6.3.0
 yamllint==1.32.0
-ansible-lint
+ansible-lint >= 6.22


### PR DESCRIPTION
By the first quarter of 2024, all collections must pass ansible-lint tests run with version 6.22.x. This PR ensure that all ansible-freeipa tests depending on ansible-lint use a valid version of it.