### PR TITLE
Fix CA certificates iteration

### DIFF
--- a/roles/ipaclient/library/ipaclient_setup_nss.py
+++ b/roles/ipaclient/library/ipaclient_setup_nss.py
@@ -340,17 +340,19 @@ def main():
                                                       ca_subject)
         ca_certs_trust = [(c, n,
                            certstore.key_policy_to_trust_flags(t, True, u))
-                          for (c, n, t, u) in ca_certs]
+                          for (c, n, t, u) in [x[0:4] for x in ca_certs]]
 
         if hasattr(paths, "KDC_CA_BUNDLE_PEM"):
             x509.write_certificate_list(
-                [c for c, n, t, u in ca_certs if t is not False],
+                [c for c, n, t, u in [x[0:4] for x in ca_certs]
+                    if t is not False],
                 paths.KDC_CA_BUNDLE_PEM,
                 # mode=0o644
             )
         if hasattr(paths, "CA_BUNDLE_PEM"):
             x509.write_certificate_list(
-                [c for c, n, t, u in ca_certs if t is not False],
+                [c for c, n, t, u in [x[0:4] for x in ca_certs]
+                    if t is not False],
                 paths.CA_BUNDLE_PEM,
                 # mode=0o644
             )


### PR DESCRIPTION
FreeIPA fix for https://pagure.io/freeipa/issue/9652 now produces five elements tuple when iterating over CA certificate list, the last element being the serial number. We do not need it, so extract only the first four elements (certificate, nickname, trusted, EKU).

The regression was introduced by FreeIPA commit
f91b677ada376034b25d50e78475237c5976770e.

## Summary by Sourcery

Bug Fixes:
- Fix regression in FreeIPA certificate processing that introduced an extra element (serial number) when iterating over CA certificates