### PR TITLE
GitHub workflows: Use ansible-lint GitHub Action.

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,18 +8,11 @@ jobs:
     name: Verify ansible-lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3.1.0
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: actions/setup-python@v4.3.0
-        with:
-          python-version: "3.x"
       - name: Run ansible-lint
-        run: |
-          pip install "ansible-core>=2.16,<2.17" 'ansible-lint>=6.22'
-          utils/build-galaxy-release.sh -ki
-          cd .galaxy-build
-          ansible-lint --profile production --exclude tests/integration/ --exclude tests/unit/ --parseable --nocolor
+        uses: ansible/ansible-lint@v6.22.1 # or version tag instead of 'main'
 
   yamllint:
     name: Verify yamllint


### PR DESCRIPTION
This patch removes the need to install ansible-lint using pip and make use of the Ansible maintained ansible-lint GitHub Action.