### PR TITLE
depolyment roles: Allow deployment without gather_facts

### DIFF
--- a/roles/ipaclient/tasks/main.yml
+++ b/roles/ipaclient/tasks/main.yml
@@ -1,6 +1,15 @@
 ---
 # tasks file for ipaclient
 
+- name: Ensure distribution facts are available
+  ansible.builtin.setup:
+    gather_subset:
+      - dns
+      - distribution
+      - distribution_version
+      - distribution_major_version
+      - os_family
+
 - name: Import variables specific to distribution
   ansible.builtin.include_vars: "{{ item }}"
   with_first_found:

--- a/roles/ipareplica/tasks/main.yml
+++ b/roles/ipareplica/tasks/main.yml
@@ -1,6 +1,15 @@
 ---
 # tasks file for ipareplica
 
+- name: Ensure distribution facts are available
+  ansible.builtin.setup:
+    gather_subset:
+      - dns
+      - distribution
+      - distribution_version
+      - distribution_major_version
+      - os_family
+
 - name: Import variables specific to distribution
   ansible.builtin.include_vars: "{{ item }}"
   with_first_found:

--- a/roles/ipaserver/tasks/main.yml
+++ b/roles/ipaserver/tasks/main.yml
@@ -1,6 +1,15 @@
 ---
 # tasks file for ipaserver
 
+- name: Ensure distribution facts are available
+  ansible.builtin.setup:
+    gather_subset:
+      - dns
+      - distribution
+      - distribution_version
+      - distribution_major_version
+      - os_family
+
 - name: Import variables specific to distribution
   ansible.builtin.include_vars: "{{ item }}"
   with_first_found:


### PR DESCRIPTION
When using the deployment roles, some facts about the target node distribution are required, but using 'gather_facts: true' takes a long time as it probes for a lot of facts which are not used by the deployment roles.

By restricting the facts loaded to the ones that are used, there's a reduction in the deployment tasks, as there's less data to be probed before the role is executed.