### PR TITLE
modules: Do not hide errors using IPA *_show command with Exception

### DIFF
--- a/plugins/modules/ipaautomountmap.py
+++ b/plugins/modules/ipaautomountmap.py
@@ -106,7 +106,7 @@ RETURN = '''
 '''
 
 from ansible.module_utils.ansible_freeipa_module import (
-    IPAAnsibleModule, compare_args_ipa
+    IPAAnsibleModule, compare_args_ipa, ipalib_errors
 )
 
 
@@ -124,7 +124,7 @@ class AutomountMap(IPAAnsibleModule):
                 location,
                 {"automountmapname": name, "all": True}
             )
-        except Exception:  # pylint: disable=broad-except
+        except ipalib_errors.NotFound:
             return None
         return response["result"]
 
@@ -132,7 +132,7 @@ class AutomountMap(IPAAnsibleModule):
         """Check if 'name' is an indirect map for 'parentmap'."""
         try:
             maps = self.ipa_command("automountmap_find", location, {})
-        except Exception:  # pylint: disable=broad-except
+        except ipalib_errors.NotFound:
             return []
 
         result = []

--- a/plugins/modules/ipaconfig.py
+++ b/plugins/modules/ipaconfig.py
@@ -356,7 +356,7 @@ def config_show(module):
 def get_netbios_name(module):
     try:
         _result = module.ipa_command_no_name("trustconfig_show", {"all": True})
-    except Exception:  # pylint: disable=broad-except
+    except ipalib_errors.NotFound:
         return None
     return _result["result"]["ipantflatname"][0]
 

--- a/plugins/modules/ipadelegation.py
+++ b/plugins/modules/ipadelegation.py
@@ -124,14 +124,14 @@ RETURN = """
 
 
 from ansible.module_utils.ansible_freeipa_module import \
-    IPAAnsibleModule, compare_args_ipa
+    IPAAnsibleModule, compare_args_ipa, ipalib_errors
 
 
 def find_delegation(module, name):
     """Find if a delegation with the given name already exist."""
     try:
         _result = module.ipa_command("delegation_show", name, {"all": True})
-    except Exception:  # pylint: disable=broad-except
+    except ipalib_errors.NotFound:
         # An exception is raised if delegation name is not found.
         return None
     return _result["result"]

--- a/plugins/modules/ipaidoverridegroup.py
+++ b/plugins/modules/ipaidoverridegroup.py
@@ -155,7 +155,7 @@ RETURN = """
 
 
 from ansible.module_utils.ansible_freeipa_module import \
-    IPAAnsibleModule, compare_args_ipa
+    IPAAnsibleModule, compare_args_ipa, ipalib_errors
 from ansible.module_utils import six
 
 if six.PY3:
@@ -168,7 +168,7 @@ def find_idoverridegroup(module, idview, anchor):
         _result = module.ipa_command("idoverridegroup_show", idview,
                                      {"ipaanchoruuid": anchor,
                                       "all": True})
-    except Exception:  # pylint: disable=broad-except
+    except ipalib_errors.NotFound:
         # An exception is raised if idoverridegroup anchor is not found.
         return None
     return _result["result"]

--- a/plugins/modules/ipaidoverrideuser.py
+++ b/plugins/modules/ipaidoverrideuser.py
@@ -315,7 +315,8 @@ RETURN = """
 
 from ansible.module_utils.ansible_freeipa_module import \
     IPAAnsibleModule, compare_args_ipa, gen_add_del_lists, gen_add_list, \
-    gen_intersection_list, encode_certificate, convert_input_certificates
+    gen_intersection_list, encode_certificate, convert_input_certificates, \
+    ipalib_errors
 from ansible.module_utils import six
 
 if six.PY3:
@@ -328,7 +329,7 @@ def find_idoverrideuser(module, idview, anchor):
         _result = module.ipa_command("idoverrideuser_show", idview,
                                      {"ipaanchoruuid": anchor,
                                       "all": True})
-    except Exception:  # pylint: disable=broad-except
+    except ipalib_errors.NotFound:
         # An exception is raised if idoverrideuser anchor is not found.
         return None
 

--- a/plugins/modules/ipaidp.py
+++ b/plugins/modules/ipaidp.py
@@ -184,7 +184,8 @@ RETURN = """
 
 
 from ansible.module_utils.ansible_freeipa_module import \
-    IPAAnsibleModule, compare_args_ipa, template_str, urlparse
+    IPAAnsibleModule, compare_args_ipa, template_str, urlparse, \
+    ipalib_errors
 from ansible.module_utils import six
 from copy import deepcopy
 import string
@@ -269,7 +270,7 @@ def find_idp(module, name):
     """Find if a idp with the given name already exist."""
     try:
         _result = module.ipa_command("idp_show", name, {"all": True})
-    except Exception:  # pylint: disable=broad-except
+    except ipalib_errors.NotFound:
         # An exception is raised if idp name is not found.
         return None
 

--- a/plugins/modules/ipaidrange.py
+++ b/plugins/modules/ipaidrange.py
@@ -143,7 +143,8 @@ RETURN = """
 
 
 from ansible.module_utils.ansible_freeipa_module import \
-    IPAAnsibleModule, compare_args_ipa, get_trusted_domain_sid_from_name
+    IPAAnsibleModule, compare_args_ipa, get_trusted_domain_sid_from_name, \
+    ipalib_errors
 from ansible.module_utils import six
 
 if six.PY3:
@@ -154,7 +155,7 @@ def find_idrange(module, name):
     """Find if a idrange with the given name already exist."""
     try:
         _result = module.ipa_command("idrange_show", name, {"all": True})
-    except Exception:  # pylint: disable=broad-except
+    except ipalib_errors.NotFound:
         # An exception is raised if idrange name is not found.
         return None
     return _result["result"]

--- a/plugins/modules/ipaidview.py
+++ b/plugins/modules/ipaidview.py
@@ -138,7 +138,7 @@ def find_idview(module, name):
     """Find if a idview with the given name already exist."""
     try:
         _result = module.ipa_command("idview_show", name, {"all": True})
-    except Exception:  # pylint: disable=broad-except
+    except ipalib_errors.NotFound:
         # An exception is raised if idview name is not found.
         return None
     return _result["result"]

--- a/plugins/modules/ipalocation.py
+++ b/plugins/modules/ipalocation.py
@@ -76,14 +76,14 @@ RETURN = """
 
 
 from ansible.module_utils.ansible_freeipa_module import \
-    IPAAnsibleModule, compare_args_ipa
+    IPAAnsibleModule, compare_args_ipa, ipalib_errors
 
 
 def find_location(module, name):
     """Find if a location with the given name already exist."""
     try:
         _result = module.ipa_command("location_show", name, {"all": True})
-    except Exception:  # pylint: disable=broad-except
+    except ipalib_errors.NotFound:
         # An exception is raised if location name is not found.
         return None
     return _result["result"]

--- a/plugins/modules/ipapermission.py
+++ b/plugins/modules/ipapermission.py
@@ -154,14 +154,14 @@ RETURN = """
 
 
 from ansible.module_utils.ansible_freeipa_module import \
-    IPAAnsibleModule, compare_args_ipa, to_text
+    IPAAnsibleModule, compare_args_ipa, to_text, ipalib_errors
 
 
 def find_permission(module, name):
     """Find if a permission with the given name already exist."""
     try:
         _result = module.ipa_command("permission_show", name, {"all": True})
-    except Exception:  # pylint: disable=broad-except
+    except ipalib_errors.NotFound:
         # An exception is raised if permission name is not found.
         return None
     _res = _result["result"]

--- a/plugins/modules/ipaprivilege.py
+++ b/plugins/modules/ipaprivilege.py
@@ -124,7 +124,7 @@ RETURN = """
 
 from ansible.module_utils.ansible_freeipa_module import \
     IPAAnsibleModule, compare_args_ipa, gen_add_del_lists, gen_add_list, \
-    gen_intersection_list
+    gen_intersection_list, ipalib_errors
 from ansible.module_utils import six
 
 if six.PY3:
@@ -135,7 +135,7 @@ def find_privilege(module, name):
     """Find if a privilege with the given name already exist."""
     try:
         _result = module.ipa_command("privilege_show", name, {"all": True})
-    except Exception:  # pylint: disable=broad-except
+    except ipalib_errors.NotFound:
         # An exception is raised if privilege name is not found.
         return None
     return _result["result"]

--- a/plugins/modules/iparole.py
+++ b/plugins/modules/iparole.py
@@ -129,7 +129,7 @@ EXAMPLES = """
 from ansible.module_utils._text import to_text
 from ansible.module_utils.ansible_freeipa_module import \
     IPAAnsibleModule, gen_add_del_lists, compare_args_ipa, \
-    gen_intersection_list, ensure_fqdn
+    gen_intersection_list, ensure_fqdn, ipalib_errors
 from ansible.module_utils import six
 
 if six.PY3:
@@ -140,7 +140,7 @@ def find_role(module, name):
     """Find if a role with the given name already exist."""
     try:
         _result = module.ipa_command("role_show", name, {"all": True})
-    except Exception:  # pylint: disable=broad-except
+    except ipalib_errors.NotFound:
         # An exception is raised if role name is not found.
         return None
     return _result["result"]

--- a/plugins/modules/ipaselfservice.py
+++ b/plugins/modules/ipaselfservice.py
@@ -113,14 +113,14 @@ RETURN = """
 
 
 from ansible.module_utils.ansible_freeipa_module import \
-    IPAAnsibleModule, compare_args_ipa
+    IPAAnsibleModule, compare_args_ipa, ipalib_errors
 
 
 def find_selfservice(module, name):
     """Find if a selfservice with the given name already exist."""
     try:
         _result = module.ipa_command("selfservice_show", name, {"all": True})
-    except Exception:  # pylint: disable=broad-except
+    except ipalib_errors.NotFound:
         # An exception is raised if selfservice name is not found.
         return None
     return _result["result"]

--- a/plugins/modules/ipaserver.py
+++ b/plugins/modules/ipaserver.py
@@ -192,14 +192,14 @@ RETURN = """
 
 
 from ansible.module_utils.ansible_freeipa_module import \
-    IPAAnsibleModule, compare_args_ipa, DNSName
+    IPAAnsibleModule, compare_args_ipa, DNSName, ipalib_errors
 
 
 def find_server(module, name):
     """Find if a server with the given name already exist."""
     try:
         _result = module.ipa_command("server_show", name, {"all": True})
-    except Exception:  # pylint: disable=broad-except
+    except ipalib_errors.NotFound:
         # An exception is raised if server name is not found.
         return None
     return _result["result"]
@@ -214,7 +214,7 @@ def server_role_status(module, name):
                                               "include_master": True,
                                               "raw": True,
                                               "all": True})
-    except Exception:  # pylint: disable=broad-except
+    except ipalib_errors.NotFound:
         # An exception is raised if server name is not found.
         return None
     return _result["result"][0]

--- a/plugins/modules/ipaservicedelegationrule.py
+++ b/plugins/modules/ipaservicedelegationrule.py
@@ -142,7 +142,7 @@ def find_servicedelegationrule(module, name):
     try:
         _result = module.ipa_command("servicedelegationrule_show", name,
                                      {"all": True})
-    except Exception:  # pylint: disable=broad-except
+    except ipalib_errors.NotFound:
         # An exception is raised if servicedelegationrule name is not found.
         return None
     return _result["result"]

--- a/plugins/modules/ipaservicedelegationtarget.py
+++ b/plugins/modules/ipaservicedelegationtarget.py
@@ -106,7 +106,7 @@ RETURN = """
 
 from ansible.module_utils.ansible_freeipa_module import \
     IPAAnsibleModule, gen_add_del_lists, gen_add_list, gen_intersection_list, \
-    servicedelegation_normalize_principals
+    servicedelegation_normalize_principals, ipalib_errors
 from ansible.module_utils import six
 
 if six.PY3:
@@ -118,7 +118,7 @@ def find_servicedelegationtarget(module, name):
     try:
         _result = module.ipa_command("servicedelegationtarget_show", name,
                                      {"all": True})
-    except Exception:  # pylint: disable=broad-except
+    except ipalib_errors.NotFound:
         # An exception is raised if servicedelegationtarget name is not found.
         return None
     return _result["result"]

--- a/utils/templates/ipamodule+member.py.in
+++ b/utils/templates/ipamodule+member.py.in
@@ -113,7 +113,7 @@ RETURN = """
 
 from ansible.module_utils.ansible_freeipa_module import \
     IPAAnsibleModule, compare_args_ipa, gen_add_del_lists, gen_add_list, \
-    gen_intersection_list
+    gen_intersection_list, ipalib_errors
 from ansible.module_utils import six
 
 if six.PY3:
@@ -124,7 +124,7 @@ def find_$name(module, name):
     """Find if a $name with the given name already exist."""
     try:
         _result = module.ipa_command("$name_show", name, {"all": True})
-    except Exception:  # pylint: disable=broad-except
+    except ipalib_errors.NotFound:
         # An exception is raised if $name name is not found.
         return None
     return _result["result"]

--- a/utils/templates/ipamodule.py.in
+++ b/utils/templates/ipamodule.py.in
@@ -89,7 +89,7 @@ RETURN = """
 
 
 from ansible.module_utils.ansible_freeipa_module import \
-    IPAAnsibleModule, compare_args_ipa
+    IPAAnsibleModule, compare_args_ipa, ipalib_errors
 from ansible.module_utils import six
 
 if six.PY3:
@@ -100,7 +100,7 @@ def find_$name(module, name):
     """Find if a $name with the given name already exist."""
     try:
         _result = module.ipa_command("$name_show", name, {"all": True})
-    except Exception:  # pylint: disable=broad-except
+    except ipalib_errors.NotFound:
         # An exception is raised if $name name is not found.
         return None
     return _result["result"]


### PR DESCRIPTION
When searching for objects with *_show IPA API command, most plugins were hiding errors other than "ipalib_errors.NotFound" by handling the broad exception Exception instead.

This patch uses "ipalib_errors.NotFound" whenever "*_show" is used so that the only exception handled is when an object is not found. Other errors will not be handled making the module break as expected.

Fix #1312 