### PR TITLE
README-dnszone: Fix yaml code block declaration.

### DIFF
--- a/README-dnszone.md
+++ b/README-dnszone.md
@@ -135,7 +135,7 @@ Example playbook to enable a zone:
 
 Example playbook to allow per-zone privilege delegation:
 
-``` yaml
+```yaml
 ---
 - name: Playbook to enable per-zone privilege delegation
   hosts: ipaserver


### PR DESCRIPTION
There was a space between the code block marker and the highlight hint in a playbook example.