### PR TITLE
pylint gihub workflow: Disable too-many-positional-arguments

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -56,7 +56,8 @@ disable =
     too-many-branches,
     too-many-locals,
     fixme,
-    use-dict-literal
+    use-dict-literal,
+    too-many-positional-arguments
 
 [pylint.BASIC]
 good-names =


### PR DESCRIPTION
This change disables the too-many-positional-arguments message for the pylint github workflow.