### PR TITLE
pre-commit: Update pre-commit repo versions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 ---
 repos:
 - repo: https://github.com/ansible/ansible-lint.git
-  rev: v24.5.0
+  rev: v25.9.2
   hooks:
   - id: ansible-lint
     always_run: false
@@ -21,16 +21,16 @@ repos:
           --parseable
           --nocolor
 - repo: https://github.com/adrienverge/yamllint.git
-  rev: v1.35.1
+  rev: v1.37.1
   hooks:
   - id: yamllint
     files: \.(yaml|yml)$
 - repo: https://github.com/pycqa/flake8
-  rev: 7.2.0
+  rev: 7.3.0
   hooks:
   - id: flake8
 - repo: https://github.com/pycqa/pylint
-  rev: v3.2.2
+  rev: v4.0.2
   hooks:
   - id: pylint
     args:


### PR DESCRIPTION
ansible-lint version series 24.y is not working with ansible-core 2.19 and requires versions in series 25.y. Also, other tools were update to more recent versions.

## Summary by Sourcery

Update pre-commit configuration to use the latest versions of linting tools for improved compatibility and up-to-date checks

Enhancements:
- Bump ansible-lint pre-commit hook to v25.9.2 to ensure compatibility with ansible-core 2.19
- Update yamllint to v1.37.1, flake8 to v7.3.0, and pylint to v4.0.2