### PR TITLE
ipalib.install.kinit moved to ipalib

### DIFF
--- a/plugins/module_utils/ansible_freeipa_module.py
+++ b/plugins/module_utils/ansible_freeipa_module.py
@@ -87,9 +87,13 @@ try:
     from ipalib.constants import DEFAULT_CONFIG, LDAP_GENERALIZED_TIME_FORMAT
 
     try:
-        from ipalib.install.kinit import kinit_password, kinit_keytab
+        from ipalib.kinit import kinit_password, kinit_keytab
     except ImportError:
-        from ipapython.ipautil import kinit_password, kinit_keytab
+        try:
+            from ipalib.install.kinit import kinit_password, kinit_keytab
+        except ImportError:
+            # pre 4.5.0
+            from ipapython.ipautil import kinit_password, kinit_keytab
     from ipapython.ipautil import run
     from ipapython.ipautil import template_str
     from ipapython.dn import DN

--- a/roles/ipaclient/library/ipaclient_get_otp.py
+++ b/roles/ipaclient/library/ipaclient_get_otp.py
@@ -89,9 +89,13 @@ try:
     from ipapython.ipautil import run
     from ipalib.constants import DEFAULT_CONFIG
     try:
-        from ipalib.install.kinit import kinit_password, kinit_keytab
+        from ipalib.kinit import kinit_password, kinit_keytab
     except ImportError:
-        from ipapython.ipautil import kinit_password, kinit_keytab
+        try:
+            from ipalib.install.kinit import kinit_password, kinit_keytab
+        except ImportError:
+            # pre 4.5.0
+            from ipapython.ipautil import kinit_password, kinit_keytab
 except ImportError as _err:
     MODULE_IMPORT_ERROR = str(_err)
 else:

--- a/roles/ipaclient/module_utils/ansible_ipa_client.py
+++ b/roles/ipaclient/module_utils/ansible_ipa_client.py
@@ -173,9 +173,13 @@ try:
             ipa_generate_password
         from ipapython.dn import DN
         try:
-            from ipalib.install.kinit import kinit_keytab, kinit_password
+            from ipalib.kinit import kinit_password, kinit_keytab
         except ImportError:
-            from ipapython.ipautil import kinit_keytab, kinit_password
+            try:
+                from ipalib.install.kinit import kinit_keytab, kinit_password
+            except ImportError:
+                # pre 4.5.0
+                from ipapython.ipautil import kinit_keytab, kinit_password
         from ipapython.ipa_log_manager import standard_logging_setup
         from gssapi.exceptions import GSSError
         try:

--- a/roles/ipareplica/module_utils/ansible_ipa_replica.py
+++ b/roles/ipareplica/module_utils/ansible_ipa_replica.py
@@ -104,7 +104,10 @@ try:
         from ipaclient.install.ipachangeconf import IPAChangeConf
         from ipalib.install import certstore, sysrestore
         from ipapython.ipautil import ipa_generate_password
-        from ipalib.install.kinit import kinit_keytab
+        try:
+            from ipalib.kinit import kinit_keytab
+        except ImportError:
+            from ipalib.install.kinit import kinit_keytab
         from ipapython import ipaldap, ipautil, kernel_keyring
         from ipapython.certdb import IPA_CA_TRUST_FLAGS, \
             EXTERNAL_CA_TRUST_FLAGS

--- a/roles/ipaserver/library/ipaserver_get_connected_server.py
+++ b/roles/ipaserver/library/ipaserver_get_connected_server.py
@@ -77,9 +77,13 @@ try:
     from ipapython.ipautil import run
     from ipalib.constants import DEFAULT_CONFIG
     try:
-        from ipalib.install.kinit import kinit_password
+        from ipalib.kinit import kinit_password
     except ImportError:
-        from ipapython.ipautil import kinit_password
+        try:
+            from ipalib.install.kinit import kinit_password
+        except ImportError:
+            # pre 4.5.0
+            from ipapython.ipautil import kinit_password
 except ImportError as _err:
     MODULE_IMPORT_ERROR = str(_err)
 else:


### PR DESCRIPTION
FreeIPA PR https://github.com/freeipa/freeipa/pull/7286 moved ipalib.install.kinit to ipalib.

It is first tried to import kinit_keytab and kinit_password from ipalib.kinit, then ipalib.install.kinit and finally in some cases where support for IPA 4.5.0 is needed still also ipapython.ipautil.

Related: https://github.com/freeipa/freeipa/pull/7286