### PR TITLE
ipaserver: Fix deployment after Bronze-bit fix

### DIFF
--- a/roles/ipaserver/library/ipaserver_set_ds_password.py
+++ b/roles/ipaserver/library/ipaserver_set_ds_password.py
@@ -131,7 +131,8 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.ansible_ipa_server import (
     check_imports,
     MAX_DOMAIN_LEVEL, AnsibleModuleLog, options, sysrestore, paths,
-    api_Backend_ldap2, ds_init_info, redirect_stdout, setup_logging
+    api_Backend_ldap2, ds_init_info, redirect_stdout, setup_logging,
+    krbinstance, service
 )
 
 
@@ -220,6 +221,16 @@ def main():
 
     with redirect_stdout(ansible_log):
         ds.change_admin_password(options.admin_password)
+
+    # Force KDC to refresh the cached value of ipaKrbAuthzData by restarting.
+    # ipaKrbAuthzData has to be set with "MS-PAC" to trigger PAC generation,
+    # which is required to handle S4U2Proxy with the Bronze-Bit fix.
+    # Not doing so would cause API malfunction for around a minute, which is
+    # long enough to cause the hereafter client installation to fail.
+    krb = krbinstance.KrbInstance(fstore)
+    krb.set_output(ansible_log)
+    service.print_msg("Restarting the KDC")
+    krb.restart()
 
     # done ##########################################################
 


### PR DESCRIPTION
As FreeIPA now requires MS-PAC to be set in ipaKrbAuthzData to trigger PAC generation, there's a timing issue that causes API malfunction which is long enough to cause the client part insallation to fail.

By restarting KDC after DS password is set, we force cached values to be refreshed, allowing the API to work correctly.

Fixes #1200