### PR TITLE
Set Python Intepreter

### DIFF
--- a/tests/azure/azure-pipelines.yml
+++ b/tests/azure/azure-pipelines.yml
@@ -72,6 +72,7 @@ stages:
       build_number: $(Build.BuildNumber)
       scenario: c8s
       ansible_version: "-core >=2.14,<2.15"
+      python_interpreter: "/usr/libexec/platform-python"
 
 # CentOS 7
 

--- a/tests/azure/nightly.yml
+++ b/tests/azure/nightly.yml
@@ -176,6 +176,7 @@ stages:
       build_number: $(Build.BuildNumber)
       scenario: c8s
       ansible_version: "-core >=2.13,<2.14"
+      python_interpreter: "/usr/libexec/platform-python"
 
 - stage: c8s_Ansible_Core_2_14
   dependsOn: []
@@ -185,6 +186,7 @@ stages:
       build_number: $(Build.BuildNumber)
       scenario: c8s
       ansible_version: "-core >=2.14,<2.15"
+      python_interpreter: "/usr/libexec/platform-python"
 
 - stage: c8s_Ansible_Core_2_15
   dependsOn: []
@@ -194,6 +196,7 @@ stages:
       build_number: $(Build.BuildNumber)
       scenario: c8s
       ansible_version: "-core >=2.15,<2.16"
+      python_interpreter: "/usr/libexec/platform-python"
 
 - stage: c8s_Ansible_latest
   dependsOn: []
@@ -203,6 +206,7 @@ stages:
       build_number: $(Build.BuildNumber)
       scenario: c8s
       ansible_version: ""
+      python_interpreter: "/usr/libexec/platform-python"
 
 # CentOS 7
 

--- a/tests/azure/pr-pipeline.yml
+++ b/tests/azure/pr-pipeline.yml
@@ -50,6 +50,7 @@ stages:
       build_number: $(Build.BuildNumber)
       scenario: c8s
       ansible_version: "-core >=2.14,<2.15"
+      python_interpreter: "/usr/libexec/platform-python"
 
 # CentOS 7
 

--- a/tests/azure/templates/group_tests.yml
+++ b/tests/azure/templates/group_tests.yml
@@ -8,6 +8,9 @@ parameters:
   - name: ansible_version
     type: string
     default: ""
+  - name: python_interpreter
+    type: string
+    default: ""
 
 jobs:
 - template: playbook_tests.yml
@@ -18,6 +21,7 @@ jobs:
     scenario: ${{ parameters.scenario }}
     ansible_version: ${{ parameters.ansible_version }}
     python_version: '< 3.12'
+    python_interpreter: ${{ parameters.python_interpreter }}
 
 - template: playbook_tests.yml
   parameters:
@@ -27,6 +31,7 @@ jobs:
     scenario: ${{ parameters.scenario }}
     ansible_version: ${{ parameters.ansible_version }}
     python_version: '< 3.12'
+    python_interpreter: ${{ parameters.python_interpreter }}
 
 - template: playbook_tests.yml
   parameters:
@@ -36,6 +41,7 @@ jobs:
     scenario: ${{ parameters.scenario }}
     ansible_version: ${{ parameters.ansible_version }}
     python_version: '< 3.12'
+    python_interpreter: ${{ parameters.python_interpreter }}
 
 # Temporarily disabled due to ansible docker plugin issue.
 #- template: pytest_tests.yml

--- a/tests/azure/templates/playbook_fast.yml
+++ b/tests/azure/templates/playbook_fast.yml
@@ -17,6 +17,9 @@ parameters:
     default: 3.x
   - name: build_number
     type: string
+  - name: python_interpreter
+    type: string
+    default: ""
 
 jobs:
 - job: Test_Group${{ parameters.group_number }}
@@ -84,6 +87,7 @@ jobs:
       IPA_DISABLED_MODULES: ${{ variables.ipa_disabled_modules }}
       IPA_DISABLED_TESTS: ${{ variables.ipa_disabled_tests }}
       IPA_VERBOSITY: "-vvv"
+      PYTHON_INTERPRETER: ${{ parameters.python_interpreter }}
 
   - task: PublishTestResults@2
     inputs:

--- a/tests/azure/templates/playbook_tests.yml
+++ b/tests/azure/templates/playbook_tests.yml
@@ -17,6 +17,9 @@ parameters:
     default: 3.x
   - name: build_number
     type: string
+  - name: python_interpreter
+    type: string
+    default: ""
 
 jobs:
 - job: Test_Group${{ parameters.group_number }}
@@ -80,6 +83,7 @@ jobs:
       IPA_ENABLED_MODULES: ${{ variables.ipa_enabled_modules }}
       IPA_ENABLED_TESTS: ${{ variables.ipa_enabled_tests }}
       IPA_VERBOSITY: "-vvv"
+      PYTHON_INTERPRETER: ${{ parameters.python_interpreter }}
 
   - task: PublishTestResults@2
     inputs:

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -39,6 +39,10 @@ def get_docker_env():
     return docker_env
 
 
+def get_python_interpreter():
+    return os.getenv("PYTHON_INTERPRETER", None)
+
+
 def get_ssh_password():
     return os.getenv("IPA_SSH_PASSWORD")
 
@@ -92,6 +96,9 @@ def get_inventory_content():
     container_engine = get_docker_env()
     if container_engine is not None:
         ipa_server_host += f" ansible_connection={container_engine}"
+    python_interpreter = get_python_interpreter()
+    if python_interpreter is not None:
+        ipa_server_host += f" ansible_python_interpreter={python_interpreter}"
 
     sshpass = get_ssh_password()
     if sshpass:

--- a/utils/run-tests.sh
+++ b/utils/run-tests.sh
@@ -121,9 +121,10 @@ make_inventory() {
     local scenario=$1 engine=${2:-podman}
     inventory="${test_env}/inventory"
     log info "Inventory file: ${inventory}"
+    [ -n "${PYTHON_INTERPRETER}" ] && ADD_PYTHON_INTERPRETER="ansible_python_interpreter=${PYTHON_INTERPRETER}"
     cat << EOF > "${inventory}"
 [ipaserver]
-${scenario} ansible_connection=${engine}
+${scenario} ansible_connection=${engine} ${ADD_PYTHON_INTERPRETER}
 [ipaserver:vars]
 ipaserver_domain = test.local
 ipaserver_realm = TEST.LOCAL
@@ -288,7 +289,7 @@ then
     log warn "Installed collections will not be removed after execution."
     log none "Installing: Ansible Collection ${ANSIBLE_COLLECTIONS}"
     # shellcheck disable=SC2086
-    quiet ansible-galaxy collection install ${ANSIBLE_COLLECTIONS} || die "Failed to install Ansible collections."
+    ansible-galaxy collection install ${ANSIBLE_COLLECTIONS} || die "Failed to install Ansible collections."
 fi
 
 # Ansible configuration


### PR DESCRIPTION
Since RHEL 8.6 there may be an issue that prevent Ansible (ansible-core) from correctly detecting '/usr/libexec/python-platform' as the Python interpreter to use.

This patch allows 'ansible_python_interpreter' to be set both on Azure tests and on `utils/run-tests.sh` by setting the environment variable PYTHON_INTERPRETER.