### PR TITLE
infra/image/shcontainer: Fix log message in container_tee

### DIFF
--- a/infra/image/shcontainer
+++ b/infra/image/shcontainer
@@ -204,8 +204,8 @@ container_tee() {
     local destination=${2}
     tmpfile=$(mktemp /tmp/container-temp.XXXXXX)
 
-    log info "= Creating ${name}:${filename} from stdin ="
-    cat - > ${tmpfile}
+    log info "= Creating ${name}:${destination} from stdin ="
+    cat - > "${tmpfile}"
     podman cp "${tmpfile}" "${name}:${destination}"
     rm "${tmpfile}"
     echo


### PR DESCRIPTION
Fix a log message in function container_tee and quote the temporary filename.

## Summary by Sourcery

Bug Fixes:
- Corrected the log message formatting in the container_tee function to improve clarity and readability