### PR TITLE
infra/image/shcontainer: New container_copy and container_fetch

### DIFF
--- a/infra/image/shcontainer
+++ b/infra/image/shcontainer
@@ -175,3 +175,23 @@ container_image_list() {
 container_check() {
     [ -n "$(command -v "podman")" ] || die "podman is required."
 }
+
+container_copy() {
+    local name="${1}"
+    local source="${2}"
+    local destination="${3}"
+
+    log info "= Copying ${source} to ${name}:${destination} ="
+    podman cp "${source}" "${name}:${destination}"
+    echo
+}
+
+container_fetch() {
+    local name="${1}"
+    local source="${2}"
+    local destination="${3}"
+
+    log info "= Copying ${name}:${source} to ${destination} ="
+    podman cp "${name}:${source}" "${destination}"
+    echo
+}


### PR DESCRIPTION
container_copy can be used to copy a file to the container, container_fetch can be used to copy a file from the container.

For more information, please have a look at the podman-cp man page.