### PR TITLE
ipasudorule: Evaluate all members related to hosts and users

### DIFF
--- a/plugins/modules/ipasudorule.py
+++ b/plugins/modules/ipasudorule.py
@@ -710,7 +710,11 @@ def main():
 
                     # Generate addition and removal lists
                     host_add, host_del = gen_add_del_lists(
-                        entry.host, res_find.get('memberhost_host', []))
+                        entry.host, (
+                            list(res_find.get('memberhost_host', []))
+                            + list(res_find.get('externalhost', []))
+                        )
+                    )
 
                     hostgroup_add, hostgroup_del = gen_add_del_lists(
                         entry.hostgroup,
@@ -721,7 +725,11 @@ def main():
                         entry.hostmask, res_find.get('hostmask', []))
 
                     user_add, user_del = gen_add_del_lists(
-                        entry.user, res_find.get('memberuser_user', []))
+                        entry.user, (
+                            list(res_find.get('memberuser_user', []))
+                            + list(res_find.get('externaluser', []))
+                        )
+                    )
 
                     group_add, group_del = gen_add_del_lists(
                         entry.group, res_find.get('memberuser_group', []))
@@ -751,8 +759,7 @@ def main():
                     # the provided list against both users and external
                     # users list.
                     runasuser_add, runasuser_del = gen_add_del_lists(
-                        entry.runasuser,
-                        (
+                        entry.runasuser, (
                             list(res_find.get('ipasudorunas_user', []))
                             + list(res_find.get('ipasudorunasextuser', []))
                         )
@@ -785,7 +792,11 @@ def main():
                     # the sudorule already
                     if entry.host is not None:
                         host_add = gen_add_list(
-                            entry.host, res_find.get("memberhost_host"))
+                            entry.host, (
+                                list(res_find.get("memberhost_host", []))
+                                + list(res_find.get("externalhost", []))
+                            )
+                        )
                     if entry.hostgroup is not None:
                         hostgroup_add = gen_add_list(
                             entry.hostgroup,
@@ -796,7 +807,11 @@ def main():
                             entry.hostmask, res_find.get("hostmask"))
                     if entry.user is not None:
                         user_add = gen_add_list(
-                            entry.user, res_find.get("memberuser_user"))
+                            entry.user, (
+                                list(res_find.get('memberuser_user', []))
+                                + list(res_find.get('externaluser', []))
+                            )
+                        )
                     if entry.group is not None:
                         group_add = gen_add_list(
                             entry.group, res_find.get("memberuser_group"))
@@ -862,7 +877,11 @@ def main():
                     # in sudorule
                     if entry.host is not None:
                         host_del = gen_intersection_list(
-                            entry.host, res_find.get("memberhost_host"))
+                            entry.host, (
+                                list(res_find.get("memberhost_host", []))
+                                + list(res_find.get("externalhost", []))
+                            )
+                        )
 
                     if entry.hostgroup is not None:
                         hostgroup_del = gen_intersection_list(
@@ -876,7 +895,11 @@ def main():
 
                     if entry.user is not None:
                         user_del = gen_intersection_list(
-                            entry.user, res_find.get("memberuser_user"))
+                            entry.user, (
+                                list(res_find.get('memberuser_user', []))
+                                + list(res_find.get('externaluser', []))
+                            )
+                        )
 
                     if entry.group is not None:
                         group_del = gen_intersection_list(
@@ -911,8 +934,7 @@ def main():
                     # users list.
                     if entry.runasuser is not None:
                         runasuser_del = gen_intersection_list(
-                            entry.runasuser,
-                            (
+                            entry.runasuser, (
                                 list(res_find.get('ipasudorunas_user', []))
                                 + list(res_find.get('ipasudorunasextuser', []))
                             )

--- a/tests/sudorule/test_sudorule_user_host_external.yml
+++ b/tests/sudorule/test_sudorule_user_host_external.yml
@@ -1,0 +1,94 @@
+---
+- name: Test correct handling of users and hosts lists on ipasudorule
+  hosts: ipaserver
+  become: false
+  gather_facts: false
+  module_defaults:
+    ipauser:
+      ipaadmin_password: SomeADMINpassword
+    ipahost:
+      ipaadmin_password: SomeADMINpassword
+    ipasudorule:
+      ipaadmin_password: SomeADMINpassword
+  tasks:
+  - name: Ensure test state is valid
+    block:
+      - name: Ensure users are present
+        ipauser:
+          users:
+          - name: user_s1
+            first: user
+            last: s1
+          - name: user_s2
+            first: user
+            last: s2
+      - name: Ensure hosts are present
+        ipahost:
+          hosts:
+            - name: mytesthost1.ipadomain.test
+              force: true
+            - name: mytesthost1a.ipadomain.test
+              force: true
+      - name: Ensure sudorule_5a is absent
+        ipasudorule:
+          name: sudorule_5a
+          state: absent
+      - name: Ensule sudorule_5a is present with host masks and external hosts
+        ipasudorule:
+          name: sudorule_5a
+          hostmask: [192.168.221.0/24, 192.168.110.0/24]
+          host: [mytesthost1.ipa.test, mytesthost2.ipa.test]
+          user: [user_s1, user_s2]
+
+  - name: Ensure that sudorule remain present after remove their members(using action member).
+    block:
+      - name: Ensure sudorules members are absent
+        ipasudorule:
+          name: sudorule_5a
+          hostmask: 192.168.221.0/24
+          user: "user_s1"
+          host: "mytesthost1.ipa.test"
+          action: member
+          state: absent
+        register: result
+        failed_when: not result.changed or result.failed
+
+      - name: Ensure sudorules members are absent, again
+        ipasudorule:
+          name: sudorule_5a
+          hostmask: 192.168.221.0/24
+          user: "user_s1"
+          host: "mytesthost1.ipa.test"
+          action: member
+          state: absent
+        register: result
+        failed_when: result.changed or result.failed
+
+      - name: Check if other sudorule members are still present.
+        ipasudorule:
+          name: sudorule_5a
+          hostmask: 192.168.110.0/24
+          user: "user_s2"
+          host: "mytesthost2.ipa.test"
+          action: member
+        check_mode: true
+        register: result
+        failed_when: result.changed or result.failed
+
+  # cleanup
+
+  - name: Ensure test sudorule is absent
+    ipasudorule:
+      name: sudorule_5a
+      state: absent
+
+  - name: Ensure test hosts are absent
+    ipahost:
+      name: [mytesthost1.ipa.test, mytesthost1a.ipa.test]
+      state: absent
+
+  - name: Ensure test users are absent
+    ipauser:
+      name: [user_s1, user_s2]
+      state: absent
+...


### PR DESCRIPTION
When handling users and hosts is ipasudorule we were missing nome entry attributes returned from FreeIPA, which would cause the add/del lists to be incorrectly generated.

By adding the proper lists, both attributes are handled correctly.

A new test to verify the fix is added:

    tests/sudorule/test_sudorule_user_host_external.yml

Fixes https://issues.redhat.com/browse/RHEL-68439