### PR TITLE
ipaclient: Enable SELinux for SSSD

### DIFF
--- a/roles/ipaclient/library/ipaclient_test.py
+++ b/roles/ipaclient/library/ipaclient_test.py
@@ -226,6 +226,10 @@ nosssd_files:
   returned: always
   type: list
   elements: str
+selinux_works:
+  description: True if the selinux status check passed.
+  returned: always
+  type: bool
 '''
 
 import os
@@ -495,6 +499,8 @@ def main():
     #     not installer.no_krb5_offline_passwords
     installer.sssd = not installer.no_sssd
 
+    selinux_works = False
+
     try:
 
         # client
@@ -529,7 +535,7 @@ def main():
                 "You must be root to run ipa-client-install.",
                 rval=CLIENT_INSTALL_ERROR)
 
-        tasks.check_selinux_status()
+        selinux_works = tasks.check_selinux_status()
 
         # if is_ipa_client_installed(fstore, on_master=options.on_master):
         #     logger.error("IPA client is already configured on this system.")
@@ -971,7 +977,8 @@ def main():
                      ntp_pool=options.ntp_pool,
                      client_already_configured=client_already_configured,
                      ipa_python_version=IPA_PYTHON_VERSION,
-                     nosssd_files=nosssd_files)
+                     nosssd_files=nosssd_files,
+                     selinux_works=selinux_works)
 
 
 if __name__ == '__main__':

--- a/roles/ipaclient/module_utils/ansible_ipa_client.py
+++ b/roles/ipaclient/module_utils/ansible_ipa_client.py
@@ -46,7 +46,8 @@ __all__ = ["gssapi", "version", "ipadiscovery", "api", "errors", "x509",
            "configure_nslcd_conf", "configure_ssh_config",
            "configure_sshd_config", "configure_automount",
            "configure_firefox", "sync_time", "check_ldap_conf",
-           "sssd_enable_ifp", "getargspec", "paths", "options",
+           "sssd_enable_ifp", "configure_selinux_for_client",
+           "getargspec", "paths", "options",
            "IPA_PYTHON_VERSION", "NUM_VERSION", "certdb", "get_ca_cert",
            "ipalib", "logger", "ipautil", "installer"]
 
@@ -301,6 +302,11 @@ try:
             from ipaclient.install.client import sssd_enable_ifp
         except ImportError:
             sssd_enable_ifp = None
+
+        try:
+            from ipaclient.install.client import configure_selinux_for_client
+        except ImportError:
+            configure_selinux_for_client = None
 
         logger = logging.getLogger("ipa-client-install")
         root_logger = logger

--- a/roles/ipaclient/tasks/install.yml
+++ b/roles/ipaclient/tasks/install.yml
@@ -384,6 +384,7 @@
               | default(ipasssd_no_krb5_offline_passwords) }}"
         no_dns_sshfp: "{{ ipaclient_no_dns_sshfp }}"
         nosssd_files: "{{ result_ipaclient_test.nosssd_files }}"
+        selinux_works: "{{ result_ipaclient_test.selinux_works }}"
         krb_name: "{{ result_ipaclient_temp_krb5.krb_name }}"
 
     - name: Install - Configure SSH and SSHD


### PR DESCRIPTION
This is "ipa-client-install: enable SELinux for SSSD" https://github.com/freeipa/freeipa/pull/6978 for ansible-freeipa:

For passkeys (FIDO2) support, SSSD uses libfido2 library which needs access to USB devices. Add SELinux booleans handling to ipa-client-install so that correct SELinux booleans can be enabled and disabled during install and uninstall. Ignore and record a warning when SELinux policy does not support the boolean.

Fixes: https://pagure.io/freeipa/issue/9434