### PR TITLE
WIP: Ansible playground

### DIFF
--- a/infra/azure/azure-pipelines.yml
+++ b/infra/azure/azure-pipelines.yml
@@ -6,8 +6,8 @@ pool:
   vmImage: 'ubuntu-24.04'
 
 variables:
-  ansible_version: "-core >=2.16,<2.17"
-  ansible_latest: "-core"
+  ansible_version: "-core==2.19.0b5"
+  ansible_latest: "-core==2.19.0b5"
   ansible_minimum: "-core <2.16"
   distros: "fedora-latest,c9s,c10s,fedora-rawhide"
 

--- a/infra/azure/pr-pipeline.yml
+++ b/infra/azure/pr-pipeline.yml
@@ -7,7 +7,7 @@ pool:
 
 variables:
   distros: "fedora-latest,c10s,c9s,c8s,fedora-rawhide"
-  ansible_version: "-core >=2.15,<2.16"
+  ansible_version: "-core==2.19.0b5"
 
 stages:
 

--- a/infra/image/shcontainer
+++ b/infra/image/shcontainer
@@ -40,6 +40,7 @@ container_create() {
     podman create \
            --security-opt label=disable \
            --network bridge:interface_name=eth0 \
+           --cap-add DAC_READ_SEARCH \
            --systemd true \
            --name "${name}" \
            --memory-swap -1 \

--- a/plugins/module_utils/ansible_freeipa_module.py
+++ b/plugins/module_utils/ansible_freeipa_module.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 
+# Force tests to run: TRUE
+
 # Authors:
 #   Sergio Oliveira Campos <seocam@redhat.com>
 #   Thomas Woerner <twoerner@redhat.com>

--- a/roles/ipaserver/tasks/uninstall.yml
+++ b/roles/ipaserver/tasks/uninstall.yml
@@ -42,6 +42,13 @@
     when: ipaserver_remove_on_server is defined or
           result_get_connected_server.server is defined
 
+- name: Unnstall - Check if IPA server packages are installed
+  ansible.builtin.package:
+    name: "{{ ipaserver_packages }}"
+    state: present
+  check_mode: true
+  register: ipapackages_available
+
 - name: Uninstall - Uninstall IPA server
   ansible.builtin.command: >
     /usr/sbin/ipa-server-install
@@ -54,3 +61,4 @@
   # 1 means that uninstall failed because IPA server was not configured
   failed_when: uninstall.rc != 0 and uninstall.rc != 1
   changed_when: uninstall.rc == 0
+  when: not ipapackages_available.changed

--- a/tests/cert/test_cert_host.yml
+++ b/tests/cert/test_cert_host.yml
@@ -140,7 +140,7 @@
       certificate_out: "/root/cert_1.pem"
       state: requested
     register: result
-    failed_when: not result.changed or result.failed or result.certificate
+    failed_when: not result.changed or result.failed or result.certificate != {}
 
   - name: Check requested certificate file
     ansible.builtin.file:
@@ -155,7 +155,7 @@
       certificate_out: "/root/retrieved.pem"
       state: retrieved
     register: result
-    failed_when: result.changed or result.failed or result.certificate
+    failed_when: result.changed or result.failed or result.certificate != {}
 
   - name: Check retrieved certificate file
     ansible.builtin.file:

--- a/tests/cert/test_cert_service.yml
+++ b/tests/cert/test_cert_service.yml
@@ -153,7 +153,7 @@
       certificate_out: "/root/cert_1.pem"
       state: requested
     register: result
-    failed_when: not result.changed or result.failed or result.certificate
+    failed_when: not result.changed or result.failed or result.certificate != {}
 
   - name: Check requested certificate file
     ansible.builtin.file:
@@ -168,7 +168,7 @@
       certificate_out: "/root/retrieved.pem"
       state: retrieved
     register: result
-    failed_when: result.changed or result.failed or result.certificate
+    failed_when: result.changed or result.failed or result.certificate != {}
 
   - name: Check retrieved certificate file
     ansible.builtin.file:

--- a/tests/cert/test_cert_user.yml
+++ b/tests/cert/test_cert_user.yml
@@ -140,7 +140,7 @@
       certificate_out: "/root/cert_1.pem"
       state: requested
     register: result
-    failed_when: not result.changed or result.failed or result.certificate
+    failed_when: not result.changed or result.failed or result.certificate != {}
 
   - name: Check requested certificate file
     ansible.builtin.file:
@@ -155,7 +155,7 @@
       certificate_out: "/root/retrieved.pem"
       state: retrieved
     register: result
-    failed_when: result.changed or result.failed or result.certificate
+    failed_when: result.changed or result.failed or result.certificate != {}
 
   - name: Check retrieved certificate file
     ansible.builtin.file:

--- a/tests/group/test_group_case_insensitive.yml
+++ b/tests/group/test_group_case_insensitive.yml
@@ -49,8 +49,8 @@
             - { id: 2, value: "{{ user_names[0] | upper }}", expected: false }
             - { id: 3, value: "{{ user_names[0] }}", expected: false }
             - { id: 4, value: "{{ user_names }}", expected: true }
-            - { id: 5, value: "{{ user_names | upper }}", expected: false }
-            - { id: 6, value: "{{ user_names | lower }}", expected: false }
+            - { id: 5, value: "{{ user_names | map('upper') }}", expected: false }
+            - { id: 6, value: "{{ user_names | map('lower') }}", expected: false }
             - { id: 7, value: "{{ user_names[1] }}", expected: true }
             - { id: 8, value: "{{ user_names[1] | upper }}", expected: false }
             - { id: 9, value: "{{ user_names[1] | lower }}", expected: false }
@@ -64,7 +64,7 @@
             failed_when: output.changed != item.expected or output.failed
             loop: "{{ test_cases }}"
             loop_control:
-              label: "Test id: {{ item.id }}"
+              label: "Test id: {{ item.id }} - {{ item.value }}"
 
       - name: Test group presence with group parameter
         vars:
@@ -73,8 +73,8 @@
             - { id: 2, value: "{{ group_names[0] | upper }}", expected: false }
             - { id: 3, value: "{{ group_names[0] }}", expected: false }
             - { id: 4, value: "{{ group_names }}", expected: true }
-            - { id: 5, value: "{{ group_names | upper }}", expected: false }
-            - { id: 6, value: "{{ group_names | lower }}", expected: false }
+            - { id: 5, value: "{{ group_names | map('upper') }}", expected: false }
+            - { id: 6, value: "{{ group_names | map('lower') }}", expected: false }
             - { id: 7, value: "{{ group_names[1] }}", expected: true }
             - { id: 8, value: "{{ group_names[1] | upper }}", expected: false }
             - { id: 9, value: "{{ group_names[1] | lower }}", expected: false }
@@ -159,8 +159,8 @@
             - { id: 2, value: "{{ user_names[0] | upper }}", expected: false }
             - { id: 3, value: "{{ user_names[0] }}", expected: false }
             - { id: 4, value: "{{ user_names }}", expected: true }
-            - { id: 5, value: "{{ user_names | upper }}", expected: false }
-            - { id: 6, value: "{{ user_names | lower }}", expected: false }
+            - { id: 5, value: "{{ user_names | map('upper') }}", expected: false }
+            - { id: 6, value: "{{ user_names | map('lower') }}", expected: false }
             - { id: 7, value: "{{ user_names[1] }}", expected: true }
             - { id: 8, value: "{{ user_names[1] | upper }}", expected: false }
             - { id: 9, value: "{{ user_names[1] | lower }}", expected: false }
@@ -183,8 +183,8 @@
             - { id: 2, value: "{{ group_names[0] | upper }}", expected: false }
             - { id: 3, value: "{{ group_names[0] }}", expected: false }
             - { id: 4, value: "{{ group_names }}", expected: true }
-            - { id: 5, value: "{{ group_names | upper }}", expected: false }
-            - { id: 6, value: "{{ group_names | lower }}", expected: false }
+            - { id: 5, value: "{{ group_names | map('upper') }}", expected: false }
+            - { id: 6, value: "{{ group_names | map('lower') }}", expected: false }
             - { id: 7, value: "{{ group_names[1] }}", expected: true }
             - { id: 8, value: "{{ group_names[1] | upper }}", expected: false }
             - { id: 9, value: "{{ group_names[1] | lower }}", expected: false }

--- a/tests/hbacsvcgroup/test_hbacsvcgroup_member_case_insensitive.yml
+++ b/tests/hbacsvcgroup/test_hbacsvcgroup_member_case_insensitive.yml
@@ -97,7 +97,7 @@
         ipahbacsvcgroup:
           ipaadmin_password: SomeADMINpassword
           name: testgroup
-          hbacsvc: "{{ hbacsvc_list | lower }}"
+          hbacsvc: "{{ hbacsvc_list | map('lower') }}"
         register: result
         failed_when: result.changed or result.failed
 
@@ -105,7 +105,7 @@
         ipahbacsvcgroup:
           ipaadmin_password: SomeADMINpassword
           name: testgroup
-          hbacsvc: "{{ hbacsvc_list | upper }}"
+          hbacsvc: "{{ hbacsvc_list | map('upper') }}"
         register: result
         failed_when: result.changed or result.failed
 
@@ -153,7 +153,7 @@
         ipahbacsvcgroup:
           ipaadmin_password: SomeADMINpassword
           name: testgroup
-          hbacsvc: "{{ hbacsvc_list | lower }}"
+          hbacsvc: "{{ hbacsvc_list | map('lower') }}"
           action: member
         register: result
         failed_when: result.changed or result.failed
@@ -162,7 +162,7 @@
         ipahbacsvcgroup:
           ipaadmin_password: SomeADMINpassword
           name: testgroup
-          hbacsvc: "{{ hbacsvc_list | upper }}"
+          hbacsvc: "{{ hbacsvc_list | map('upper') }}"
           action: member
         register: result
         failed_when: result.changed or result.failed
@@ -171,7 +171,7 @@
         ipahbacsvcgroup:
           ipaadmin_password: SomeADMINpassword
           name: testgroup
-          hbacsvc: "{{ hbacsvc_list | upper }}"
+          hbacsvc: "{{ hbacsvc_list | map('upper') }}"
           action: member
           state: absent
         check_mode: yes
@@ -182,7 +182,7 @@
         ipahbacsvcgroup:
           ipaadmin_password: SomeADMINpassword
           name: testgroup
-          hbacsvc: "{{ hbacsvc_list | upper }}"
+          hbacsvc: "{{ hbacsvc_list | map('upper') }}"
           action: member
           state: absent
         register: result
@@ -192,7 +192,7 @@
         ipahbacsvcgroup:
           ipaadmin_password: SomeADMINpassword
           name: testgroup
-          hbacsvc: "{{ hbacsvc_list | upper }}"
+          hbacsvc: "{{ hbacsvc_list | map('upper') }}"
           action: member
           state: absent
         check_mode: yes
@@ -213,7 +213,7 @@
         ipahbacsvcgroup:
           ipaadmin_password: SomeADMINpassword
           name: testgroup
-          hbacsvc: "{{ hbacsvc_list | lower }}"
+          hbacsvc: "{{ hbacsvc_list | map('lower') }}"
           action: member
           state: absent
         register: result

--- a/tests/host/test_host_random.yml
+++ b/tests/host/test_host_random.yml
@@ -92,11 +92,11 @@
 
   - name: Print generated random password for "{{ host1_fqdn }}"
     ansible.builtin.debug:
-      var: ipahost.host["{{ host1_fqdn }}"].randompassword
+      var: ipahost.host[host1_fqdn].randompassword
 
   - name: Print generated random password for "{{ host2_fqdn }}"
     ansible.builtin.debug:
-      var: ipahost.host["{{ host2_fqdn }}"].randompassword
+      var: ipahost.host[host2_fqdn].randompassword
 
   - name: Enrolled host "{{ server_fqdn }}" fails to set random password with update_password always
     ipahost:

--- a/tests/hostgroup/test_hostgroup_case_insensitive.yml
+++ b/tests/hostgroup/test_hostgroup_case_insensitive.yml
@@ -81,8 +81,8 @@
       - name: Test hostgroup presence with multiple hosts and action hostgroup
         vars:
           test_cases:
-            - { id: 1, value: "{{ test_hosts | lower }}", expected: true }
-            - { id: 2, value: "{{ test_hosts | upper }}", expected: false }
+            - { id: 1, value: "{{ test_hosts | map('lower') }}", expected: true }
+            - { id: 2, value: "{{ test_hosts | map('upper') }}", expected: false }
             - { id: 3, value: "{{ test_hosts }}", expected: false }
             - { id: 4, value: "{{ test_hosts[1] }}", expected: true }
             - { id: 5, value: "{{ test_hosts[1] | lower }}", expected: false }
@@ -104,8 +104,8 @@
       - name: Test hostgroup with multiple hosts and action member
         vars:
           test_cases:
-            - { id: 1, value: "{{ test_hosts | lower }}", state: "absent", expected: true }
-            - { id: 2, value: "{{ test_hosts | upper }}", state: "absent", expected: false }
+            - { id: 1, value: "{{ test_hosts | map('lower') }}", state: "absent", expected: true }
+            - { id: 2, value: "{{ test_hosts | map('upper') }}", state: "absent", expected: false }
             - { id: 3, value: "{{ test_hosts }}", state: "present", expected: true }
             - { id: 4, value: "{{ test_hosts[1] }}", state: "absent", expected: true }
             - { id: 5, value: "{{ test_hosts[1] | lower }}", state: "absent", expected: false }
@@ -113,7 +113,7 @@
             - { id: 7, value: "{{ test_hosts[0] | lower }}", state: "present", expected: false }
             - { id: 8, value: "{{ test_hosts[0] }}", state: "present", expected: false }
             - { id: 9, value: "{{ test_hosts[0] | upper }}", state: "present", expected: false }
-            - { id: 10, value: "{{ test_hosts | upper }}", state: "present", expected: true }
+            - { id: 10, value: "{{ test_hosts | map('upper') }}", state: "present", expected: true }
             - { id: 11, value: "{{ test_hosts[1] }}", state: "present", expected: false }
             - { id: 12, value: "{{ test_hosts[0] | lower }}", state: "present", expected: false }
             - { id: 13, value: "{{ test_hosts[0] }}", state: "absent", expected: true }

--- a/tests/service/test_service_disable.yml
+++ b/tests/service/test_service_disable.yml
@@ -48,7 +48,8 @@
   - name: Verify keytab
     ansible.builtin.shell: ipa service-find "mysvc1/{{ ansible_facts['fqdn'] }}"
     register: result
-    failed_when: result.failed or result.stdout | regex_search(" Keytab. true")
+    changed_when: false
+    failed_when: result.failed or (result.stdout | regex_search(" Keytab. [Tt]rue")) in [None, ""]
 
   - name: Ensure service is disabled
     ipaservice:
@@ -61,7 +62,8 @@
   - name: Verify keytab
     ansible.builtin.shell: ipa service-find "mysvc1/{{ ansible_facts['fqdn'] }}"
     register: result
-    failed_when: result.failed or result.stdout | regex_search(" Keytab. true")
+    changed_when: false
+    failed_when: result.failed or (result.stdout | regex_search(" Keytab. [Ff]alse")) in [None, ""]
 
   - name: Obtain keytab
     ansible.builtin.shell: ipa-getkeytab -s "{{ ansible_facts['fqdn'] }}" -p "mysvc1/{{ ansible_facts['fqdn'] }}" -k mysvc1.keytab
@@ -69,7 +71,8 @@
   - name: Verify keytab
     ansible.builtin.shell: ipa service-find "mysvc1/{{ ansible_facts['fqdn'] }}"
     register: result
-    failed_when: result.failed or result.stdout | regex_search(" Keytab. true")
+    changed_when: false
+    failed_when: result.failed or (result.stdout | regex_search(" Keytab. [Tt]rue")) in [None, ""]
 
   - name: Ensure service is disabled
     ipaservice:
@@ -82,7 +85,8 @@
   - name: Verify keytab
     ansible.builtin.shell: ipa service-find "mysvc1/{{ ansible_facts['fqdn'] }}"
     register: result
-    failed_when: result.failed or result.stdout | regex_search(" Keytab. true")
+    changed_when: false
+    failed_when: result.failed or (result.stdout | regex_search(" Keytab. [Ff]alse")) in [None, ""]
 
   - name: Ensure service is disabled, with no keytab.
     ipaservice:


### PR DESCRIPTION
Run tests against ansible-core 2.19 beta release.

## Summary by Sourcery

Update CI and uninstall tasks to support ansible-core 2.19 beta and ensure tests run

Enhancements:
- Add a check-mode task to verify IPA server packages are installed before executing the uninstall routine

CI:
- Bump Azure Pipelines ansible-core version to 2.19.0b5 for both `ansible_version` and `ansible_latest` variables

Tests:
- Add a "Force tests to run: TRUE" marker in ansible_freeipa_module to ensure test execution