### PR TITLE
ipacert: Fix tests for inexistent certificate

### DIFF
--- a/tests/cert/test_cert_host.yml
+++ b/tests/cert/test_cert_host.yml
@@ -124,7 +124,7 @@
       reason: 9
       state: revoked
     register: result
-    failed_when: not (result.failed and ("Request failed with status 404" in result.msg or "Certificate serial number 0x123456789 not found" in result.msg))
+    failed_when: not (result.failed and ("Request failed with status 404" in result.msg or result.msg is regex("Certificate [^0]*0x123456789 not found")))
 
   - name: Try to release revoked certificate
     ipacert:

--- a/tests/cert/test_cert_service.yml
+++ b/tests/cert/test_cert_service.yml
@@ -136,7 +136,7 @@
       reason: 9
       state: revoked
     register: result
-    failed_when: not (result.failed and ("Request failed with status 404" in result.msg or "Certificate serial number 0x123456789 not found" in result.msg))
+    failed_when: not (result.failed and ("Request failed with status 404" in result.msg or result.msg is regex("Certificate [^0]*0x123456789 not found")))
 
   - name: Try to release revoked certificate
     ipacert:

--- a/tests/cert/test_cert_user.yml
+++ b/tests/cert/test_cert_user.yml
@@ -123,7 +123,7 @@
       reason: 9
       state: revoked
     register: result
-    failed_when: not (result.failed and ("Request failed with status 404" in result.msg or "Certificate serial number 0x123456789 not found" in result.msg))
+    failed_when: not (result.failed and ("Request failed with status 404" in result.msg or result.msg is regex("Certificate [^0]*0x123456789 not found")))
 
   - name: Try to release revoked certificate
     ipacert:


### PR DESCRIPTION
After a PKI update the message returned for 'cert_show' in the case of an inexistent certificate has changed, causing tests to fail.

The fix is only required for the tests, as the behavior has not changed.

## Summary by Sourcery

Tests:
- Use regex in failed_when checks to match the new "Certificate ... not found" message pattern alongside 404 errors