### PR TITLE
ipaservice: Do not set continue to None for service_del

### DIFF
--- a/plugins/modules/ipaservice.py
+++ b/plugins/modules/ipaservice.py
@@ -840,7 +840,9 @@ def main():
             elif state == "absent":
                 if action == "service":
                     if res_find is not None:
-                        args = {'continue': delete_continue}
+                        args = {}
+                        if delete_continue is not None:
+                            args['continue'] = delete_continue
                         commands.append([name, 'service_del', args])
 
                 elif action == "member":


### PR DESCRIPTION
delete_continue defaults to None. The use of continue: None is resulting in an error with the batch command. Therefore only set continue if it is not None.