### PR TITLE
user: Fix idp_user_id aliases

### DIFF
--- a/plugins/modules/ipauser.py
+++ b/plugins/modules/ipauser.py
@@ -1110,7 +1110,7 @@ def main():
         nomembers=dict(type='bool', default=None),
         idp=dict(type="str", default=None, aliases=['ipaidpconfiglink']),
         idp_user_id=dict(type="str", default=None,
-                         aliases=['ipaidpconfiglink']),
+                         aliases=['ipaidpsub']),
         rename=dict(type="str", required=False, default=None,
                     aliases=["new_name"]),
     )


### PR DESCRIPTION
The alias for idp_user_id was ipaidpconfiglink by mistake. It was already correct (ipaidpsub) in the DOCUMENTATION section and also in the README.