### PR TITLE
c10s: Prepare environment for beta testing CentOS Stream 10

### DIFF
--- a/molecule/c10s-build/Dockerfile
+++ b/molecule/c10s-build/Dockerfile
@@ -1,0 +1,28 @@
+FROM quay.io/centos/centos:stream10-development
+ENV container=docker
+
+RUN rm -fv /var/cache/dnf/metadata_lock.pid; \
+dnf makecache; \
+dnf --assumeyes install \
+    /usr/bin/python3 \
+    sudo \
+    bash \
+    systemd \
+    procps-ng \
+    iproute && \
+dnf clean all; \
+(cd /lib/systemd/system/sysinit.target.wants/; for i in *; do [ $i == systemd-tmpfiles-setup.service ] || rm -f $i; done); \
+rm -f /lib/systemd/system/multi-user.target.wants/*;\
+rm -f /etc/systemd/system/*.wants/*;\
+rm -f /lib/systemd/system/local-fs.target.wants/*; \
+rm -f /lib/systemd/system/sockets.target.wants/*udev*; \
+rm -f /lib/systemd/system/sockets.target.wants/*initctl*; \
+rm -f /lib/systemd/system/basic.target.wants/*;\
+rm -f /lib/systemd/system/anaconda.target.wants/*; \
+rm -rf /var/cache/dnf/;
+
+STOPSIGNAL RTMIN+3
+
+VOLUME ["/sys/fs/cgroup"]
+
+CMD ["/usr/sbin/init"]

--- a/molecule/c10s-build/molecule.yml
+++ b/molecule/c10s-build/molecule.yml
@@ -1,0 +1,19 @@
+---
+driver:
+  name: docker
+platforms:
+  - name: c10s-build
+    image: "quay.io/centos/centos:stream10-development"
+    dockerfile: Dockerfile
+    hostname: ipaserver.test.local
+    dns_servers:
+      - 8.8.8.8
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    command: /usr/sbin/init
+    privileged: true
+provisioner:
+  name: ansible
+  playbooks:
+    prepare: ../resources/playbooks/prepare-build.yml
+prerun: false

--- a/molecule/c10s/molecule.yml
+++ b/molecule/c10s/molecule.yml
@@ -1,0 +1,19 @@
+---
+driver:
+  name: docker
+platforms:
+  - name: c10s
+    image: quay.io/ansible-freeipa/upstream-tests:c10s
+    pre_build_image: true
+    hostname: ipaserver.test.local
+    dns_servers:
+      - 127.0.0.1
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    command: /usr/sbin/init
+    privileged: true
+provisioner:
+  name: ansible
+  playbooks:
+    prepare: ../resources/playbooks/prepare.yml
+prerun: false


### PR DESCRIPTION
Provides build scripts and environment setup for preparing container images to test ansible-freeipa using CentOS Stream 1r containeres.

Currently, the c10s containers are in pre-alpha stage, so these tests should be executed only on a case by case basis, and the image should also be created when needed and not on the regular image build pipeline.