### PR TITLE
test container: Add DAC_READ_SEARCH capability

### DIFF
--- a/infra/image/shcontainer
+++ b/infra/image/shcontainer
@@ -32,6 +32,7 @@ container_create() {
     podman create \
            --security-opt label=disable \
            --network bridge:interface_name=eth0 \
+           --cap-add DAC_READ_SEARCH \
            --systemd true \
            --name "${name}" \
            --memory-swap -1 \


### PR DESCRIPTION
SSSD 2.10+ runs under non-privileged user 'sssd' and relies on system capabilities to get access to certain resources like /etc/krb5.keytab. Not having these capabilities result in SSSD not starting.

Podman has reduced the capabilities granted to containers, and to be able to start SSSD it is needed to add DAC_READ_SEARCH back.

See: https://github.com/containers/podman/discussions/24904#discussioncomment-11718823