### PR TITLE
ipaserver: Use ansible_host instead of group name

### DIFF
--- a/roles/ipaclient/tasks/install.yml
+++ b/roles/ipaclient/tasks/install.yml
@@ -9,12 +9,12 @@
 
 - name: Install - Set ipaclient_servers
   ansible.builtin.set_fact:
-    ipaclient_servers: "{{ groups['ipaservers'] | list }}"
+    ipaclient_servers: "{{ groups['ipaservers'] | map('extract', hostvars) | map(attribute='ansible_host') }}"
   when: groups.ipaservers is defined and ipaclient_servers is not defined
 
 - name: Install - Set ipaclient_servers from cluster inventory
   ansible.builtin.set_fact:
-    ipaclient_servers: "{{ groups['ipaserver'] | list }}"
+    ipaclient_servers: "{{ groups['ipaserver'] | map('extract', hostvars) | map(attribute='ansible_host') }}"
   when: ipaclient_no_dns_lookup | bool and groups.ipaserver is defined and
         ipaclient_servers is not defined
 

--- a/roles/ipareplica/tasks/install.yml
+++ b/roles/ipareplica/tasks/install.yml
@@ -54,12 +54,12 @@
 
 - name: Install - Set ipareplica_servers
   ansible.builtin.set_fact:
-    ipareplica_servers: "{{ groups['ipaservers'] | list }}"
+    ipareplica_servers: "{{ groups['ipaservers'] | map('extract', hostvars) | map(attribute='ansible_host') }}"
   when: groups.ipaservers is defined and ipareplica_servers is not defined
 
 - name: Install - Set ipareplica_servers from cluster inventory
   ansible.builtin.set_fact:
-    ipareplica_servers: "{{ groups['ipaserver'] | list }}"
+    ipareplica_servers: "{{ groups['ipaserver'] | map('extract', hostvars) | map(attribute='ansible_host') }}"
   when: ipareplica_servers is not defined and groups.ipaserver is defined
 
 - name: Install - Set default principal if no keytab is given


### PR DESCRIPTION
Deployment of any node fails when hosts defined in groups do not represent the hostname, for example, when using `ansible_host`.

For example, the following inventory YAML file would fail deployment:

```yaml
---
all:
  children:
    ipaserver:
      hosts:
        ipa_server:
          ansible_host: "{{ ipaserver_hostname }}"
          ansible_user: root
      vars:
        ipaserver_setup_ca: true
        ipaserver_setup_dns: true
        ipaserver_no_forwarders: true
        ipaserver_auto_reverse: true
        ipaserver_allow_zone_overlap: true
        ipaserver_setup_adtrust: true
        ipaserver_netbios_name: IPA 
        ipaserver_random_serial_numbers: true
        ipaserver_no_hbac_allow: false
  vars:
    ipaserver_hostname: server.lin.ipa.test
```

By maping the inventory name to the actual `ansible_host` the inventory file can act as a template, and the node names can use `ansible_host` to set the actual host.

See the individual commits for specific changes. 