### PR TITLE
infra/image/shdefaults: Add SYS_PTRACE to CAP_DEFAULTS

### DIFF
--- a/infra/image/shcontainer
+++ b/infra/image/shcontainer
@@ -4,6 +4,7 @@
 SCRIPTDIR="$(dirname -- "$(readlink -f "${BASH_SOURCE[0]}")")"
 TOPDIR="$(readlink -f "${SCRIPTDIR}/../..")"
 
+# shellcheck disable=SC1091
 . "${SCRIPTDIR}/shdefaults"
 
 # shellcheck disable=SC1091
@@ -15,7 +16,8 @@ container_create() {
     shift 2
     declare -a extra_opts
     readarray -t extra_opts < \
-        <(sed -e "s/-/--cap-drop=/g" -e "s/+/--cap-add=/g" <<< "${CAP_DEFAULTS[@]}")
+        <(sed -e "s/-/--cap-drop=/g" -e "s/+/--cap-add=/g" \
+        <<< "$(printf '%s\n' "${CAP_DEFAULTS[@]}")")
     for opt in "$@"
     do
         [ -z "${opt}" ] && continue

--- a/infra/image/shdefaults
+++ b/infra/image/shdefaults
@@ -5,4 +5,5 @@
 # Use +CAP to add the capability and -CAP to drop the capability.
 CAP_DEFAULTS=(
     "+DAC_READ_SEARCH"  # Required for SSSD
+    "+SYS_PTRACE"       # Required for debugging
 )


### PR DESCRIPTION
Debugging is now enabled by default in the containers that are generated with container_create. "+SYS_PTRACE" has been added to CAP_DEFAULTS in shdefaults for this.