### PR TITLE
tests/service/env_cleanup.yml: Turn on update_dns for test host removal

### DIFF
--- a/tests/service/env_cleanup.yml
+++ b/tests/service/env_cleanup.yml
@@ -31,7 +31,7 @@
       - "{{ host2_fqdn }}"
       - "{{ nohost_fqdn }}"
       - svc.ihavenodns.info
-    update_dns: no
+    update_dns: true
     state: absent
 
 - name: Ensure testing users are absent.


### PR DESCRIPTION
The tests hosts are generated with IP addresses in env_setup, but removed without update_dns turned on. Therefore the IP addresses are not removed from DNS.

This results in a failure if the host test test_host_ipaddresses is run afterwards.