### PR TITLE
[WIP] upstream ci: Remove dependency on molecule

### DIFF
--- a/molecule/fedora-latest/molecule.yml
+++ b/molecule/fedora-latest/molecule.yml
@@ -13,9 +13,10 @@ platforms:
     command: /usr/sbin/init
     privileged: true
     systemd: always
-    tmpfs:
-      - /run
-      - /tmp
+    cgroupns_mode: host
+    # tmpfs:
+    #   - /run
+    #   - /tmp
 provisioner:
   name: ansible
   playbooks:

--- a/molecule/fedora-latest/molecule.yml
+++ b/molecule/fedora-latest/molecule.yml
@@ -12,6 +12,10 @@ platforms:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
     command: /usr/sbin/init
     privileged: true
+    systemd: always
+    tmpfs:
+      - /run
+      - /tmp
 provisioner:
   name: ansible
   playbooks:


### PR DESCRIPTION
We only use molecule to build images and start testing containers, which adds unneeded complexity by increasing the software stack in a way that does not bring any advantage.

There's also risk that changes on molecule break the tests, which has happened a few times.

This change removes the dependency on molecule by using docker/podman directly to build and run the test containers.