### PR TITLE
ipaconfig: Validate emaildomain

### DIFF
--- a/plugins/module_utils/ansible_freeipa_module.py
+++ b/plugins/module_utils/ansible_freeipa_module.py
@@ -33,7 +33,7 @@ __all__ = ["DEBUG_COMMAND_ALL", "DEBUG_COMMAND_LIST",
            "paths", "tasks", "get_credentials_if_valid", "Encoding",
            "DNSName", "getargspec", "certificate_loader",
            "write_certificate_list", "boolean", "template_str",
-           "urlparse", "normalize_sshpubkey"]
+           "urlparse", "normalize_sshpubkey", "Email"]
 
 DEBUG_COMMAND_ALL = 0b1111
 # Print the while command list:
@@ -116,6 +116,7 @@ try:
     from ipalib.krb_utils import get_credentials_if_valid
     from ipapython.dnsutil import DNSName
     from ipapython import kerberos
+    from ipapython.ipavalidate import Email
 
     try:
         from ipalib.x509 import Encoding

--- a/plugins/modules/ipaconfig.py
+++ b/plugins/modules/ipaconfig.py
@@ -344,7 +344,7 @@ config:
 
 
 from ansible.module_utils.ansible_freeipa_module import \
-    IPAAnsibleModule, compare_args_ipa, ipalib_errors
+    IPAAnsibleModule, compare_args_ipa, ipalib_errors, Email
 
 
 def config_show(module):
@@ -514,6 +514,13 @@ def main():
             ansible_module.fail_json(
                 msg="Argument '%s' must be between %d and %d."
                     % (arg, minimum, maximum))
+
+    # verify email domain
+    emaildomain = params.get("ipadefaultemaildomain", None)
+    if emaildomain:
+        if not Email("test@{0}".format(emaildomain)):
+            ansible_module.fail_json(
+                msg="Invalid 'emaildomain' value: %s" % emaildomain)
 
     changed = False
     exit_args = {}

--- a/tests/config/test_config.yml
+++ b/tests/config/test_config.yml
@@ -34,6 +34,16 @@
           ipaapi_context: "{{ ipa_context | default(omit) }}"
           emaildomain: ipa.test
 
+      - name: Ensure the default e-mail domain cannot be set to an invalid email domain.
+        ipaconfig:
+          ipaadmin_password: SomeADMINpassword
+          ipaapi_context: "{{ ipa_context | default(omit) }}"
+          emaildomain: invalid@emaildomain
+        register: invalid_emaildomain
+        failed_when:
+          invalid_emaildomain.changed
+          or not (invalid_emaildomain.failed and "Invalid 'emaildomain' value:" in invalid_emaildomain.msg)
+
       - name: Set default shell to '/bin/sh'
         ipaconfig:
           ipaadmin_password: SomeADMINpassword


### PR DESCRIPTION
When setting the default email domain, there was no validation on the provide value. Using ipapython.validate.Email applies the same validation method as implemented in IPA.