### PR TITLE
tests/sanity/sanity.sh: Install setuptools with pip

### DIFF
--- a/tests/sanity/sanity.sh
+++ b/tests/sanity/sanity.sh
@@ -13,6 +13,7 @@ python -m venv "$VENV"
 source "$VENV"/bin/activate
 
 python -m pip install --upgrade pip
+pip install setuptools
 pip install galaxy_importer
 
 rm -f "$ANSIBLE_COLLECTION"-*.tar.gz


### PR DESCRIPTION
setuptools might not be installed before importing and using galaxy_importer. This could result in a backtrace by disabling ANSIBLE_TEST_LOCAL_IMAGE in galaxy-importer.cfg to run latest tests.