### PR TITLE
ipaserver_test: Return generated domain_name

### DIFF
--- a/roles/ipaserver/library/ipaserver_test.py
+++ b/roles/ipaserver/library/ipaserver_test.py
@@ -1171,7 +1171,7 @@ def main():
         changed=False,
         ipa_python_version=IPA_PYTHON_VERSION,
         # basic
-        domain=options.domain_name,
+        domain=domain_name,
         realm=realm_name,
         hostname=host_name,
         _hostname_overridden=bool(options.host_name),


### PR DESCRIPTION
If ipaserver_domain is not given, the domain name is generated from the host fqdn.

This generated value was so far not returned, but the empty given value instead.