### PR TITLE
infra/image/shcontainer: Safer host removal from /etc/hosts

### DIFF
--- a/infra/image/shcontainer
+++ b/infra/image/shcontainer
@@ -60,7 +60,7 @@ container_start() {
     hostname=$(podman inspect "${name}" --format "{{.Config.Hostname}}")
     if [ -n "${ip}" ] && [ -n "${hostname}" ]; then
         cmd=$(cat <<EOF
-sed -i -e "/[ \t]${hostname}/d" /etc/hosts
+sed -i -E "/\s+${hostname}(\s|$)/d" /etc/hosts
 echo -e "$ip\t${hostname} ${hostname%%.*}" >> /etc/hosts
 EOF
            )


### PR DESCRIPTION
The sed command for host removal from PR #1364 is used now. This makes sure that only full matches are removed and not substring matches.

## Summary by Sourcery

Bug Fixes:
- Use a sed-based approach with regex boundaries to remove host entries from /etc/hosts safely, avoiding partial substring matches.