### PR TITLE
Fixes for ansible-lint 6.22.1

### DIFF
--- a/playbooks/cert/cert-hold.yml
+++ b/playbooks/cert/cert-hold.yml
@@ -1,3 +1,4 @@
+---
 - name: Certificate manage example
   hosts: ipaserver
   become: false

--- a/tests/config/test_config_sid.yml
+++ b/tests/config/test_config_sid.yml
@@ -30,7 +30,7 @@
       check_mode: yes
       register: sid_disabled
 
-    - name: Ensure netbios_name can't be changed without SID enabled.  # noqa 503
+    - name: Ensure netbios_name can't be changed without SID enabled.  # noqa no-handler
       ipaconfig:
         ipaadmin_password: SomeADMINpassword
         ipaapi_context: "{{ ipa_context | default(omit) }}"
@@ -39,7 +39,7 @@
       failed_when: not result.failed and "SID generation must be enabled" in result.msg
       when: sid_disabled.changed
 
-    - name: Ensure SIDs can't be changed without SID enabled.  # noqa 503
+    - name: Ensure SIDs can't be changed without SID enabled.  # noqa no-handler
       ipaconfig:
         ipaadmin_password: SomeADMINpassword
         ipaapi_context: "{{ ipa_context | default(omit) }}"

--- a/tests/dnsrecord/test_dnsrecord.yml
+++ b/tests/dnsrecord/test_dnsrecord.yml
@@ -1549,7 +1549,7 @@
   - name: Cleanup test environment.
     ansible.builtin.include_tasks: env_cleanup.yml
 
-  - name: Remove certificate files.  # noqa: deprecated-command-syntax
+  - name: Remove certificate files.
     ansible.builtin.shell: rm -f "private{{ item }}.key" "cert{{ item }}.pem" "cert{{ item }}.der" "cert{{ item }}.b64"
     with_items: [1]
     become: no

--- a/tests/group/test_group.yml
+++ b/tests/group/test_group.yml
@@ -283,7 +283,7 @@
       register: result
       failed_when: result.changed or result.failed
 
-    # user
+  # user
 
   - name: Ensure users user1, user2 and user3 are present in group group1
     ipagroup:

--- a/tests/group/test_groups_absent.yml
+++ b/tests/group/test_groups_absent.yml
@@ -9,7 +9,7 @@
   tasks:
   - name: Include groups.json
     ansible.builtin.include_vars:
-      file: groups.json  # noqa 505
+      file: groups.json
 
   - name: Initialize groups_names
     ansible.builtin.set_fact:

--- a/tests/group/test_groups_present.yml
+++ b/tests/group/test_groups_present.yml
@@ -9,7 +9,7 @@
   tasks:
   - name: Include groups.json
     ansible.builtin.include_vars:
-      file: groups.json  # noqa 505
+      file: groups.json
 
   - name: Groups present len:{{ group_list | length }}
     ipagroup:

--- a/tests/group/test_groups_present_slice.yml
+++ b/tests/group/test_groups_present_slice.yml
@@ -11,7 +11,7 @@
   tasks:
   - name: Include groups.json
     ansible.builtin.include_vars:
-      file: groups.json  # noqa 505
+      file: groups.json
 
   - name: Size of groups slice.
     ansible.builtin.debug:

--- a/tests/host/certificate/test_host_certificate.yml
+++ b/tests/host/certificate/test_host_certificate.yml
@@ -99,7 +99,7 @@
     register: result
     failed_when: result.changed or result.failed
 
-  - name: Remove certificate files.  # noqa: deprecated-command-syntax
+  - name: Remove certificate files.
     ansible.builtin.shell:
       cmd: rm -f "private{{ item }}.key" "cert{{ item }}.pem" "cert{{ item }}.der" "cert{{ item }}.b64"
     with_items: [1, 2, 3]

--- a/tests/host/certificate/test_hosts_certificate.yml
+++ b/tests/host/certificate/test_hosts_certificate.yml
@@ -98,7 +98,7 @@
     register: result
     failed_when: not result.changed or result.failed
 
-  - name: Remove certificate files.  # noqa: deprecated-command-syntax
+  - name: Remove certificate files.
     ansible.builtin.shell:
       cmd: rm -f "private{{ item }}.key" "cert{{ item }}.pem" "cert{{ item }}.der" "cert{{ item }}.b64"
     with_items: [1, 2, 3]

--- a/tests/idoverrideuser/test_idoverrideuser.yml
+++ b/tests/idoverrideuser/test_idoverrideuser.yml
@@ -558,7 +558,7 @@
       name: test_idview
       state: absent
 
-  - name: Remove certificate files.  # noqa: deprecated-command-syntax
+  - name: Remove certificate files.
     ansible.builtin.shell:
       cmd: rm -f "private{{ item }}.key" "cert{{ item }}.pem" "cert{{ item }}.der" "cert{{ item }}.b64"
     with_items: [1, 2, 3]

--- a/tests/service/certificate/test_service_certificate.yml
+++ b/tests/service/certificate/test_service_certificate.yml
@@ -214,7 +214,7 @@
       update_dns: yes
       state: absent
 
-  - name: Remove certificate files.  # noqa: deprecated-command-syntax
+  - name: Remove certificate files.
     ansible.builtin.shell:
       cmd: rm -f "private{{ item }}.key" "cert{{ item }}.pem" "cert{{ item }}.der" "cert{{ item }}.b64"
     with_items: [1, 2]

--- a/tests/service/certificate/test_service_certificate_newline.yml
+++ b/tests/service/certificate/test_service_certificate_newline.yml
@@ -192,7 +192,7 @@
     register: result
     failed_when: not result.changed or result.failed
 
-  - name: Remove certificate files.  # noqa: deprecated-command-syntax
+  - name: Remove certificate files.
     ansible.builtin.shell:
       cmd: rm -f "private{{ item }}.key" "cert{{ item }}.pem" "cert{{ item }}.der" "cert{{ item }}.b64"
     with_items: [1, 2, 3]

--- a/tests/service/certificate/test_services_certificate_newline.yml
+++ b/tests/service/certificate/test_services_certificate_newline.yml
@@ -306,7 +306,7 @@
     register: result
     failed_when: not result.changed or result.failed
 
-  - name: Remove certificate files.  # noqa: deprecated-command-syntax
+  - name: Remove certificate files.
     ansible.builtin.shell:
       cmd: rm -f "private{{ item }}.key" "cert{{ item }}.pem" "cert{{ item }}.der" "cert{{ item }}.b64"
     with_items: [11, 12, 13, 21, 22, 23, 31, 32, 33]

--- a/tests/service/test_service_disable.yml
+++ b/tests/service/test_service_disable.yml
@@ -100,7 +100,7 @@
   - name: Destroy Kerberos tickets.
     ansible.builtin.shell: kdestroy -A -q -c ${KRB5CCNAME}
 
-  - name: Remove certificate files.  # noqa: deprecated-command-syntax
+  - name: Remove certificate files.
     ansible.builtin.shell:
       cmd: rm -f "private{{ item }}.key" "cert{{ item }}.pem" "cert{{ item }}.der" "cert{{ item }}.b64"
     with_items: [1]

--- a/tests/user/certificate/test_user_certificate.yml
+++ b/tests/user/certificate/test_user_certificate.yml
@@ -80,7 +80,7 @@
     register: result
     failed_when: not result.changed or result.failed
 
-  - name: Remove certificate files.  # noqa: deprecated-command-syntax
+  - name: Remove certificate files.
     ansible.builtin.shell:
       cmd: rm -f "private{{ item }}.key" "cert{{ item }}.pem" "cert{{ item }}.der" "cert{{ item }}.b64"
     with_items: [1, 2, 3]

--- a/tests/user/certificate/test_users_certificate.yml
+++ b/tests/user/certificate/test_users_certificate.yml
@@ -93,7 +93,7 @@
     register: result
     failed_when: not result.changed or result.failed
 
-  - name: Remove certificate files.  # noqa: deprecated-command-syntax
+  - name: Remove certificate files.
     ansible.builtin.shell:
       cmd: rm -f "private{{ item }}.key" "cert{{ item }}.pem" "cert{{ item }}.der" "cert{{ item }}.b64"
     with_items: [1, 2, 3]

--- a/tests/user/certmapdata/test_user_certmapdata.yml
+++ b/tests/user/certmapdata/test_user_certmapdata.yml
@@ -225,7 +225,7 @@
     register: result
     failed_when: not result.changed or result.failed
 
-  - name: Remove certificate files.   # noqa: deprecated-command-syntax
+  - name: Remove certificate files.
     ansible.builtin.shell:
       cmd: rm -f "private{{ item }}.key" "cert{{ item }}.pem" "cert{{ item }}.der" "cert{{ item }}.b64"
     with_items: [1, 2, 3]

--- a/tests/user/certmapdata/test_users_certmapdata.yml
+++ b/tests/user/certmapdata/test_users_certmapdata.yml
@@ -161,7 +161,7 @@
     register: result
     failed_when: not result.changed or result.failed
 
-  - name: Remove certificate files.  # noqa: deprecated-command-syntax
+  - name: Remove certificate files.
     ansible.builtin.shell:
       cmd: rm -f "private{{ item }}.key" "cert{{ item }}.pem" "cert{{ item }}.der" "cert{{ item }}.b64"
     with_items: [1, 2, 3]

--- a/tests/user/test_users_invalid_cert.yml
+++ b/tests/user/test_users_invalid_cert.yml
@@ -54,7 +54,7 @@
     register: result
     failed_when: not result.changed or result.failed
 
-  - name: Remove certificate files.  # noqa: deprecated-command-syntax
+  - name: Remove certificate files.
     ansible.builtin.shell:
       cmd: rm -f "private{{ item }}.key" "cert{{ item }}.pem" "cert{{ item }}.der" "cert{{ item }}.b64"
     with_items: [1, 2]


### PR DESCRIPTION
- Replace outdated noqa 503 with noqa no-handler
- Drop outdated and not needed noqa 505 for include_vars
- Drop outdated noqa deprecated-command-syntax for ansible.builtin.shell using cmd tag

These warnings have been reported by utils/lint_check.sh using ansible-lint 6.22.1.