### PR TITLE
[WIP] upstream CI: Update runner images to Ubuntu 24.04

### DIFF
--- a/infra/azure/azure-pipelines.yml
+++ b/infra/azure/azure-pipelines.yml
@@ -3,7 +3,7 @@ trigger:
 - master
 
 pool:
-  vmImage: 'ubuntu-20.04'
+  vmImage: 'ubuntu-24.04'
 
 variables:
   ansible_version: "-core >=2.16,<2.17"

--- a/infra/azure/nightly.yml
+++ b/infra/azure/nightly.yml
@@ -10,7 +10,7 @@ schedules:
 trigger: none
 
 pool:
-  vmImage: 'ubuntu-20.04'
+  vmImage: 'ubuntu-24.04'
 
 variables:
   # We need to have two sets, as c8s is not supported by all ansible versions

--- a/infra/azure/pr-pipeline.yml
+++ b/infra/azure/pr-pipeline.yml
@@ -3,7 +3,7 @@ trigger:
 - master
 
 pool:
-  vmImage: 'ubuntu-20.04'
+  vmImage: 'ubuntu-24.04'
 
 variables:
   distros: "fedora-latest,c10s,c9s,c8s,fedora-rawhide"


### PR DESCRIPTION
Current upstream hosts use Ubuntu 20.04 images which will be fully unsupported by 2025-04-01.

Update runners to use Ubuntu 24.04.

See: https://github.com/actions/runner-images/issues/11101