### PR TITLE
infra/image/shcontainer: Volume support and new container_tee

### DIFF
--- a/infra/image/shcontainer
+++ b/infra/image/shcontainer
@@ -19,6 +19,7 @@ container_create() {
             cpus=*) extra_opts+=("--${opt}") ;;
             memory=*) extra_opts+=("--${opt}") ;;
             capabilities=*) extra_opts+=("--cap-add=${opt##*=}") ;;
+            volume=*) extra_opts+=("--volume=${opt##*=}") ;;
             *) log error "container_create: Invalid option: ${opt}" ;;
         esac
     done
@@ -195,5 +196,17 @@ container_fetch() {
 
     log info "= Copying ${name}:${source} to ${destination} ="
     podman cp "${name}:${source}" "${destination}"
+    echo
+}
+
+container_tee() {
+    local name=${1}
+    local destination=${2}
+    tmpfile=$(mktemp /tmp/container-temp.XXXXXX)
+
+    log info "= Creating ${name}:${filename} from stdin ="
+    cat - > ${tmpfile}
+    podman cp "${tmpfile}" "${name}:${destination}"
+    rm "${tmpfile}"
     echo
 }


### PR DESCRIPTION
This change adds support for volumes to container_create. Now it can be used like in this example:

    container_create "${name}" "${local_image}" "hostname=${hostname}" \
        "${capabilities:+capabilities=$capabilities}" \
        volume=$PWD:/root/src

The new function container_tee has been added to enable creation of fiiles with content from stdin like in this example:

    cat <<EOF | container_tee "${name}" "/root/.gdbinit"
    set debuginfod enabled on
    set follow-fork-mode child
    EOF

## Summary by Sourcery

Enhance container management script with volume support and file creation capabilities

New Features:
- Add volume mounting support to container_create function
- Introduce container_tee function for creating files inside containers from stdin

Enhancements:
- Extend container creation flexibility by allowing volume mappings
- Provide a convenient method to write files directly into containers