### PR TITLE
ipacert: Fix ipacert tests

### DIFF
--- a/tests/cert/test_cert_host.yml
+++ b/tests/cert/test_cert_host.yml
@@ -40,7 +40,7 @@
 
   - name: Create CSR
     ansible.builtin.shell:
-      cmd: "openssl req -newkey rsa:1024 -keyout /dev/null -nodes -subj /CN=certhost.{{ ipa_domain }}"
+      cmd: "openssl req -newkey rsa:2048 -keyout /dev/null -nodes -subj /CN=certhost.{{ ipa_domain }}"
     register: host_req
 
   - name: Create CSR file

--- a/tests/cert/test_cert_service.yml
+++ b/tests/cert/test_cert_service.yml
@@ -51,7 +51,7 @@
 
   - name: Create signing request for certificate
     ansible.builtin.shell:
-      cmd: "openssl req -newkey rsa:1024 -keyout /dev/null -nodes -subj /CN=certservice.{{ ipa_domain }}"
+      cmd: "openssl req -newkey rsa:2048 -keyout /dev/null -nodes -subj /CN=certservice.{{ ipa_domain }}"
     register: service_req
 
   - name: Create CSR file

--- a/tests/cert/test_cert_user.yml
+++ b/tests/cert/test_cert_user.yml
@@ -36,7 +36,7 @@
   - name: Crete CSR
     ansible.builtin.shell:
       cmd:
-        'openssl req -newkey rsa:1024 -keyout /dev/null -nodes -subj /CN=certuser -reqexts IECUserRoles
+        'openssl req -newkey rsa:2048 -keyout /dev/null -nodes -subj /CN=certuser -reqexts IECUserRoles
           -config <(cat /etc/pki/tls/openssl.cnf; printf "[IECUserRoles]\n1.2.840.10070.8.1=ASN1:UTF8String:hello world")'
       executable: /bin/bash
     register: user_req


### PR DESCRIPTION
It seems that in recent versions, a minimum of 2048 bits for RSA keys are required to request a certificate. This seems to be enforced by crypto policies.

By adjusting the key size all ipacert tests pass.