### PR TITLE
utils/build-galaxy-release.sh: Do not create duplicates for role plugins

### DIFF
--- a/roles/ipaserver/module_utils/ansible_ipa_server.py
+++ b/roles/ipaserver/module_utils/ansible_ipa_server.py
@@ -23,7 +23,9 @@
 
 from __future__ import (absolute_import, division, print_function)
 
-__metaclass__ = type  # pylint: disable=invalid-name
+# pylint: disable=invalid-name
+__metaclass__ = type
+# pylint: enable=invalid-name
 
 __all__ = ["IPAChangeConf", "certmonger", "sysrestore", "root_logger",
            "ipa_generate_password", "run", "ScriptError", "services",

--- a/utils/build-galaxy-release.sh
+++ b/utils/build-galaxy-release.sh
@@ -140,21 +140,18 @@ sed -i -e "s/ansible.module_utils.ansible_freeipa_module/ansible_collections.${c
 
 python utils/create_action_group.py "meta/runtime.yml" "$collection_prefix"
 
-(cd plugins/module_utils && {
-    ln -sf ../../roles/*/module_utils/*.py .
-})
+mv roles/*/module_utils/*.py plugins/module_utils/
+rmdir roles/*/module_utils
 
-(cd plugins/modules && {
-    sed -i -e "s/ansible.module_utils.ansible_ipa_/ansible_collections.${collection_prefix}.plugins.module_utils.ansible_ipa_/" ../../roles/*/library/*.py
-    ln -sf ../../roles/*/library/*.py .
-})
+sed -i -e "s/ansible.module_utils.ansible_ipa_/ansible_collections.${collection_prefix}.plugins.module_utils.ansible_ipa_/" roles/*/library/*.py
+mv roles/*/library/*.py plugins/modules/
+rmdir roles/*/library
 
 # There are no action plugins anymore in the roles, therefore this section
 # is commneted out.
 #[ ! -x plugins/action ] && mkdir plugins/action
-#(cd plugins/action && {
-#    ln -sf ../../roles/*/action_plugins/*.py .
-#})
+#mv roles/*/action_plugins/*.py plugins/action/
+#rmdir roles/*/action_plugins
 
 # Adapt inventory plugin and inventory plugin README
 echo "Fixing inventory plugin and doc..."
@@ -181,19 +178,11 @@ find plugins/modules -name "*.py" -print0 |
     done
 echo -e "\033[AFixing examples in plugins/modules... \033[32;1mDONE\033[0m"
 
-echo "Fixing examples in roles/*/library..."
-find roles/*/library -name "*.py" -print0 |
-    while IFS= read -d '' -r line; do
-        python utils/galaxyfy-module-EXAMPLES.py "$line" \
-               "ipa" "$collection_prefix"
-    done
-echo -e "\033[AFixing examples in roles/*/library... \033[32;1mDONE\033[0m"
-
 echo "Fixing playbooks in roles/*/tasks..."
 for line in roles/*/tasks/*.yml; do
     python utils/galaxyfy-playbook.py "$line" "ipa" "$collection_prefix"
 done
-echo -e "\033[AFixing playbooks in roles/*tasks... \033[32;1mDONE\033[0m"
+echo -e "\033[AFixing playbooks in roles/*/tasks... \033[32;1mDONE\033[0m"
 
 echo "Fixing playbooks in playbooks..."
 find playbooks -name "*.yml" -print0 |


### PR DESCRIPTION
This change reduces the size of the Ansible collection and removes unused files.

While creating the collection, the role plugins have been linked into the global plugin folders, but a subsequent sed call replaced the links with changed files. The original files have also been changed with another sed call in the same way. This resulted in the duplication of the changed files.

The plugins of the roles are now moved into the global plugin folders and only changed there. The now empty plugin folders in the roles are removed.