### PR TITLE
upstream CI: bump vm and ansible versions

### DIFF
--- a/tests/azure/azure-pipelines.yml
+++ b/tests/azure/azure-pipelines.yml
@@ -31,25 +31,36 @@ stages:
 
 # Fedora
 
-- stage: Fedora_Latest
+- stage: Fedora_Ansible_2_16
   dependsOn: []
   jobs:
   - template: templates/group_tests.yml
     parameters:
       build_number: $(Build.BuildNumber)
       scenario: fedora-latest
-      ansible_version: "-core >=2.14,<2.15"
+      ansible_version: "-core >=2.16,<2.17"
 
 # Galaxy on Fedora
 
-- stage: Galaxy_Fedora_Latest
+- stage: Galaxy_Fedora_Ansible_Latest
   dependsOn: []
   jobs:
   - template: templates/galaxy_tests.yml
     parameters:
       build_number: $(Build.BuildNumber)
       scenario: fedora-latest
-      ansible_version: "-core >=2.14,<2.15"
+      ansible_version: "-core"
+
+# Galaxy on Fedora
+
+- stage: Galaxy_Fedora_Ansible_2_16
+  dependsOn: []
+  jobs:
+  - template: templates/galaxy_tests.yml
+    parameters:
+      build_number: $(Build.BuildNumber)
+      scenario: fedora-latest
+      ansible_version: "-core >=2.16,<2.17"
 
 # CentOS 9 Stream
 
@@ -60,7 +71,7 @@ stages:
     parameters:
       build_number: $(Build.BuildNumber)
       scenario: c9s
-      ansible_version: "-core >=2.14,<2.15"
+      ansible_version: "-core >=2.16,<2.17"
 
 # CentOS 8 Stream
 
@@ -71,7 +82,7 @@ stages:
     parameters:
       build_number: $(Build.BuildNumber)
       scenario: c8s
-      ansible_version: "-core >=2.14,<2.15"
+      ansible_version: "-core >=2.16,<2.17"
 
 # CentOS 7
 
@@ -82,4 +93,4 @@ stages:
     parameters:
       build_number: $(Build.BuildNumber)
       scenario: centos-7
-      ansible_version: "-core >=2.14,<2.15"
+      ansible_version: "-core >=2.16,<2.17"

--- a/tests/azure/nightly.yml
+++ b/tests/azure/nightly.yml
@@ -16,15 +16,6 @@ stages:
 
 # Fedora
 
-- stage: FedoraLatest_Ansible_Core_2_13
-  dependsOn: []
-  jobs:
-  - template: templates/group_tests.yml
-    parameters:
-      build_number: $(Build.BuildNumber)
-      scenario: fedora-latest
-      ansible_version: "-core >=2.13,<2.14"
-
 - stage: FedoraLatest_Ansible_Core_2_14
   dependsOn: []
   jobs:
@@ -43,6 +34,15 @@ stages:
       scenario: fedora-latest
       ansible_version: "-core >=2.15,<2.16"
 
+- stage: FedoraLatest_Ansible_Core_2_16
+  dependsOn: []
+  jobs:
+  - template: templates/group_tests.yml
+    parameters:
+      build_number: $(Build.BuildNumber)
+      scenario: fedora-latest
+      ansible_version: "-core >=2.16,<2.17"
+
 - stage: FedoraLatest_Ansible_latest
   dependsOn: []
   jobs:
@@ -53,15 +53,6 @@ stages:
       ansible_version: ""
 
 # Galaxy on Fedora
-
-- stage: Galaxy_FedoraLatest_Ansible_Core_2_13
-  dependsOn: []
-  jobs:
-  - template: templates/galaxy_tests.yml
-    parameters:
-      build_number: $(Build.BuildNumber)
-      scenario: fedora-latest
-      ansible_version: "-core >=2.13,<2.14"
 
 - stage: Galaxy_FedoraLatest_Ansible_Core_2_14
   dependsOn: []
@@ -81,6 +72,15 @@ stages:
       scenario: fedora-latest
       ansible_version: "-core >=2.15,<2.16"
 
+- stage: Galaxy_FedoraLatest_Ansible_Core_2_16
+  dependsOn: []
+  jobs:
+  - template: templates/galaxy_tests.yml
+    parameters:
+      build_number: $(Build.BuildNumber)
+      scenario: fedora-latest
+      ansible_version: "-core >=2.16,<2.17"
+
 - stage: Galaxy_FedoraLatest_Ansible_latest
   dependsOn: []
   jobs:
@@ -91,15 +91,6 @@ stages:
       ansible_version: ""
 
 # Fedora Rawhide
-
-- stage: FedoraRawhide_Ansible_Core_2_13
-  dependsOn: []
-  jobs:
-  - template: templates/group_tests.yml
-    parameters:
-      build_number: $(Build.BuildNumber)
-      scenario: fedora-rawhide
-      ansible_version: "-core >=2.13,<2.14"
 
 - stage: FedoraRawhide_Ansible_Core_2_14
   dependsOn: []
@@ -119,6 +110,15 @@ stages:
       scenario: fedora-rawhide
       ansible_version: "-core >=2.15,<2.16"
 
+- stage: FedoraRawhide_Ansible_Core_2_16
+  dependsOn: []
+  jobs:
+  - template: templates/group_tests.yml
+    parameters:
+      build_number: $(Build.BuildNumber)
+      scenario: fedora-rawhide
+      ansible_version: "-core >=2.16,<2.17"
+
 - stage: FedoraRawhide_Ansible_latest
   dependsOn: []
   jobs:
@@ -129,15 +129,6 @@ stages:
       ansible_version: ""
 
 # CentoOS 9 Stream
-
-- stage: c9s_Ansible_Core_2_13
-  dependsOn: []
-  jobs:
-  - template: templates/group_tests.yml
-    parameters:
-      build_number: $(Build.BuildNumber)
-      scenario: c9s
-      ansible_version: "-core >=2.13,<2.14"
 
 - stage: c9s_Ansible_Core_2_14
   dependsOn: []
@@ -157,6 +148,15 @@ stages:
       scenario: c9s
       ansible_version: "-core >=2.15,<2.16"
 
+- stage: c9s_Ansible_Core_2_16
+  dependsOn: []
+  jobs:
+  - template: templates/group_tests.yml
+    parameters:
+      build_number: $(Build.BuildNumber)
+      scenario: c9s
+      ansible_version: "-core >=2.16,<2.17"
+
 - stage: c9s_Ansible_latest
   dependsOn: []
   jobs:
@@ -167,15 +167,6 @@ stages:
       ansible_version: ""
 
 # CentOS 8 Stream
-
-- stage: c8s_Ansible_Core_2_13
-  dependsOn: []
-  jobs:
-  - template: templates/group_tests.yml
-    parameters:
-      build_number: $(Build.BuildNumber)
-      scenario: c8s
-      ansible_version: "-core >=2.13,<2.14"
 
 - stage: c8s_Ansible_Core_2_14
   dependsOn: []
@@ -195,6 +186,15 @@ stages:
       scenario: c8s
       ansible_version: "-core >=2.15,<2.16"
 
+- stage: c8s_Ansible_Core_2_16
+  dependsOn: []
+  jobs:
+  - template: templates/group_tests.yml
+    parameters:
+      build_number: $(Build.BuildNumber)
+      scenario: c8s
+      ansible_version: "-core >=2.16,<2.17"
+
 - stage: c8s_Ansible_latest
   dependsOn: []
   jobs:
@@ -205,15 +205,6 @@ stages:
       ansible_version: ""
 
 # CentOS 7
-
-- stage: CentOS7_Ansible_Core_2_13
-  dependsOn: []
-  jobs:
-  - template: templates/group_tests.yml
-    parameters:
-      build_number: $(Build.BuildNumber)
-      scenario: centos-7
-      ansible_version: "-core >=2.13,<2.14"
 
 - stage: CentOS7_Ansible_Core_2_14
   dependsOn: []
@@ -232,6 +223,15 @@ stages:
       build_number: $(Build.BuildNumber)
       scenario: centos-7
       ansible_version: "-core >=2.15,<2.16"
+
+- stage: CentOS7_Ansible_Core_2_16
+  dependsOn: []
+  jobs:
+  - template: templates/group_tests.yml
+    parameters:
+      build_number: $(Build.BuildNumber)
+      scenario: centos-7
+      ansible_version: "-core >=2.16,<2.17"
 
 - stage: CentOS7_Ansible_latest
   dependsOn: []

--- a/tests/azure/pr-pipeline.yml
+++ b/tests/azure/pr-pipeline.yml
@@ -16,7 +16,7 @@ stages:
     parameters:
       build_number: $(Build.BuildNumber)
       scenario: fedora-latest
-      ansible_version: "-core >=2.14,<2.15"
+      ansible_version: "-core >=2.15,<2.16"
 
 # Galaxy on Fedora
 
@@ -27,7 +27,7 @@ stages:
     parameters:
       build_number: $(Build.BuildNumber)
       scenario: fedora-latest
-      ansible_version: "-core >=2.14,<2.15"
+      ansible_version: "-core >=2.16,<2.17"
 
 # CentOS 9 Stream
 
@@ -38,7 +38,7 @@ stages:
     parameters:
       build_number: $(Build.BuildNumber)
       scenario: c9s
-      ansible_version: "-core >=2.14,<2.15"
+      ansible_version: "-core >=2.16,<2.17"
 
 # CentOS 8 Stream
 
@@ -49,7 +49,7 @@ stages:
     parameters:
       build_number: $(Build.BuildNumber)
       scenario: c8s
-      ansible_version: "-core >=2.14,<2.15"
+      ansible_version: "-core >=2.16,<2.17"
 
 # CentOS 7
 
@@ -60,7 +60,7 @@ stages:
     parameters:
       build_number: $(Build.BuildNumber)
       scenario: centos-7
-      ansible_version: "-core >=2.14,<2.15"
+      ansible_version: "-core >=2.16,<2.17"
 
 # Rawhide
 
@@ -71,4 +71,4 @@ stages:
     parameters:
       build_number: $(Build.BuildNumber)
       scenario: fedora-rawhide
-      ansible_version: "-core >=2.14,<2.15"
+      ansible_version: "-core >=2.16,<2.17"


### PR DESCRIPTION
As ansible-core 2.17 was released and it does not support Python 2 or Python 3.6, this patch adds tests for both latest ansible-core and ansible-core 2.16, and it also bumps the different versions of ansible-core to use 2.14, 2.15 and 2.16 for the pipelines.

Also, the Ubuntu VM image version is updated to 22.04.