### PR TITLE
"if options.no_ntp or options.ntp_servers or options.ntp_pool" fails all configurations. Adding "not options.no_ntp" ensures replicas install when explicitly telling role not to configure ntp.

### DIFF
--- a/roles/ipareplica/library/ipareplica_test.py
+++ b/roles/ipareplica/library/ipareplica_test.py
@@ -607,7 +607,7 @@ def main():
         pass
     else:
         # The NTP configuration can not be touched on pre-installed client:
-        if options.no_ntp or options.ntp_servers or options.ntp_pool:
+        if not options.no_ntp or options.ntp_servers or options.ntp_pool:
             ansible_module.fail_json(
                 msg="NTP configuration cannot be updated during promotion")
 


### PR DESCRIPTION
tested with 4 replica environment:
existing master
existing replica
uninstalled replica
new replica

## Summary by Sourcery

Bug Fixes:
- Use 'not options.no_ntp' in NTP configuration check to avoid blocking installations when NTP is explicitly disabled