### PR TITLE
ipareplica: Don't rely on pkg_resources whenever possible

### DIFF
--- a/roles/ipareplica/module_utils/ansible_ipa_replica.py
+++ b/roles/ipareplica/module_utils/ansible_ipa_replica.py
@@ -80,6 +80,13 @@ except ImportError:
 try:
     from contextlib import contextmanager as contextlib_contextmanager
     from ipapython.version import NUM_VERSION, VERSION
+    try:
+        from ipapython.version import parse_version
+    except ImportError:
+        # In IPA we either need pkg_resources or packaging Version
+        # class to compare versions with check_remote_version, so
+        # we let an exception to be raised if neither is available.
+        from pkg_resources import parse_version
 
     if NUM_VERSION < 30201:
         # See ipapython/version.py
@@ -98,8 +105,6 @@ try:
         import dns.name as dnsname
         import dns.resolver as dnsresolver
         import dns.reversename as dnsreversename
-
-        from pkg_resources import parse_version
 
         from ipaclient.install.ipachangeconf import IPAChangeConf
         from ipalib.install import certstore, sysrestore


### PR DESCRIPTION
Python's module "pkg_resources" API has been deprecated in Python 3.12 and will be removed in a future release, and recent FreeIPA versions provide a replacement for pkg_resources.parse_version.

To remove ansible-freeipa dependency on pkg_resources and not add a dependency on the 'packaging' module, which is not available in the standard Python distribution, we'll try to import the funcion used in FreeIPA to parse versions, and fallback to pkg_resources when it fails.

As an equivalent class is needed, a fallback function is not provided and execution will fail if neither the FreeIPA nor the pkg_resources parse_version function are available.