### PR TITLE
Disable config tests for pac type without ms pac

### DIFF
--- a/tests/azure/templates/variables.yaml
+++ b/tests/azure/templates/variables.yaml
@@ -15,8 +15,9 @@
 #
 ---
 variables:
-  empty: true
+  # empty: true
   # ipa_enabled_modules: >-
   # ipa_enabled_tests: >-
-  # ipa_disabled_modules: >-
+  ipa_disabled_modules: >-
+    config
   # ipa_disabled_tests: >-


### PR DESCRIPTION
**[TEMP] Temporarily modify ipaconfig to verify test deactivation**

**config:` Disable config tests due to pac type requirement MS-PAC**
    
    The config tests are currently setting the pac type to empty or without
    MS-PAC type. This results in failed authorization for IPA API.
    
    An issue has been opened for FreeIPA to address this:
    https://pagure.io/freeipa/issue/9527
