### PR TITLE
utils/build-galaxy-release.sh: Fix unary operator expected (v2)

### DIFF
--- a/utils/build-galaxy-release.sh
+++ b/utils/build-galaxy-release.sh
@@ -128,7 +128,7 @@ find . -name "*~" -exec rm {} \;
 find . -name "__py*__" -exec rm -rf {} \;
 
 
-if [ "$offline" != "" ]; then
+if [ "$offline" != "1" ]; then
     echo "Creating CHANGELOG.rst..."
     "$(dirname "$0")/changelog" --galaxy > CHANGELOG.rst
     echo -e "\033[ACreating CHANGELOG.rst... \033[32;1mDONE\033[0m"


### PR DESCRIPTION
This fixes a bad tests if offline is not set:
utils/build-galaxy-release.sh: line 130: [: -ne: unary operator expected

Fixes f17f83d6bddd839efa2691ddf88d418e0921d4f0