### PR TITLE
ipagroup: Fix test for externalmember use in client context

### DIFF
--- a/plugins/modules/ipagroup.py
+++ b/plugins/modules/ipagroup.py
@@ -581,8 +581,8 @@ def main():
                 "https://pagure.io/freeipa/issue/9349")
 
     if (
-        externalmember is not None
-        or idoverrideuser is not None
+        (externalmember is not None
+         or idoverrideuser is not None)
         and context == "client"
     ):
         ansible_module.fail_json(


### PR DESCRIPTION
The test has been changed with the management fix for AD objects. The conditional was lacking brackets and therefore did not properly work. The brackets have been added.

Related: https://issues.redhat.com/browse/RHEL-70023