### PR TITLE
tests/service/test_services_present.yml: Add missing cleanup

### DIFF
--- a/tests/service/test_services_present.yml
+++ b/tests/service/test_services_present.yml
@@ -8,6 +8,18 @@
   - name: Include generate_test_data.yml
     ansible.builtin.include_tasks: generate_test_data.yml
 
+  - name: Cleanup Services len:{{ service_list | length }}
+    ipaservice:
+      ipaadmin_password: SomeADMINpassword
+      services: "{{ service_absent_list }}"
+      state: absent
+
+  - name: Cleanup Hosts len:{{ host_list | length }}
+    ipahost:
+      ipaadmin_password: SomeADMINpassword
+      hosts: "{{ host_absent_list }}"
+      state: absent
+
   - name: Hosts present len:{{ host_list | length }}
     ipahost:
       ipaadmin_password: SomeADMINpassword


### PR DESCRIPTION
The cleanup of the test services and hosts have been missing, which could lead to a test failure.