### PR TITLE
ansible_freeipa_module: date_format should return a string, not datetime

### DIFF
--- a/plugins/module_utils/ansible_freeipa_module.py
+++ b/plugins/module_utils/ansible_freeipa_module.py
@@ -365,7 +365,8 @@ def date_format(value):
 
     for _date_format in accepted_date_formats:
         try:
-            return datetime.strptime(value, _date_format)
+            val = datetime.strptime(value, _date_format)
+            return val.strftime(LDAP_GENERALIZED_TIME_FORMAT)
         except ValueError:
             pass
     raise ValueError("Invalid date '%s'" % value)


### PR DESCRIPTION
date_format was returning a datetime.datetime instead of a string. This has ben working fine with normal command processing, but is sometimes an issue with batch processing in the user module.