### PR TITLE
linters: Remove pydocstyle from linter checks

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -34,21 +34,6 @@ jobs:
       - name: Run yaml-lint
         uses: ibiqlik/action-yamllint@v3.1.1
 
-  pydocstyle:
-    name: Verify pydocstyle
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4.1.1
-        with:
-          fetch-depth: 1
-      - uses: actions/setup-python@v5.1.0
-        with:
-          python-version: "3.x"
-      - name: Run pydocstyle
-        run: |
-            pip install pydocstyle
-            pydocstyle
-
   flake8:
     name: Verify flake8
     runs-on: ubuntu-latest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,10 +29,6 @@ repos:
   rev: 7.0.0
   hooks:
   - id: flake8
-- repo: https://github.com/pycqa/pydocstyle
-  rev: 6.3.0
-  hooks:
-  - id: pydocstyle
 - repo: https://github.com/pycqa/pylint
   rev: v3.2.2
   hooks:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,6 +5,5 @@ flake8==7.0.0
 flake8-bugbear
 pylint>=3.2
 wrapt==1.14.1
-pydocstyle==6.3.0
 yamllint==1.35.1
 ansible-lint>=24.5.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,10 +28,6 @@ per-file-ignores =
     plugins/*:E402
     roles/*:E402
 
-[pydocstyle]
-inherit = false
-ignore = D1,D212,D203
-
 [pylint.MASTER]
 disable =
     consider-using-f-string,  # f-string is not supported on Python2

--- a/utils/lint_check.sh
+++ b/utils/lint_check.sh
@@ -10,8 +10,6 @@ pushd "${topdir}/.." >/dev/null 2>&1  || exit 1
 
 echo -e "${INFO}Running 'flake8'...${RST}"
 flake8 plugins utils roles setup.py
-echo -e "${INFO}Running 'pydocstyle'...${RST}"
-pydocstyle plugins utils roles setup.py
 echo -e "${INFO}Running 'pylint'...${RST}"
 pylint plugins roles setup.py
 


### PR DESCRIPTION
Pydocstyle has been deprecated is no longer in development. It is also not a requirement for Ansible tests.

This patch removes pydocstyle from current checks performed.