### PR TITLE
ipaclient: client_dns has new statestore arg with IPA change e6445b8

### DIFF
--- a/roles/ipaclient/library/ipaclient_setup_nss.py
+++ b/roles/ipaclient/library/ipaclient_setup_nss.py
@@ -388,7 +388,11 @@ def main():
         tasks.insert_ca_certs_into_systemwide_ca_store(ca_certs)
 
         if not options.on_master:
-            client_dns(cli_server[0], hostname, options)
+            argspec_client_dns = getargspec(client_dns)
+            if "statestore" in argspec_client_dns.args:
+                client_dns(cli_server[0], hostname, options, statestore)
+            else:
+                client_dns(cli_server[0], hostname, options)
 
         if hasattr(paths, "SSH_CONFIG_DIR"):
             ssh_config_dir = paths.SSH_CONFIG_DIR


### PR DESCRIPTION
The new argument was introduced with the IPA change e6445b8 to disable the previous Unbound configuration before setting up new configuration for DNS over TLS.

Related: https://pagure.io/freeipa/issue/9814

## Summary by Sourcery

Add compatibility for the new statestore parameter in client_dns by checking its signature and passing the argument when supported

Enhancements:
- Introspect client_dns function to detect support for the new statestore argument
- Pass statestore to client_dns when the new argument is available