### PR TITLE
Remove 'vars' files of unsupported distributions

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Supported Distributions
 -----------------------
 
 * RHEL/CentOS 7.4+
-* Fedora 26+
+* Fedora 40+
 * Ubuntu
 * Debian 10+ (ipaclient only, no server or replica!)
 
@@ -125,7 +125,7 @@ ansible-freeipa/plugins/module_utils to ~/.ansible/plugins/
 
 **RPM package**
 
-There are RPM packages available for Fedora 29+. These are installing the roles and modules into the global Ansible directories for `roles`, `plugins/modules` and `plugins/module_utils` in the `/usr/share/ansible` directory. Therefore is it possible to use the roles and modules without adapting the names like it is done in the example playbooks.
+There are RPM packages available for Fedora. These are installing the roles and modules into the global Ansible directories for `roles`, `plugins/modules` and `plugins/module_utils` in the `/usr/share/ansible` directory. Therefore is it possible to use the roles and modules without adapting the names like it is done in the example playbooks.
 
 **Ansible Galaxy**
 

--- a/roles/ipabackup/README.md
+++ b/roles/ipabackup/README.md
@@ -34,7 +34,7 @@ Supported Distributions
 
 * RHEL/CentOS 7.6+
 * CentOS Stream 8+
-* Fedora 26+
+* Fedora 40+
 * Ubuntu 16.04 and 18.04
 
 

--- a/roles/ipaclient/README.md
+++ b/roles/ipaclient/README.md
@@ -25,7 +25,7 @@ Supported Distributions
 
 * RHEL/CentOS 7.4+
 * CentOS Stream 8+
-* Fedora 26+
+* Fedora 40+
 * Ubuntu
 * Debian
 

--- a/roles/ipaclient/vars/Fedora-25.yml
+++ b/roles/ipaclient/vars/Fedora-25.yml
@@ -1,5 +1,0 @@
-# defaults file for ipaclient
-# vars/Fedora-25.yml
----
-ipaclient_packages: [ "ipa-client", "libselinux-python" ]
-# ansible_python_interpreter: '/usr/bin/python2'

--- a/roles/ipaclient/vars/Fedora-26.yml
+++ b/roles/ipaclient/vars/Fedora-26.yml
@@ -1,5 +1,0 @@
-# defaults file for ipaclient
-# vars/Fedora-26.yml
----
-ipaclient_packages: [ "ipa-client", "libselinux-python" ]
-# ansible_python_interpreter: '/usr/bin/python2'

--- a/roles/ipaclient/vars/RedHat-7.3.yml
+++ b/roles/ipaclient/vars/RedHat-7.3.yml
@@ -1,5 +1,0 @@
-# defaults file for ipaclient
-# vars/RedHat-7.3.yml
----
-ipaclient_packages: [ "ipa-client", "ipa-admintools", "libselinux-python" ]
-# ansible_python_interpreter: '/usr/bin/python2'

--- a/roles/ipareplica/README.md
+++ b/roles/ipareplica/README.md
@@ -28,7 +28,7 @@ Supported Distributions
 
 * RHEL/CentOS 7.6+
 * CentOS Stream 8+
-* Fedora 26+
+* Fedora 40+
 * Ubuntu 16.04 and 18.04
 
 

--- a/roles/ipareplica/vars/Fedora-25.yml
+++ b/roles/ipareplica/vars/Fedora-25.yml
@@ -1,7 +1,0 @@
-# defaults file for ipareplica
-# vars/Fedora-25.yml
----
-ipareplica_packages: [ "ipa-server", "libselinux-python" ]
-ipareplica_packages_dns: [ "ipa-server-dns" ]
-ipareplica_packages_adtrust: [ "ipa-server-trust-ad" ]
-ipareplica_packages_firewalld: [ "firewalld" ]

--- a/roles/ipareplica/vars/Fedora-26.yml
+++ b/roles/ipareplica/vars/Fedora-26.yml
@@ -1,7 +1,0 @@
-# defaults file for ipareplica
-# vars/Fedora-26.yml
----
-ipareplica_packages: [ "ipa-server", "libselinux-python" ]
-ipareplica_packages_dns: [ "ipa-server-dns" ]
-ipareplica_packages_adtrust: [ "ipa-server-trust-ad" ]
-ipareplica_packages_firewalld: [ "firewalld" ]

--- a/roles/ipareplica/vars/Fedora-27.yml
+++ b/roles/ipareplica/vars/Fedora-27.yml
@@ -1,7 +1,0 @@
-# defaults file for ipareplica
-# vars/Fedora-27.yml
----
-ipareplica_packages: [ "ipa-server", "libselinux-python" ]
-ipareplica_packages_dns: [ "ipa-server-dns" ]
-ipareplica_packages_adtrust: [ "ipa-server-trust-ad" ]
-ipareplica_packages_firewalld: [ "firewalld" ]

--- a/roles/ipaserver/README.md
+++ b/roles/ipaserver/README.md
@@ -25,7 +25,7 @@ Supported Distributions
 
 * RHEL/CentOS 7.6+
 * CentOS Stream 8+
-* Fedora 26+
+* Fedora 40+
 * Ubuntu 16.04 and 18.04
 
 

--- a/roles/ipaserver/vars/Fedora-25.yml
+++ b/roles/ipaserver/vars/Fedora-25.yml
@@ -1,7 +1,0 @@
-# defaults file for ipaserver
-# vars/Fedora-25.yml
----
-ipaserver_packages: [ "ipa-server", "libselinux-python" ]
-ipaserver_packages_dns: [ "ipa-server-dns" ]
-ipaserver_packages_adtrust: [ "ipa-server-trust-ad" ]
-ipaserver_packages_firewalld: [ "firewalld" ]

--- a/roles/ipaserver/vars/Fedora-26.yml
+++ b/roles/ipaserver/vars/Fedora-26.yml
@@ -1,7 +1,0 @@
-# defaults file for ipaserver
-# vars/Fedora-26.yml
----
-ipaserver_packages: [ "ipa-server", "libselinux-python" ]
-ipaserver_packages_dns: [ "ipa-server-dns" ]
-ipaserver_packages_adtrust: [ "ipa-server-trust-ad" ]
-ipaserver_packages_firewalld: [ "firewalld" ]

--- a/roles/ipaserver/vars/Fedora-27.yml
+++ b/roles/ipaserver/vars/Fedora-27.yml
@@ -1,7 +1,0 @@
-# defaults file for ipaserver
-# vars/Fedora-27.yml
----
-ipaserver_packages: [ "ipa-server", "libselinux-python" ]
-ipaserver_packages_dns: [ "ipa-server-dns" ]
-ipaserver_packages_adtrust: [ "ipa-server-trust-ad" ]
-ipaserver_packages_firewalld: [ "firewalld" ]

--- a/roles/ipasmartcard_client/README.md
+++ b/roles/ipasmartcard_client/README.md
@@ -25,7 +25,7 @@ Supported Distributions
 
 * RHEL/CentOS 7.6+
 * CentOS Stream 8+
-* Fedora 26+
+* Fedora 40+
 
 
 Requirements

--- a/roles/ipasmartcard_server/README.md
+++ b/roles/ipasmartcard_server/README.md
@@ -27,7 +27,7 @@ Supported Distributions
 
 * RHEL/CentOS 7.6+
 * CentOS Stream 8+
-* Fedora 26+
+* Fedora 40+
 
 
 Requirements


### PR DESCRIPTION
This patch removes 'vars' files from roles for unsupported distributions and change minimum supported Fedora to version 34+.