### PR TITLE
Convert input certificates

### DIFF
--- a/plugins/modules/ipahost.py
+++ b/plugins/modules/ipahost.py
@@ -510,7 +510,8 @@ host:
 from ansible.module_utils.ansible_freeipa_module import \
     IPAAnsibleModule, compare_args_ipa, gen_add_del_lists, \
     encode_certificate, is_ipv4_addr, is_ipv6_addr, ipalib_errors, \
-    gen_add_list, gen_intersection_list, normalize_sshpubkey
+    gen_add_list, gen_intersection_list, normalize_sshpubkey, \
+    convert_input_certificates
 from ansible.module_utils import six
 if six.PY3:
     unicode = str
@@ -680,13 +681,6 @@ def check_authind(module, auth_ind):
         module.fail_json(
             msg="The use of krbprincipalauthind '%s' is not supported "
             "by your IPA version" % "','".join(_invalid))
-
-
-def convert_certificate(certificate):
-    if certificate is None:
-        return None
-
-    return [cert.strip() for cert in certificate]
 
 
 # pylint: disable=unused-argument
@@ -894,7 +888,8 @@ def main():
         auth_ind, requires_pre_auth, ok_as_delegate, ok_to_auth_as_delegate,
         force, reverse, ip_address, update_dns, update_password)
 
-    certificate = convert_certificate(certificate)
+    certificate = convert_input_certificates(ansible_module, certificate,
+                                             state)
 
     if sshpubkey is not None:
         sshpubkey = [str(normalize_sshpubkey(key)) for key in sshpubkey]
@@ -982,7 +977,8 @@ def main():
                     ok_to_auth_as_delegate, force, reverse, ip_address,
                     update_dns, update_password)
 
-                certificate = convert_certificate(certificate)
+                certificate = convert_input_certificates(ansible_module,
+                                                         certificate, state)
 
                 if sshpubkey is not None:
                     sshpubkey = [str(normalize_sshpubkey(key)) for

--- a/plugins/modules/ipaidoverrideuser.py
+++ b/plugins/modules/ipaidoverrideuser.py
@@ -315,7 +315,7 @@ RETURN = """
 
 from ansible.module_utils.ansible_freeipa_module import \
     IPAAnsibleModule, compare_args_ipa, gen_add_del_lists, gen_add_list, \
-    gen_intersection_list, encode_certificate
+    gen_intersection_list, encode_certificate, convert_input_certificates
 from ansible.module_utils import six
 
 if six.PY3:
@@ -479,8 +479,8 @@ def main():
 
     ansible_module.params_fail_used_invalid(invalid, state, action)
 
-    if certificate is not None:
-        certificate = [cert.strip() for cert in certificate]
+    certificate = convert_input_certificates(ansible_module, certificate,
+                                             state)
 
     # Init
 

--- a/plugins/modules/ipauser.py
+++ b/plugins/modules/ipauser.py
@@ -741,7 +741,8 @@ user:
 from ansible.module_utils.ansible_freeipa_module import \
     IPAAnsibleModule, compare_args_ipa, gen_add_del_lists, date_format, \
     encode_certificate, load_cert_from_str, DN_x500_text, to_text, \
-    ipalib_errors, gen_add_list, gen_intersection_list
+    ipalib_errors, gen_add_list, gen_intersection_list, \
+    convert_input_certificates
 from ansible.module_utils import six
 if six.PY3:
     unicode = str
@@ -959,13 +960,6 @@ def extend_emails(email, default_email_domain):
                 if "@" not in _email else _email
                 for _email in email]
     return email
-
-
-def convert_certificate(certificate):
-    if certificate is None:
-        return None
-
-    return [cert.strip() for cert in certificate]
 
 
 def convert_certmapdata(certmapdata):
@@ -1260,7 +1254,8 @@ def main():
             preserve, update_password, smb_logon_script, smb_profile_path,
             smb_home_dir, smb_home_drive, idp, idp_user_id, rename,
         )
-        certificate = convert_certificate(certificate)
+        certificate = convert_input_certificates(ansible_module, certificate,
+                                                 state)
         certmapdata = convert_certmapdata(certmapdata)
 
     # Init
@@ -1371,7 +1366,8 @@ def main():
                     update_password, smb_logon_script, smb_profile_path,
                     smb_home_dir, smb_home_drive, idp, idp_user_id, rename,
                 )
-                certificate = convert_certificate(certificate)
+                certificate = convert_input_certificates(ansible_module,
+                                                         certificate, state)
                 certmapdata = convert_certmapdata(certmapdata)
 
                 # Check API specific parameters


### PR DESCRIPTION
Certificates given by ansible could have leading and trailing white
space, but also multi line input is possible that also could have
leading and training white space and newlines.