### PR TITLE
Fix issue #1346 - fix sssd options for ipaclient install

### DIFF
--- a/roles/ipaclient/tasks/install.yml
+++ b/roles/ipaclient/tasks/install.yml
@@ -70,7 +70,7 @@
     all_ip_addresses: "{{ ipaclient_all_ip_addresses }}"
     on_master: "{{ ipaclient_on_master }}"
     ### sssd ###
-    enable_dns_updates: "{{ ipassd_enable_dns_updates
+    enable_dns_updates: "{{ ipasssd_enable_dns_updates
                             | default(ipasssd_enable_dns_updates) }}"
   register: result_ipaclient_test
 
@@ -321,15 +321,15 @@
         no_sshd: "{{ ipaclient_no_sshd }}"
         no_sudo: "{{ ipaclient_no_sudo }}"
         all_ip_addresses: "{{ ipaclient_all_ip_addresses }}"
-        fixed_primary: "{{ ipassd_fixed_primary
+        fixed_primary: "{{ ipasssd_fixed_primary
                            | default(ipasssd_fixed_primary) }}"
-        permit: "{{ ipassd_permit | default(ipasssd_permit) }}"
-        enable_dns_updates: "{{ ipassd_enable_dns_updates
+        permit: "{{ ipasssd_permit | default(ipasssd_permit) }}"
+        enable_dns_updates: "{{ ipasssd_enable_dns_updates
                                 | default(ipasssd_enable_dns_updates) }}"
-        preserve_sssd: "{{ ipassd_preserve_sssd
+        preserve_sssd: "{{ ipasssd_preserve_sssd
                            | default(ipasssd_preserve_sssd) }}"
         no_krb5_offline_passwords:
-          "{{ ipassd_no_krb5_offline_passwords
+          "{{ ipasssd_no_krb5_offline_passwords
               | default(ipasssd_no_krb5_offline_passwords) }}"
 
     - name: Install - IPA API calls for remaining enrollment parts
@@ -365,22 +365,22 @@
         ca_enabled: "{{ result_ipaclient_api.ca_enabled }}"
         on_master: "{{ ipaclient_on_master }}"
         dnsok: "{{ result_ipaclient_test.dnsok }}"
-        enable_dns_updates: "{{ ipassd_enable_dns_updates
+        enable_dns_updates: "{{ ipasssd_enable_dns_updates
                                 | default(ipasssd_enable_dns_updates) }}"
         all_ip_addresses: "{{ ipaclient_all_ip_addresses }}"
         ip_addresses: "{{ ipaclient_ip_addresses | default(omit) }}"
         request_cert: "{{ ipaclient_request_cert }}"
-        preserve_sssd: "{{ ipassd_preserve_sssd
+        preserve_sssd: "{{ ipasssd_preserve_sssd
                            | default(ipasssd_preserve_sssd) }}"
         no_ssh: "{{ ipaclient_no_ssh }}"
         no_sshd: "{{ ipaclient_no_sshd }}"
         no_sudo: "{{ ipaclient_no_sudo }}"
         subid: "{{ ipaclient_subid }}"
-        fixed_primary: "{{ ipassd_fixed_primary
+        fixed_primary: "{{ ipasssd_fixed_primary
                            | default(ipasssd_fixed_primary) }}"
-        permit: "{{ ipassd_permit | default(ipasssd_permit) }}"
+        permit: "{{ ipasssd_permit | default(ipasssd_permit) }}"
         no_krb5_offline_passwords:
-          "{{ ipassd_no_krb5_offline_passwords
+          "{{ ipasssd_no_krb5_offline_passwords
               | default(ipasssd_no_krb5_offline_passwords) }}"
         no_dns_sshfp: "{{ ipaclient_no_dns_sshfp }}"
         nosssd_files: "{{ result_ipaclient_test.nosssd_files }}"


### PR DESCRIPTION
Fix to the role ipaclient found in [#1346](https://github.com/freeipa/ansible-freeipa/issues/1346):

`roles/ipaclient`

more specifically:

`roles/ipaclient/tasks/install.yml`

Previous variable naming schemes did not match the default values found in roles/ipaclient/defaults/main.yml, causing issues with the documented SSSD IPA client options. Role only used default variables for SSSD configuration.

This role allows to join hosts as clients to an IPA domain. This can be done in different ways using auto-discovery of the servers, domain and other settings or by specifying them.

Here is the documentation for the role (not changed):

`roles/ipaclient/README.md`