### PR TITLE
ipaclient: Fix AttributeError by defaulting dns_over_tls to False

### DIFF
--- a/roles/ipaclient/library/ipaclient_setup_sssd.py
+++ b/roles/ipaclient/library/ipaclient_setup_sssd.py
@@ -174,6 +174,7 @@ def main():
     options.no_krb5_offline_passwords = module.params.get(
         'no_krb5_offline_passwords')
     options.krb5_offline_passwords = not options.no_krb5_offline_passwords
+    options.dns_over_tls = False
 
     fstore = sysrestore.FileStore(paths.IPA_CLIENT_SYSRESTORE)
     client_domain = hostname[hostname.find(".") + 1:]


### PR DESCRIPTION
## Bug Summary

This change addresses [[freeipa/ansible-freeipa#1356](https://github.com/freeipa/ansible-freeipa/issues/1356#issuecomment-2891804763)](https://github.com/freeipa/ansible-freeipa/issues/1356#issuecomment-2891804763) by explicitly setting `options.dns_over_tls = False` to ensure the attribute is always defined when running ipaclient ansible role.

On RHEL 9 systems (or any environment where `ipasssd_enable_dns_updates: true`), the `ipaclient` python module references `dns_over_tls` without first checking its existence, which results in the following `AttributeError: 'installer_obj' object has no attribute 'dns_over_tls'`:

```
TASK \[freeipa.ansible\_freeipa.ipaclient : Install - Configure SSSD] \*\*\*\*\*\*\*\*\*\*\*\*
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: AttributeError: 'installer\_obj' object has no attribute 'dns\_over\_tls'
fatal: \[vm-test-rhel9]: FAILED! => {"changed": false, "module\_stderr": "Traceback (most recent call last):\n  File "<stdin>", line 107, in <module>\n  File "<stdin>", line 99, in \_ansiballz\_main\n  File "<stdin>", line 47, in invoke\_module\n  File "/usr/lib64/python3.9/runpy.py", line 225, in run\_module\n    return \_run\_module\_code(code, init\_globals, run\_name, mod\_spec)\n  File "/usr/lib64/python3.9/runpy.py", line 97, in \_run\_module\_code\n    \_run\_code(code, mod\_globals, init\_globals,\n  File "/usr/lib64/python3.9/runpy.py", line 87, in \_run\_code\n    exec(code, run\_globals)\n  File "/tmp/ansible\_freeipa.ansible\_freeipa.ipaclient\_setup\_sssd\_payload\_zkyct7sn/ansible\_freeipa.ansible\_freeipa.ipaclient\_setup\_sssd\_payload.zip/ansible\_collections/freeipa/ansible\_freeipa/plugins/modules/ipaclient\_setup\_sssd.py", line 190, in <module>\n  File "/tmp/ansible\_freeipa.ansible\_freeipa.ipaclient\_setup\_sssd\_payload\_zkyct7sn/ansible\_freeipa.ansible\_freeipa.ipaclient\_setup\_sssd\_payload.zip/ansible\_collections/freeipa/ansible\_freeipa/plugins/modules/ipaclient\_setup\_sssd.py", line 181, in main\n  File "/usr/lib/python3.9/site-packages/ipaclient/install/client.py", line 1005, in configure\_sssd\_conf\n    if options.dns\_over\_tls:\nAttributeError: 'installer\_obj' object has no attribute 'dns\_over\_tls'\n", "module\_stdout": "", "msg": "MODULE FAILURE\nSee stdout/stderr for the exact error", "rc": 1}
```

To prevent this, the attribute `options.dns_over_tls` is now initialised to false in `roles/ipaclient/library/ipaclient_setup_sssd.py`.This fix is inspired by a similar pattern in [[PR #1340](https://github.com/freeipa/ansible-freeipa/pull/1340/files)](https://github.com/freeipa/ansible-freeipa/pull/1340/files).

## Affected FreeIPA Collection Versions

This failure has been observed in versions `1.14.6` and `1.14.5` of the [ansible_freeipa collection](https://galaxy.ansible.com/ui/repo/published/freeipa/ansible_freeipa/) from Ansible Galaxy.