### PR TITLE
Don't execute deployment roles if packages are not installed

### DIFF
--- a/roles/ipaclient/tasks/install.yml
+++ b/roles/ipaclient/tasks/install.yml
@@ -19,6 +19,19 @@
       name: "{{ _ipapackages }}"
       state: present
 
+- name: Check installer availability
+  when: not (ipaclient_install_packages | bool)
+  block:
+    - name: Install - Check ipaclient installer is available
+      ansible.builtin.stat:
+        path: /usr/sbin/ipa-client-install
+      register: __ipa_client_install_available
+
+    - name: Install - Abort installation due to missing installer
+      ansible.builtin.fail:
+        msg: "IPA client installer not found"
+      when: not __ipa_client_install_available.stat.exists
+
 - name: Install - Set ipaclient_servers
   ansible.builtin.set_fact:
     ipaclient_servers: "{{ groups['ipaservers'] | list }}"

--- a/roles/ipaclient/tasks/uninstall.yml
+++ b/roles/ipaclient/tasks/uninstall.yml
@@ -1,17 +1,25 @@
 ---
 # tasks to uninstall IPA client
 
-- name: Uninstall - Uninstall IPA client
-  ansible.builtin.command: >
-    /usr/sbin/ipa-client-install
-    --uninstall
-    -U
-  register: uninstall
-  # 2 means that uninstall failed because IPA client was not configured
-  failed_when: uninstall.rc != 0 and uninstall.rc != 2
-  changed_when: uninstall.rc == 0
+- name: Uninstall - Check if ipa-client-install is present
+  ansible.builtin.stat:
+    path: /usr/sbin/ipa-client-install
+  register: __ipa_client_install_available
 
-- name: Uninstall - Unconfigure DNS resolver
-  ipaclient_configure_dns_resolver:
-    state: absent
-  when: ipaclient_cleanup_dns_resolver | bool
+- name: Uninstall - Perform uninstall
+  when: __ipa_client_install_available.stat.exists
+  block:
+  - name: Uninstall - Uninstall IPA client
+    ansible.builtin.command: >
+      /usr/sbin/ipa-client-install
+      --uninstall
+      -U
+    register: uninstall
+    # 2 means that uninstall failed because IPA client was not configured
+    failed_when: uninstall.rc != 0 and uninstall.rc != 2
+    changed_when: uninstall.rc == 0
+
+  - name: Uninstall - Unconfigure DNS resolver
+    ipaclient_configure_dns_resolver:
+      state: absent
+    when: ipaclient_cleanup_dns_resolver | bool

--- a/roles/ipareplica/tasks/install.yml
+++ b/roles/ipareplica/tasks/install.yml
@@ -38,6 +38,19 @@
       name: "{{ _ipapackages }}"
       state: present
 
+- name: Check installer availability
+  when: not (ipareplica_install_packages | bool)
+  block:
+    - name: Install - Check ipareplica installer is avaiable
+      ansible.builtin.stat:
+        path: /usr/sbin/ipa-replica-install
+      register: __ipa_replica_install_available
+
+    - name: Install - Abort installation due to missing installer
+      ansible.builtin.fail:
+        msg: "IPA replica installer not found"
+      when: not __ipa_replica_install_available.stat.exists
+
 - name: Firewall configuration
   when: ipareplica_setup_firewalld | bool
   block:

--- a/roles/ipaserver/tasks/install.yml
+++ b/roles/ipaserver/tasks/install.yml
@@ -38,6 +38,19 @@
       name: "{{ _ipapackages }}"
       state: present
 
+- name: Check installer availability
+  when: not (ipaserver_install_packages | bool)
+  block:
+    - name: Install - Check ipaserver installer is available
+      ansible.builtin.stat:
+        path: /usr/sbin/ipa-server-install
+      register: __ipa_server_install_available
+
+    - name: Install - Abort installation due to missing installer
+      ansible.builtin.fail:
+        msg: "IPA server installer not found"
+      when: not __ipa_server_install_available.stat.exists
+
 - name: Install - Firewall configuration
   when: ipaserver_setup_firewalld | bool
   block:

--- a/roles/ipaserver/tasks/uninstall.yml
+++ b/roles/ipaserver/tasks/uninstall.yml
@@ -42,6 +42,11 @@
     when: ipaserver_remove_on_server is defined or
           result_get_connected_server.server is defined
 
+- name: Uninstall - Check if ipa-server-install is present
+  ansible.builtin.stat:
+    path: /usr/sbin/ipa-server-install
+  register: __ipa_server_install_available
+
 - name: Uninstall - Uninstall IPA server
   ansible.builtin.command: >
     /usr/sbin/ipa-server-install
@@ -54,3 +59,4 @@
   # 1 means that uninstall failed because IPA server was not configured
   failed_when: uninstall.rc != 0 and uninstall.rc != 1
   changed_when: uninstall.rc == 0
+  when: __ipa_server_install_available.stat.exists


### PR DESCRIPTION
When running the deployment roles, if packages are not installed, an
error of a missing module is shown, which is confusing to users.

By ensuring that either installation or uninstallation only work if a
minimal set of tools is available allows to provide a meaningful message
and let users act on the environment.

For installation, if ipa-server/client-install is not available, the
installation is aborted with a meaningful error. For uninstallation, we
assume that IPA is not installed and gently finish the process with no
errors.

`ipareplica` uninstall is not modified as it uses `ipaserver` role.

Fix #1362 