### PR TITLE
Infra image system services dns and kinit

### DIFF
--- a/infra/image/system-service/fixipaip.sh
+++ b/infra/image/system-service/fixipaip.sh
@@ -44,11 +44,16 @@ if [ -z "${PTR}" ] || [ -n "${PTR//[0-9]}" ]; then
     echo "ERROR: Failed to get PTR from IPv4 address: '${PTR}'"
     exit 1
 fi
+FORWARDER=$(grep -s -m 1 ^nameserver /etc/resolv.conf.fixnet | cut -d" " -f 2)
+if [ -z "${FORWARDER}" ] || [ "${FORWARDER}" == "127.0.0.1" ]; then
+    FORWARDER="8.8.8.8"
+fi
 
-echo "Fix IPA IP:"
+echo "Fix IPA:"
 echo "  HOSTNAME: '${HOSTNAME}'"
 echo "  IP: '${IP}'"
 echo "  PTR: '${PTR}'"
+echo "  FORWARDER: '${FORWARDER}'"
 
 if ! echo "SomeADMINpassword" | kinit -c "${KRB5CCNAME}"
 then
@@ -76,6 +81,8 @@ for zone in ${ZONES}; do
         ipa dnsrecord-mod test.local ipa-ca --a-rec="$IP"
     fi
 done
+
+ipa dnsserver-mod "${HOSTNAME}" --forwarder="${FORWARDER}"
 
 kdestroy -c "${KRB5CCNAME}" -A
 

--- a/infra/image/system-service/fixipaip.sh
+++ b/infra/image/system-service/fixipaip.sh
@@ -55,7 +55,7 @@ echo "  IP: '${IP}'"
 echo "  PTR: '${PTR}'"
 echo "  FORWARDER: '${FORWARDER}'"
 
-if ! echo "SomeADMINpassword" | kinit -c "${KRB5CCNAME}"
+if ! echo "SomeADMINpassword" | kinit -c "${KRB5CCNAME}" admin >/dev/null
 then
     echo "ERROR: Failed to obtain Kerberos ticket"
     exit 1

--- a/infra/image/system-service/fixnet.sh
+++ b/infra/image/system-service/fixnet.sh
@@ -51,7 +51,11 @@ else
     echo -e "$IP\t${HOSTNAME} ${HOSTNAME%%.*}" >> /etc/hosts
 fi
 
-echo "nameserver 127.0.0.1" > /etc/resolv.conf
+cp -a /etc/resolv.conf /etc/resolv.conf.fixnet
+cat > /etc/resolv.conf <<EOF
+search ${HOSTNAME#*.}
+nameserver 127.0.0.1
+EOF
 
 echo "/etc/hosts:"
 cat "/etc/hosts"


### PR DESCRIPTION
**infra/image/system-service/fixipaip.sh: Use of admin for kinit call**
    
    The kinit call have been missing the principal.

**infra/image system-services: Fix DNS forwarder**
    
    The DNS forwarder is set while deploying the IPA server. This forwarder
    might not be correct later on.
    
    The old /etc/resolv.conf is copied to /etc/resolv.conf.fixnet by the
    fixnet service and later on the fixipaip service is trying to get the
    nameserver from the copied file. If the retrieval failed of if the
    namesever is 127.0.0.1, then the nameserver will be set to 8.8.8.8.
    
    After fixing the IP addresses for the forward and reverse zone, also the
    forwarder is set for the dnsserver "${HOSTNAME}".
