### PR TITLE
README-user.md: Fix state for user rename in example playbook

### DIFF
--- a/README-user.md
+++ b/README-user.md
@@ -311,7 +311,7 @@ Example playbook to rename users:
       ipaadmin_password: SomeADMINpassword
       name: pinky
       rename: reddy
-      state: enabled
+      state: renamed
 ```
 
 Example playbook to unlock users:


### PR DESCRIPTION
A user rename requires "state: renamed". This has been wrong in the example.