### PR TITLE
infra/image: Make fixnet and fixipaip services active by default

### DIFF
--- a/infra/image/build.sh
+++ b/infra/image/build.sh
@@ -119,13 +119,6 @@ then
         deployed=true
     fi
     echo
-
-    if $deployed; then
-        log info "= Enabling services ="
-        container_exec "${name}" systemctl enable fixnet
-        container_exec "${name}" systemctl enable fixipaip
-        echo
-    fi
     
     container_stop "${name}"
 

--- a/infra/image/dockerfile/c10s
+++ b/infra/image/dockerfile/c10s
@@ -31,6 +31,8 @@ COPY system-service/fixipaip.sh /root/
 COPY system-service/fixnet.service /etc/systemd/system/
 COPY system-service/fixipaip.service /etc/systemd/system/
 RUN chmod +x /root/fixnet.sh /root/fixipaip.sh
+RUN systemctl enable fixnet.service
+RUN systemctl enable fixipaip.service
 
 STOPSIGNAL RTMIN+3
 

--- a/infra/image/dockerfile/c8s
+++ b/infra/image/dockerfile/c8s
@@ -34,6 +34,8 @@ COPY system-service/fixipaip.sh /root/
 COPY system-service/fixnet.service /etc/systemd/system/
 COPY system-service/fixipaip.service /etc/systemd/system/
 RUN chmod +x /root/fixnet.sh /root/fixipaip.sh
+RUN systemctl enable fixnet.service
+RUN systemctl enable fixipaip.service
 
 STOPSIGNAL RTMIN+3
 

--- a/infra/image/dockerfile/c9s
+++ b/infra/image/dockerfile/c9s
@@ -30,6 +30,8 @@ COPY system-service/fixipaip.sh /root/
 COPY system-service/fixnet.service /etc/systemd/system/
 COPY system-service/fixipaip.service /etc/systemd/system/
 RUN chmod +x /root/fixnet.sh /root/fixipaip.sh
+RUN systemctl enable fixnet.service
+RUN systemctl enable fixipaip.service
 
 STOPSIGNAL RTMIN+3
 

--- a/infra/image/dockerfile/fedora-latest
+++ b/infra/image/dockerfile/fedora-latest
@@ -33,6 +33,8 @@ COPY system-service/fixipaip.sh /root/
 COPY system-service/fixnet.service /etc/systemd/system/
 COPY system-service/fixipaip.service /etc/systemd/system/
 RUN chmod +x /root/fixnet.sh /root/fixipaip.sh
+RUN systemctl enable fixnet.service
+RUN systemctl enable fixipaip.service
 
 STOPSIGNAL RTMIN+3
 

--- a/infra/image/dockerfile/fedora-rawhide
+++ b/infra/image/dockerfile/fedora-rawhide
@@ -33,6 +33,8 @@ COPY system-service/fixipaip.sh /root/
 COPY system-service/fixnet.service /etc/systemd/system/
 COPY system-service/fixipaip.service /etc/systemd/system/
 RUN chmod +x /root/fixnet.sh /root/fixipaip.sh
+RUN systemctl enable fixnet.service
+RUN systemctl enable fixipaip.service
 
 STOPSIGNAL RTMIN+3
 

--- a/infra/image/system-service/fixipaip.service
+++ b/infra/image/system-service/fixipaip.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=Fix IPA server IP in IPA Server
 After=ipa.service
+PartOf=ipa.service
 
 [Service]
 Type=oneshot
@@ -9,4 +10,4 @@ StandardOutput=journal
 StandardError=journal
 
 [Install]
-WantedBy=default.target
+WantedBy=ipa.service

--- a/infra/image/system-service/fixipaip.sh
+++ b/infra/image/system-service/fixipaip.sh
@@ -50,9 +50,9 @@ if [ -z "${FORWARDER}" ] || [ "${FORWARDER}" == "127.0.0.1" ]; then
 fi
 
 echo "Fix IPA:"
-echo "  HOSTNAME: '${HOSTNAME}'"
-echo "  IP: '${IP}'"
-echo "  PTR: '${PTR}'"
+echo "  HOSTNAME:  '${HOSTNAME}'"
+echo "  IP:        '${IP}'"
+echo "  PTR:       '${PTR}'"
 echo "  FORWARDER: '${FORWARDER}'"
 
 ZONES=$(ipa -e in_server=true dnszone-find --name-from-ip="${HOSTNAME}." \

--- a/infra/image/system-service/fixnet.service
+++ b/infra/image/system-service/fixnet.service
@@ -1,8 +1,5 @@
 [Unit]
-Description=Fix server IP in IPA Server
-Wants=network.target
-After=network.target
-Before=ipa.service
+Description=Fix /etc/hosts and with local DNS also /etc/resolv.conf
 
 [Service]
 Type=oneshot
@@ -11,4 +8,4 @@ StandardOutput=journal
 StandardError=journal
 
 [Install]
-WantedBy=ipa.service
+WantedBy=container-ipa.target


### PR DESCRIPTION
The services are now active by default and do not need to be activated after IPA has been deployed.

The fixnet service is always activated and removes all lines containing the hostname from /etc/hosts and adds a new line with the IP and the hostname with and without domain. If IPA is deployed with DNS (the config file /etc/named.conf exists and there is a '^dyndb "ipa"' line in /etc/named.conf) then /etc/resolv.conf is also changed to use the local DNS server.

The fixipaip service is now also always activated, but only started IF IPA has been deployed and the ipa service was started before.

infra/image/build.sh is not actvating the services anymore, the services are now actiavted in alll dockerfiles.

## Summary by Sourcery

Always enable fixnet and fixipaip services by default in container images, remove manual activation in build.sh, and enhance fixnet to reset /etc/hosts and configure /etc/resolv.conf for IPA DNS setups.

New Features:
- Enhance fixnet service to detect IPA DNS via named.conf and update resolv.conf to use the local DNS server.

Enhancements:
- Simplify fixnet.sh by removing stale hostname entries before appending a new hosts record and printing the updated file.
- Align logging output formatting in fixnet and fixipaip scripts.

Build:
- Remove service enabling logic from infra/image/build.sh now handled by Dockerfiles.