### PR TITLE
Update images to Fedora 41

### DIFF
--- a/infra/azure/templates/build_container.yml
+++ b/infra/azure/templates/build_container.yml
@@ -25,7 +25,7 @@ jobs:
   - script: ansible-galaxy collection install containers.podman
     displayName: Install Ansible Galaxy collections
 
-  - script: infra/image/build.sh -s ${{ parameters.distro }}
+  - script: infra/image/build.sh -p -s ${{ parameters.distro }}
     displayName: Build ${{ parameters.distro }} base image
     env:
       ANSIBLE_ROLES_PATH: "${PWD}/roles"

--- a/infra/image/dockerfile/fedora-latest
+++ b/infra/image/dockerfile/fedora-latest
@@ -6,7 +6,7 @@ dnf makecache; \
 dnf --assumeyes install \
     /usr/bin/python3 \
     /usr/bin/python3-config \
-    /usr/bin/dnf-3 \
+    python3-libdnf5 \
     sudo \
     bash \
     systemd \

--- a/infra/image/dockerfile/fedora-rawhide
+++ b/infra/image/dockerfile/fedora-rawhide
@@ -6,7 +6,6 @@ dnf makecache; \
 dnf --assumeyes install \
     /usr/bin/python3 \
     /usr/bin/python3-config \
-    /usr/bin/dnf-3 \
     python3-libdnf5 \
     sudo \
     bash \


### PR DESCRIPTION
With the release of Fedora 41 there's a need to include DNF 5 libraries so that the image can be built.

The PR also fixes the missing "--privileged" option required to deploy IPA in our container images.