### PR TITLE
Cache sys.stdout instead of assuming it is equal to sys.__stdout__

### DIFF
--- a/roles/ipareplica/module_utils/ansible_ipa_replica.py
+++ b/roles/ipareplica/module_utils/ansible_ipa_replica.py
@@ -208,11 +208,13 @@ def setup_logging():
 
 @contextlib_contextmanager
 def redirect_stdout(stream):
+    old_stdout = sys.stdout
+
     sys.stdout = stream
     try:
         yield stream
     finally:
-        sys.stdout = sys.__stdout__
+        sys.stdout = old_stdout
 
 
 class AnsibleModuleLog():

--- a/roles/ipaserver/module_utils/ansible_ipa_server.py
+++ b/roles/ipaserver/module_utils/ansible_ipa_server.py
@@ -241,11 +241,13 @@ def setup_logging():
 
 @contextlib_contextmanager
 def redirect_stdout(stream):
+    old_stdout = sys.stdout
+
     sys.stdout = stream
     try:
         yield stream
     finally:
-        sys.stdout = sys.__stdout__
+        sys.stdout = old_stdout
 
 
 class AnsibleModuleLog():


### PR DESCRIPTION
When running under Mitogen, ipa_server and ipa_replica breaks execution by overwriting sys.stdout with sys.stdout.

With Mitogen, sys.stdout != sys.stdout at this point in the code, and changing it in this manner results in access to closed file descriptors for future invocations. Generally, it is recommended not to use sys.stdout and instead explicitly cache the current value of sys.stdout as proposed in this PR.
