### PR TITLE
Strip and verify encoded certificates

### DIFF
--- a/plugins/modules/ipahost.py
+++ b/plugins/modules/ipahost.py
@@ -510,7 +510,8 @@ host:
 from ansible.module_utils.ansible_freeipa_module import \
     IPAAnsibleModule, compare_args_ipa, gen_add_del_lists, \
     encode_certificate, is_ipv4_addr, is_ipv6_addr, ipalib_errors, \
-    gen_add_list, gen_intersection_list, normalize_sshpubkey
+    gen_add_list, gen_intersection_list, normalize_sshpubkey, \
+    strip_encoded_certificates
 from ansible.module_utils import six
 if six.PY3:
     unicode = str
@@ -680,13 +681,6 @@ def check_authind(module, auth_ind):
         module.fail_json(
             msg="The use of krbprincipalauthind '%s' is not supported "
             "by your IPA version" % "','".join(_invalid))
-
-
-def convert_certificate(certificate):
-    if certificate is None:
-        return None
-
-    return [cert.strip() for cert in certificate]
 
 
 # pylint: disable=unused-argument
@@ -894,7 +888,7 @@ def main():
         auth_ind, requires_pre_auth, ok_as_delegate, ok_to_auth_as_delegate,
         force, reverse, ip_address, update_dns, update_password)
 
-    certificate = convert_certificate(certificate)
+    certificate = strip_encoded_certificates(ansible_module, certificate)
 
     if sshpubkey is not None:
         sshpubkey = [str(normalize_sshpubkey(key)) for key in sshpubkey]
@@ -982,7 +976,8 @@ def main():
                     ok_to_auth_as_delegate, force, reverse, ip_address,
                     update_dns, update_password)
 
-                certificate = convert_certificate(certificate)
+                certificate = strip_encoded_certificates(ansible_module,
+                                                         certificate)
 
                 if sshpubkey is not None:
                     sshpubkey = [str(normalize_sshpubkey(key)) for

--- a/plugins/modules/ipaservice.py
+++ b/plugins/modules/ipaservice.py
@@ -378,7 +378,7 @@ RETURN = """
 from ansible.module_utils.ansible_freeipa_module import \
     IPAAnsibleModule, compare_args_ipa, encode_certificate, \
     gen_add_del_lists, gen_add_list, gen_intersection_list, ipalib_errors, \
-    api_get_realm, to_text
+    api_get_realm, to_text, strip_encoded_certificates
 from ansible.module_utils import six
 if six.PY3:
     unicode = str
@@ -605,8 +605,7 @@ def main():
     # certificate with serive_add_cert. To be able to compare the results
     # from service_show with the given certificates we have to remove the
     # white space also.
-    if certificate is not None:
-        certificate = [cert.strip() for cert in certificate]
+    certificate = strip_encoded_certificates(ansible_module, certificate)
     pac_type = ansible_module.params_get(
         "pac_type", allow_empty_list_item=True)
     auth_ind = ansible_module.params_get(
@@ -673,8 +672,8 @@ def main():
                 # the certificate with serive_add_cert. To be able to compare
                 # the results from service_show with the given certificates
                 # we have to remove the white space also.
-                if certificate is not None:
-                    certificate = [cert.strip() for cert in certificate]
+                certificate = strip_encoded_certificates(ansible_module,
+                                                         certificate)
                 pac_type = service.get("pac_type")
                 auth_ind = service.get("auth_ind")
                 check_authind(ansible_module, auth_ind)

--- a/plugins/modules/ipauser.py
+++ b/plugins/modules/ipauser.py
@@ -741,7 +741,8 @@ user:
 from ansible.module_utils.ansible_freeipa_module import \
     IPAAnsibleModule, compare_args_ipa, gen_add_del_lists, date_format, \
     encode_certificate, load_cert_from_str, DN_x500_text, to_text, \
-    ipalib_errors, gen_add_list, gen_intersection_list
+    ipalib_errors, gen_add_list, gen_intersection_list, \
+    strip_encoded_certificates
 from ansible.module_utils import six
 if six.PY3:
     unicode = str
@@ -959,13 +960,6 @@ def extend_emails(email, default_email_domain):
                 if "@" not in _email else _email
                 for _email in email]
     return email
-
-
-def convert_certificate(certificate):
-    if certificate is None:
-        return None
-
-    return [cert.strip() for cert in certificate]
 
 
 def convert_certmapdata(certmapdata):
@@ -1260,7 +1254,7 @@ def main():
             preserve, update_password, smb_logon_script, smb_profile_path,
             smb_home_dir, smb_home_drive, idp, idp_user_id, rename,
         )
-        certificate = convert_certificate(certificate)
+        certificate = strip_encoded_certificates(ansible_module, certificate)
         certmapdata = convert_certmapdata(certmapdata)
 
     # Init
@@ -1371,7 +1365,8 @@ def main():
                     update_password, smb_logon_script, smb_profile_path,
                     smb_home_dir, smb_home_drive, idp, idp_user_id, rename,
                 )
-                certificate = convert_certificate(certificate)
+                certificate = strip_encoded_certificates(ansible_module,
+                                                         certificate)
                 certmapdata = convert_certmapdata(certmapdata)
 
                 # Check API specific parameters


### PR DESCRIPTION
**ansible_freeipa_module: New function strip_encoded_certificates**

The new function strip_encoded_certificates strips and verifies the base64
encoded certificates in a list if the list is not None.

The certificates are verified using base64.b64decode after removing
leading and training white space.

Several modules are using base64 encoded certificates, therefore adding
this to ansible_freeipa_module reduces duplicate code.

**ipahost: Use new strip_encoded_certificates**

To strip leading and trailing white space and to verify base64 encoded
certificates.

**ipauser: Use new strip_encoded_certificates**

To strip leading and trailing white space and to verify base64 encoded
certificates.

**ipaservice: Use new strip_encoded_certificates**

To strip leading and trailing white space and to verify base64 encoded
certificates.