### PR TITLE
ansible_freeipa_module: Fix errors in batch mode

### DIFF
--- a/plugins/module_utils/ansible_freeipa_module.py
+++ b/plugins/module_utils/ansible_freeipa_module.py
@@ -1485,7 +1485,6 @@ class IPAAnsibleModule(AnsibleModule):
                                 filter(lambda x: x[0] in keeponly,
                                        _res.items())
                             )
-                        self.tm_warn("res: %s" % repr(res))
 
                         if "error" not in res or res["error"] is None:
                             if result_handler is not None:
@@ -1498,10 +1497,9 @@ class IPAAnsibleModule(AnsibleModule):
                             changed = True
                         else:
                             _errors.append(
-                                "%s %s %s: %s" %
+                                "%s: %s: %s" %
                                 (batch_args[ri]["method"],
-                                 repr(batch_args[ri]["params"][0][0]),
-                                 repr(batch_args[ri]["params"][1]),
+                                 str(batch_args[ri]["params"][0][0]),
                                  res["error"]))
                 # clear batch command list (python2 compatible)
                 del batch_args[:]


### PR DESCRIPTION
The error string returned by execute_ipa_commands in batch mode additionally contains the whole parameter list for the command. This is different to non batch mode execution and breaks tests that are checking the returned error message.

A left over debug message also have been removed from the error processing.