### PR TITLE
upstream CI: Move scripts that evaluate repo changes to infra/azure

### DIFF
--- a/infra/azure/scripts/get_test_modules.py
+++ b/infra/azure/scripts/get_test_modules.py
@@ -159,7 +159,7 @@ def map_test_module_sources(base):
     """Create a map of 'test-modules' to 'plugin-sources', from 'base'."""
     # Find root directory of playbook tests.
     script_dir = os.path.dirname(__file__)
-    test_root = os.path.realpath(os.path.join(script_dir, f"../{base}"))
+    test_root = os.path.realpath(os.path.join(script_dir, f"../../../{base}"))
     # create modules:source_files map
     _result = {}
     for test_module in [d for d in os.scandir(test_root) if d.is_dir()]:
@@ -170,7 +170,7 @@ def map_test_module_sources(base):
 
 
 def usage(err=0):
-    print("filter_plugins.py [-h|--help] [-p|--pytest] PY_SRC...")
+    print("get_test_modules.py [-h|--help] [-p|--pytest] PY_SRC...")
     print(
         """
 Print a comma-separated list of modules that should be tested if

--- a/infra/azure/scripts/set_test_modules
+++ b/infra/azure/scripts/set_test_modules
@@ -11,7 +11,8 @@ die() {
     echo -e "${RED}${*}${RST}" >&2
 }
 
-TOPDIR="$(dirname "${BASH_SOURCE[0]}")/.."
+BASEDIR="$(readlink -f "$(dirname "${BASH_SOURCE[0]}")")"
+TOPDIR="$(readlink -f "${BASEDIR}/../../..")"
 
 [ -n "$(command -v python3)" ] && python="$(command -v python3)" || python="$(command -v python2)"
 
@@ -41,7 +42,7 @@ then
     git remote remove "${remote}"
 
     # shellcheck disable=SC2046
-    enabled_modules="$(${python} utils/get_test_modules.py $(cat "${files_list}"))"
+    enabled_modules="$(${python} "${BASEDIR}/get_test_modules.py" $(cat "${files_list}"))"
     [ -z "${enabled_modules}" ] && enabled_modules="None"
 
     # Get individual tests that should be executed

--- a/infra/azure/templates/run_tests.yml
+++ b/infra/azure/templates/run_tests.yml
@@ -46,7 +46,7 @@ jobs:
     displayName: Set repo rootdir
 
   - script: |
-      . "${TOPDIR}/utils/set_test_modules"
+      . "${TOPDIR}/infra/azure/scripts/set_test_modules"
       python3 utils/check_test_configuration.py ${{ parameters.distro }}
     displayName: Check test configuration
     env:
@@ -65,7 +65,7 @@ jobs:
       echo "ROLES: ${ANSIBLE_ROLES_PATH}"
       echo "LIBRARY: ${ANSIBLE_LIBRARY}"
       echo "MODULE_UTILS: ${ANSIBLE_MODULE_UTILS}"
-      . "${TOPDIR}/utils/set_test_modules"
+      . "${TOPDIR}/infra/azure/scripts/set_test_modules"
       [ "${{ parameters.test_galaxy }}" == "True"  ] && cd ~/.ansible/collections/ansible_collections/freeipa/ansible_freeipa
       pytest \
           -m "${{ parameters.test_type }}" \


### PR DESCRIPTION
All scripts related to the Azure CI now reside on inrfa/azure, but the scripts that evaluate the changes made against ansible-freeipa's main development branch.

This patch move these scripts to the proper locations.