### PR TITLE
Avoid an error if ipadefaultemaildomain if not defined

### DIFF
--- a/plugins/modules/ipauser.py
+++ b/plugins/modules/ipauser.py
@@ -1277,7 +1277,7 @@ def main():
         # Default email domain
 
         result = ansible_module.ipa_command_no_name("config_show", {})
-        default_email_domain = result["result"]["ipadefaultemaildomain"][0]
+        default_email_domain = result["result"]["ipadefaultemaildomain"][0] if "ipadefaultemaildomain" in result["result"] else None
 
         # Extend email addresses
 


### PR DESCRIPTION
The IPA configuration `ipadefaultemaildomain` is optional (in this case, the key don't exist).

It's usefull to unset the default email domain, because it disables the auto-generation of an email address when creating a new user. But when we have this type of configuration, the module `ipauser` always failed (with or without email) : 

> msg: '''ipadefaultemaildomain'''

While it's permitted by the FreeIPA server to have no default email domain, the module assumes that there must be one configured.

This PR simply check if this parameter exists. If not, AND if ever the module is called with a "short" email address that needs to be extended, so no miracle : it will failed with a message like this

> msg: 'user_mod: testuser: invalid ''email'': invalid e-mail format: testuser@None'

But in this case I think it is a legitimate failure (the request is not compatible with the server configuration) and the message remains relatively understandable.

