### PR TITLE
upstream CI: Use Azure 'loops' to create stages

### DIFF
--- a/infra/azure/azure-pipelines.yml
+++ b/infra/azure/azure-pipelines.yml
@@ -5,72 +5,64 @@ trigger:
 pool:
   vmImage: 'ubuntu-20.04'
 
+variables:
+  ansible_version: "-core >=2.16,<2.17"
+  ansible_latest: "-core"
+  ansible_minimum: "-core <2.16"
+  distros: "fedora-latest,c9s,fedora-rawhide"
+
 stages:
 
-# Fedora
-
-- stage: Fedora_Ansible_Latest
+- stage: fedora_latest_ansible_latest
   dependsOn: []
   jobs:
   - template: templates/group_tests.yml
     parameters:
       build_number: $(Build.BuildNumber)
       distro: fedora-latest
-      ansible_version: "-core"
+      ansible_version: ${{ variables.ansible_latest }}
       skip_git_test: true
 
-# Fedora
-
-- stage: Fedora_Ansible_min_supported
+- stage: fedora_latest_ansible_2_15
   dependsOn: []
   jobs:
   - template: templates/group_tests.yml
     parameters:
       build_number: $(Build.BuildNumber)
       distro: fedora-latest
-      ansible_version: "-core <2.16"
+      ansible_version: ${{ variables.ansbile_minimum }}
       skip_git_test: true
 
-# Fedora
+# Supported distros
 
-- stage: Fedora_Latest
-  dependsOn: []
-  jobs:
-  - template: templates/group_tests.yml
-    parameters:
-      build_number: $(Build.BuildNumber)
-      distro: fedora-latest
-      skip_git_test: true
-      ansible_version: "-core >=2.16,<2.17"
+- ${{ each distro in split(variables.distros, ',') }}:
+  - stage: ${{ replace(distro, '-', '_') }}_ansible_2_16
+    dependsOn: []
+    jobs:
+    - template: templates/group_tests.yml
+      parameters:
+        build_number: $(Build.BuildNumber)
+        distro: ${{ distro }}
+        ansible_version: ${{ variables.ansible_version }}
+        skip_git_test: true
+        test_galaxy: false
 
 # Galaxy on Fedora
 
-- stage: Galaxy_Fedora_Latest
+- stage: galaxy_fedora_latest_ansible_2_16
   dependsOn: []
   jobs:
   - template: templates/group_tests.yml
     parameters:
       build_number: $(Build.BuildNumber)
       distro: fedora-latest
-      ansible_version: "-core >=2.16,<2.17"
+      ansible_version: ${{ variables.ansible_version }}
       skip_git_test: true
       test_galaxy: true
 
-# CentOS 9 Stream
+# CentOS 8 Stream, latest supported Ansible version.
 
-- stage: CentOS_9_Stream
-  dependsOn: []
-  jobs:
-  - template: templates/group_tests.yml
-    parameters:
-      build_number: $(Build.BuildNumber)
-      distro: c9s
-      ansible_version: "-core >=2.16,<2.17"
-      skip_git_test: true
-
-# CentOS 8 Stream
-
-- stage: CentOS_8_Stream
+- stage: c8s_ansible_2_16
   dependsOn: []
   jobs:
   - template: templates/group_tests.yml

--- a/infra/azure/build-containers.yml
+++ b/infra/azure/build-containers.yml
@@ -1,5 +1,4 @@
 ---
-
 schedules:
 - cron: "0 0 * * 0"
   displayName: Weekly Sunday midnight build
@@ -13,46 +12,24 @@ trigger: none
 pool:
   vmImage: 'ubuntu-24.04'
 
+variables: { distros: "fedora-latest,fedora-rawhide,c9s" }
+
 stages:
 
+- ${{ each distro in split(variables.distros, ',') }}:
+  - stage: build_${{ join('_', split(distro, '-')) }}
+    dependsOn: []
+    jobs:
+    - template: templates/build_container.yml
+      parameters:
+        distro: ${{ distro }}
+
+# Special case for CentOS 8 Stream
 - stage: CentOS_8_Stream
   dependsOn: []
   jobs:
   - template: templates/build_container.yml
     parameters:
-      job_name_suffix: C8S
       distro: c8s
       # ansible-core 2.17+ cannot be used to deploy on CentOS 8 Stream.
       ansible_core_version: "<2.17"
-
-- stage: CentOS_9_Stream
-  dependsOn: []
-  jobs:
-  - template: templates/build_container.yml
-    parameters:
-      job_name_suffix: C9S
-      distro: c9s
-
-- stage: CentOS_10_Stream
-  dependsOn: []
-  jobs:
-  - template: templates/build_container.yml
-    parameters:
-      job_name_suffix: C10S
-      distro: c10s
-
-- stage: Fedora_Latest
-  dependsOn: []
-  jobs:
-  - template: templates/build_container.yml
-    parameters:
-      job_name_suffix: FedoraLatest
-      distro: fedora-latest
-
-- stage: Fedora_Rawhide
-  dependsOn: []
-  jobs:
-  - template: templates/build_container.yml
-    parameters:
-      job_name_suffix: FedoraRawhide
-      distro: fedora-rawhide

--- a/infra/azure/nightly.yml
+++ b/infra/azure/nightly.yml
@@ -12,115 +12,68 @@ trigger: none
 pool:
   vmImage: 'ubuntu-20.04'
 
+variables:
+  # We need to have two sets, as c8s is not supported by all ansible versions
+  recent_distros: "fedora-latest,fedora-rawhide,c9s"
+  distros: "fedora-latest,fedora-rawhide,c9s,c8s"
+  ansible_latest: "-core"
+  ansible_minimum: "-core <2.16"
+  ansible_version: "-core >=2.16,<2.17"
+
 stages:
 
-# Fedora
+# Minimum ansible
 
-- stage: fedora_latest_Ansible_Core_2_15
-  dependsOn: []
-  jobs:
-  - template: templates/group_tests.yml
-    parameters:
-      build_number: $(Build.BuildNumber)
-      distro: fedora-latest
-      ansible_version: "-core >=2.15,<2.16"
-      skip_git_test: true
+- ${{ each distro in split(variables.distros, ',') }}:
+  - stage: ${{ replace(distro, '-', '_') }}_ansible_2_15
+    dependsOn: []
+    jobs:
+    - template: templates/group_tests.yml
+      parameters:
+        build_number: $(Build.BuildNumber)
+        distro: fedora-latest
+        ansible_version: ${{ variables.ansible_minimum }}
+        skip_git_test: true
+        test_galaxy: false
 
-- stage: fedora_latest_Ansible_Core_2_16
-  dependsOn: []
-  jobs:
-  - template: templates/group_tests.yml
-    parameters:
-      build_number: $(Build.BuildNumber)
-      distro: fedora-latest
-      ansible_version: ""
-      skip_git_test: true
+# Latest ansible
 
-- stage: fedora_latest_Ansible_Core_2_17
-  dependsOn: []
-  jobs:
-  - template: templates/group_tests.yml
-    parameters:
-      build_number: $(Build.BuildNumber)
-      distro: fedora-latest
-      ansible_version: "-core >=2.17"
-      skip_git_test: true
+- ${{ each distro in split(variables.recent_distros, ',') }}:
+  - stage: ${{ replace(distro, '-', '_') }}_ansible_latest
+    dependsOn: []
+    jobs:
+    - template: templates/group_tests.yml
+      parameters:
+        build_number: $(Build.BuildNumber)
+        distro: ${{ distro }}
+        ansible_version: ${{ variables.ansible_latest }}
+        skip_git_test: true
+        test_galaxy: false
 
-# Galaxy on Fedora
+# Selected ansible-core version
 
-- stage: Galaxy_fedora_latest_Ansible_Core_2_17
-  dependsOn: []
-  jobs:
-  - template: templates/group_tests.yml
-    parameters:
-      build_number: $(Build.BuildNumber)
-      distro: fedora-latest
-      ansible_version: "-core >=2.17,<2.18"
-      skip_git_test: true
-      test_galaxy: true
+- ${{ each distro in split(variables.distros, ',') }}:
+  - stage: ${{ replace(distro, '-', '_') }}_ansible_2_16
+    dependsOn: []
+    jobs:
+    - template: templates/group_tests.yml
+      parameters:
+        build_number: $(Build.BuildNumber)
+        distro: ${{ distro }}
+        ansible_version: ${{ variables.ansible_version }}
+        skip_git_test: true
+        test_galaxy: false
 
-# Fedora Rawhide
+# Galaxy collection with selected ansible-core version
 
-- stage: fedora_rawhide_Ansible_Core_2_17
-  dependsOn: []
-  jobs:
-  - template: templates/group_tests.yml
-    parameters:
-      build_number: $(Build.BuildNumber)
-      distro: fedora-rawhide
-      ansible_version: "-core >=2.17,<2.18"
-      skip_git_test: true
-
-# CentoOS 9 Stream
-
-- stage: c9s_Ansible_Core_2_15
-  dependsOn: []
-  jobs:
-  - template: templates/group_tests.yml
-    parameters:
-      build_number: $(Build.BuildNumber)
-      distro: c9s
-      ansible_version: "-core >=2.15,<2.16"
-      skip_git_test: true
-
-- stage: c9s_Ansible_Core_2_16
-  dependsOn: []
-  jobs:
-  - template: templates/group_tests.yml
-    parameters:
-      build_number: $(Build.BuildNumber)
-      distro: c9s
-      ansible_version: "-core >=2.16,<2.17"
-      skip_git_test: true
-
-- stage: c9s_Ansible_Core_2_17
-  dependsOn: []
-  jobs:
-  - template: templates/group_tests.yml
-    parameters:
-      build_number: $(Build.BuildNumber)
-      distro: c9s
-      ansible_version: "-core >=2.17,<2.18"
-      skip_git_test: true
-
-# CentOS 8 Stream only works up to ansible-core 2.16.z
-
-- stage: c8s_Ansible_Core_2_15
-  dependsOn: []
-  jobs:
-  - template: templates/group_tests.yml
-    parameters:
-      build_number: $(Build.BuildNumber)
-      distro: c8s
-      ansible_version: "-core >=2.15,<2.16"
-      skip_git_test: true
-
-- stage: c8s_Ansible_Core_2_16
-  dependsOn: []
-  jobs:
-  - template: templates/group_tests.yml
-    parameters:
-      build_number: $(Build.BuildNumber)
-      distro: c8s
-      ansible_version: "-core >=2.16,<2.17"
-      skip_git_test: true
+- ${{ each distro in split(variables.distros, ',') }}:
+  - stage: galaxy_${{ replace(distro, '-', '_') }}_asible_2_16
+    dependsOn: []
+    jobs:
+    - template: templates/group_tests.yml
+      parameters:
+        build_number: $(Build.BuildNumber)
+        distro: ${{ distro }}
+        ansible_version: ${{ variables.ansible_version }}
+        skip_git_test: true
+        test_galaxy: true

--- a/infra/azure/pr-pipeline.yml
+++ b/infra/azure/pr-pipeline.yml
@@ -5,65 +5,35 @@ trigger:
 pool:
   vmImage: 'ubuntu-20.04'
 
+variables:
+  distros: "fedora-latest,c9s,c8s,fedora-rawhide"
+  ansible_version: "-core >=2.15,<2.16"
+
 stages:
 
-# Fedora
+# Test with repository in all distros
 
-- stage: Fedora_Latest
-  dependsOn: []
-  jobs:
-  - template: templates/run_tests.yml
-    parameters:
-      build_number: $(Build.BuildNumber)
-      distro: fedora-latest
-      ansible_version: "-core >=2.15,<2.16"
-      skip_git_test: false
+- ${{ each distro in split(variables.distros, ',') }}:
+  - stage: ${{ replace(distro, '-', '_') }}_ansible_2_16
+    dependsOn: []
+    jobs:
+    - template: templates/run_tests.yml
+      parameters:
+        build_number: $(Build.BuildNumber)
+        distro: ${{ distro }}
+        ansible_version: ${{ variables.ansible_version }}
+        skip_git_test: false
+        test_galaxy: false
 
 # Galaxy on Fedora
 
-- stage: Galaxy_Fedora_Latest
+- stage: galaxy_fedora_latest_ansible_2_16
   dependsOn: []
   jobs:
   - template: templates/run_tests.yml
     parameters:
       build_number: $(Build.BuildNumber)
       distro: fedora-latest
-      ansible_version: "-core >=2.15,<2.16"
+      ansible_version: ${{ variables.ansible_version }}
       skip_git_test: false
       test_galaxy: true
-
-# CentOS 9 Stream
-
-- stage: CentOS_9_Stream
-  dependsOn: []
-  jobs:
-  - template: templates/run_tests.yml
-    parameters:
-      build_number: $(Build.BuildNumber)
-      distro: c9s
-      ansible_version: "-core >=2.15,<2.16"
-      skip_git_test: false
-
-# CentOS 8 Stream
-
-- stage: CentOS_8_Stream
-  dependsOn: []
-  jobs:
-  - template: templates/run_tests.yml
-    parameters:
-      build_number: $(Build.BuildNumber)
-      distro: c8s
-      ansible_version: "-core >=2.15,<2.16"
-      skip_git_test: false
-
-# Rawhide
-
-- stage: Fedora_Rawhide
-  dependsOn: []
-  jobs:
-  - template: templates/run_tests.yml
-    parameters:
-      build_number: $(Build.BuildNumber)
-      distro: fedora-rawhide
-      ansible_version: "-core >=2.15,<2.16"
-      skip_git_test: false

--- a/infra/azure/templates/build_container.yml
+++ b/infra/azure/templates/build_container.yml
@@ -1,7 +1,5 @@
 ---
 parameters:
-  - name: job_name_suffix
-    type: string
   - name: distro
     type: string
   - name: python_version
@@ -11,7 +9,7 @@ parameters:
     default: ""
 
 jobs:
-- job: BuildTestImage${{ parameters.job_name_suffix }}
+- job: BuildTestImage_${{ join('_', split(parameters.distro, '-')) }}
   displayName: Build ${{ parameters.distro }} test container
   steps:
   - task: UsePythonVersion@0


### PR DESCRIPTION
This patch modify the pipelines to create stages using the 'each' expression on Azure pipelines, so that the configuration and the list of distributions can be set using variables.

Testing CentOS 8 Stream and Galaxy collections still need to be handled in a separate group, although, the pipeline configuration becomes easily changed, specially when updating Ansible versions.