### PR TITLE
infra/image/shcontainer: Drop cpu and add cap-add for podman create

### DIFF
--- a/infra/image/build.sh
+++ b/infra/image/build.sh
@@ -15,7 +15,7 @@ valid_distro() {
 usage() {
     local prog="${0##*/}"
     cat << EOF
-usage: ${prog} [-h] [-s] distro
+usage: ${prog} [-h] [-p] [-s] distro
     ${prog} build a container image to test ansible-freeipa.
 EOF
 }
@@ -29,6 +29,7 @@ positional arguments:
 
 optional arguments:
 
+    -p  Give extended privileges to the container
     -s  Deploy IPA server
 
 EOF
@@ -40,12 +41,14 @@ hostname="ipaserver.test.local"
 # cpus="2"
 memory="3g"
 quayname="quay.io/ansible-freeipa/upstream-tests"
+privileged=""
 deploy_server="N"
 
-while getopts ":hs" option
+while getopts ":hps" option
 do
     case "${option}" in
         h) help && exit 0 ;;
+        p) privileged="privileged" ;;
         s) deploy_server="Y" ;;
         *) die -u "Invalid option: ${option}" ;;
     esac
@@ -82,7 +85,7 @@ container_remove_image_if_exists "${tag}"
     container_remove_image_if_exists "${server_tag}"
 
 container_build "${tag}" "${BASEDIR}/dockerfile/${distro}" "${BASEDIR}"
-container_create "${name}" "${tag}" "${hostname}" "${memory}"
+container_create "${name}" "${tag}" "${hostname}" "${memory}" "${privileged}"
 container_commit "${name}" "${quayname}:${tag}"
 
 if [ "${deploy_server}" == "Y" ]

--- a/infra/image/shcontainer
+++ b/infra/image/shcontainer
@@ -11,18 +11,19 @@ container_create() {
     local image=${2}
     local hostname=${3}
     local memory=${4:-"3g"}
-    local cpus=${5:-"2"}
+    local privileged=""
 
+    [ "${5}" == "privileged" ] && privileged="--privileged"
     [ -n "${hostname}" ] || die "No hostname given"
 
     log info "= Creating ${name} ="
     podman create \
+           ${privileged} \
            --security-opt label=disable \
            --name "${name}" \
            --hostname "${hostname}" \
            --network bridge:interface_name=eth0 \
            --systemd true \
-           --cpus "${cpus}" \
            --memory "${memory}" \
            --memory-swap -1 \
            --no-hosts \

--- a/tests/azure/templates/build_container.yml
+++ b/tests/azure/templates/build_container.yml
@@ -32,7 +32,7 @@ jobs:
   - script: ansible-galaxy collection install containers.podman
     displayName: Install Ansible Galaxy collections
 
-  - script: infra/image/build.sh -s ${{ parameters.distro }}
+  - script: infra/image/build.sh -p -s ${{ parameters.distro }}
     displayName: Build ${{ parameters.distro }} base image
 
   - script: podman login -u="$QUAY_ROBOT_USERNAME" -p="$QUAY_ROBOT_TOKEN" quay.io


### PR DESCRIPTION
podman create does not support the cpu parameter for the build using Ubuntu. But the NET_ADMIN capability is needed.