### PR TITLE
ipa* deployment roles: Hotfix for dns_over_tls (Freeipa#7343)

### DIFF
--- a/roles/ipaclient/library/ipaclient_setup_nss.py
+++ b/roles/ipaclient/library/ipaclient_setup_nss.py
@@ -279,6 +279,7 @@ def main():
     options.no_sssd = False
     options.sssd = not options.no_sssd
     options.no_ac = False
+    options.dns_over_tls = False
     nosssd_files = module.params.get('nosssd_files')
     selinux_works = module.params.get('selinux_works')
     krb_name = module.params.get('krb_name')
@@ -376,7 +377,12 @@ def main():
             ssh_config_dir = paths.SSH_CONFIG_DIR
         else:
             ssh_config_dir = services.knownservices.sshd.get_config_dir()
-        update_ssh_keys(hostname, ssh_config_dir, options.create_sshfp)
+        argspec_update_ssh_keys = getargspec(update_ssh_keys)
+        # Hotfix for https://github.com/freeipa/freeipa/pull/7343
+        if "options" in argspec_update_ssh_keys.args:
+            update_ssh_keys(hostname, ssh_config_dir, options, cli_server[0])
+        else:
+            update_ssh_keys(hostname, ssh_config_dir, options.create_sshfp)
 
         try:
             os.remove(CCACHE_FILE)

--- a/roles/ipareplica/module_utils/ansible_ipa_replica.py
+++ b/roles/ipareplica/module_utils/ansible_ipa_replica.py
@@ -331,6 +331,13 @@ options.add_agents = False
 # ServerReplicaInstall
 options.subject_base = None
 options.ca_subject = None
+
+# Hotfix for https://github.com/freeipa/freeipa/pull/7343
+options.dns_over_tls = False
+options.dns_over_tls_key = None
+options.dns_over_tls_cert = None
+options.dot_forwarders = None
+options.dns_policy = None
 # pylint: enable=attribute-defined-outside-init
 
 

--- a/roles/ipaserver/module_utils/ansible_ipa_server.py
+++ b/roles/ipaserver/module_utils/ansible_ipa_server.py
@@ -354,6 +354,13 @@ options.add_agents = False
 # no_msdcs is deprecated
 options.no_msdcs = False
 
+# Hotfix for https://github.com/freeipa/freeipa/pull/7343
+options.dns_over_tls = False
+options.dns_over_tls_key = None
+options.dns_over_tls_cert = None
+options.dot_forwarders = None
+options.dns_policy = None
+
 # For pylint
 options.external_cert_files = None
 options.dirsrv_cert_files = None


### PR DESCRIPTION
This is a hotfix to allow deployments of clients, replicas and servers with the dns_over_tls PR for freeipa: https://github.com/freeipa/freeipa/pull/7343/

ipaclient: client.update_ssh_keys has changed parameters, options.dns_over_tls needs to be set for ipaclient_setup_nss.

ipareplica, ipaserver: Set new parameters globally in module_utils so far: options.dns_over_tls, options.dns_over_tls_key, options.dns_over_tls_cert, options.dot_forwarders and options.dns_policy.

The enablement for DNS over TLS for the deployment roles will be done later on.