### PR TITLE
test_backup.yml: Fix evaluation of 'list = False' and 'list = True'

### DIFF
--- a/tests/backup_role/test_backup.yml
+++ b/tests/backup_role/test_backup.yml
@@ -108,7 +108,7 @@
       recurse: no
       file_type: directory
     register: backups
-    failed_when: backups.files
+    failed_when: backups.files | length > 0
 
   - name: Verify backup on controller.
     ansible.builtin.find:
@@ -116,7 +116,7 @@
       pattern: "{{ ansible_facts.fqdn }}*"
       file_type: directory
     register: backups
-    failed_when: not backups.files
+    failed_when: backups.files | length == 0
     delegate_to: localhost
     become: no
 


### PR DESCRIPTION
ansible-core 2.19 is not automatically converting empty and non empty lists to bool values. Conditionals must have a boolean result.

The solution is to evaluate the length of the lists instead.