### PR TITLE
ipareplica: Pass ipareplica_ip_addresses to client deployment part

### DIFF
--- a/roles/ipareplica/README.md
+++ b/roles/ipareplica/README.md
@@ -190,7 +190,7 @@ Variable | Description | Required
 `ipaservers` | This group with the IPA master full qualified hostnames. (list of strings) | mostly
 `ipareplicas` | Group of IPA replica hostnames. (list of strings) | yes
 `ipaadmin_password` | The password for the IPA admin user (string) | mostly
-`ipareplica_ip_addresses` | The list of master server IP addresses. (list of strings) | no
+`ipareplica_ip_addresses` | The list of IPA replica IP addresses. (list of strings) | no
 `ipareplica_domain` | The primary DNS domain of an existing IPA deployment. (string) | no
 `ipaserver_realm` | The Kerberos realm of an existing IPA deployment. (string) | no
 `ipaserver_hostname` | Fully qualified name of the server. (string) | no

--- a/roles/ipareplica/library/ipareplica_create_ipa_conf.py
+++ b/roles/ipareplica/library/ipareplica_create_ipa_conf.py
@@ -47,7 +47,7 @@ options:
     type: str
     required: no
   ip_addresses:
-    description: List of Master Server IP Addresses
+    description: List of IPA replica IP addresses
     type: list
     elements: str
     required: no

--- a/roles/ipareplica/library/ipareplica_install_ca_certs.py
+++ b/roles/ipareplica/library/ipareplica_install_ca_certs.py
@@ -47,7 +47,7 @@ options:
     type: str
     required: no
   ip_addresses:
-    description: List of Master Server IP Addresses
+    description: List of IPA replica IP addresses
     type: list
     elements: str
     required: no

--- a/roles/ipareplica/library/ipareplica_prepare.py
+++ b/roles/ipareplica/library/ipareplica_prepare.py
@@ -49,7 +49,7 @@ options:
     type: str
     required: no
   ip_addresses:
-    description: List of Master Server IP Addresses
+    description: List of IPA replica IP addresses
     type: list
     elements: str
     required: no

--- a/roles/ipareplica/library/ipareplica_setup_ds.py
+++ b/roles/ipareplica/library/ipareplica_setup_ds.py
@@ -47,7 +47,7 @@ options:
     type: str
     required: no
   ip_addresses:
-    description: List of Master Server IP Addresses
+    description: List of IPA replica IP addresses
     type: list
     elements: str
     required: no

--- a/roles/ipareplica/library/ipareplica_setup_kra.py
+++ b/roles/ipareplica/library/ipareplica_setup_kra.py
@@ -47,7 +47,7 @@ options:
     type: str
     required: no
   ip_addresses:
-    description: List of Master Server IP Addresses
+    description: List of IPA replica IP addresses
     type: list
     elements: str
     required: no

--- a/roles/ipareplica/library/ipareplica_test.py
+++ b/roles/ipareplica/library/ipareplica_test.py
@@ -38,7 +38,7 @@ short_description: IPA replica deployment tests
 description: IPA replica deployment tests
 options:
   ip_addresses:
-    description: List of Master Server IP Addresses
+    description: List of IPA replica IP addresses
     type: list
     elements: str
     required: no

--- a/roles/ipareplica/tasks/install.yml
+++ b/roles/ipareplica/tasks/install.yml
@@ -125,6 +125,7 @@
       ipaclient_realm: "{{ result_ipareplica_test.realm | default(omit) }}"
       ipaclient_servers: "{{ ipareplica_servers | default(omit) }}"
       ipaclient_hostname: "{{ result_ipareplica_test.hostname }}"
+      ipaclient_ip_addresses: "{{ ipareplica_ip_addresses | default(omit) }}"
       ipaclient_install_packages: "{{ ipareplica_install_packages }}"
     when: not result_ipareplica_test.client_enrolled
 


### PR DESCRIPTION
The IP addresses set with ipareplica_ip_addresses have not been passed to ipaclient role for client deployment part. This resulted in not setting the IP addresses.

The description for ipareplica_ip_addresses in the ipareplica README and also the role modules was wrong and have been fixed to "List of IPA replica IP addresses".

Related: https://pagure.io/freeipa/issue/7405

Resolves: https://github.com/freeipa/ansible-freeipa/issues/1244