### PR TITLE
tests/idoverrideuser: Fix client context test when running on client

### DIFF
--- a/tests/idoverrideuser/test_idoverrideuser_client_context.yml
+++ b/tests/idoverrideuser/test_idoverrideuser_client_context.yml
@@ -16,7 +16,8 @@
     ipaidoverrideuser:
       ipaadmin_password: SomeADMINpassword
       ipaapi_context: server
-      name: ThisShouldNotWork
+      idview: ThisShouldNotWork
+      anchor: ThisShouldNotWork
     register: result
     failed_when: not (result.failed and result.msg is regex("No module named '*ipaserver'*"))
     when: ipa_host_is_client


### PR DESCRIPTION
When running test_idoverrideuser_client_context.yml on a client host, it tried to run a task that does not have the required fields and fails the test.