### PR TITLE
infra/image/dockerfile/c10s: Fix client part deployment for the server

### DIFF
--- a/infra/image/dockerfile/c10s
+++ b/infra/image/dockerfile/c10s
@@ -9,8 +9,15 @@ dnf --assumeyes install \
     bash \
     systemd \
     procps-ng \
-    iproute; \
+    iproute \
+    hostname; \
 rm -rf /var/cache/dnf/;
+
+# Prepare for basic ipa-server-install in container
+# Address failing nis-domainname.service in the ipa-client-install step
+RUN mv /usr/bin/nisdomainname /usr/bin/nisdomainname.orig
+ADD utils/hostnamectl-wrapper /usr/bin/nisdomainname
+RUN chmod a+rx /usr/bin/nisdomainname
 
 RUN (cd /lib/systemd/system/; \
     if [ -e dbus-broker.service ] && [ ! -e dbus.service ]; then \

--- a/infra/image/utils/hostnamectl-wrapper
+++ b/infra/image/utils/hostnamectl-wrapper
@@ -1,0 +1,12 @@
+#!/bin/bash -eu
+
+if setpriv --dump | grep -q sys_admin ; then
+	if [[ "$( basename $0 )" =~ "domainname" ]] ; then
+		/usr/bin/hostname -y "$@"
+	else
+		$0.orig "$@"
+	fi
+else
+	echo "Skipping invocation of $0 $@ in unprivileged container." >&2
+	exit
+fi


### PR DESCRIPTION
The client part deployment fails in the configuration of NIS. The command /usr/bin/nisdomainname is failing in a container in this task as the container is not privileged.

The hostnamectl-wrapper is copied from the freeipa-container container project to replace /usr/bin/nisdomainname in the container.