### PR TITLE
Remove ansible-core 2.20 deprecated imports

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -87,8 +87,8 @@ configured trust to an AD domain). For these cases, there are some `facts`
 available that will only enable the tests if the testing environment is
 enabled.
 
-The tests run automatically on every pull request, using Fedora, CentOS 7,
-and CentOS 8 environments.
+The tests run automatically on every pull request, using Fedora, and CentOS
+supported environments.
 
 See the document [Running the tests] and also the section `Preparing the
 development environment`, to prepare your environment.

--- a/README-host.md
+++ b/README-host.md
@@ -58,7 +58,7 @@ Example playbook to ensure host presence:
       ip_address: 192.168.0.123
       locality: Lab
       ns_host_location: Lab
-      ns_os_version: CentOS 7
+      ns_os_version: CentOS Stream 10
       ns_hardware_platform: Lenovo T61
       mac_address:
       - "08:00:27:E3:B1:2D"
@@ -89,7 +89,7 @@ Example playbook to ensure host presence with several IP addresses:
       - fe80::20c:29ff:fe02:a1b4
       locality: Lab
       ns_host_location: Lab
-      ns_os_version: CentOS 7
+      ns_os_version: CentOS Stream 10
       ns_hardware_platform: Lenovo T61
       mac_address:
       - "08:00:27:E3:B1:2D"

--- a/README.md
+++ b/README.md
@@ -67,7 +67,8 @@ The client role supports versions 4.4 and up, the server role is working with ve
 Supported Distributions
 -----------------------
 
-* RHEL/CentOS 7.4+
+* RHEL 8/9/10
+* CentOS Stream 8+
 * Fedora 40+
 * Ubuntu
 * Debian 10+ (ipaclient only, no server or replica!)

--- a/plugins/inventory/freeipa.py
+++ b/plugins/inventory/freeipa.py
@@ -104,7 +104,7 @@ from ansible import constants
 from ansible.errors import AnsibleParserError
 from ansible.module_utils.common.text.converters import to_native
 from ansible.plugins.inventory import BaseInventoryPlugin
-from ansible.module_utils.six.moves.urllib.parse import quote
+from urllib.parse import quote
 
 
 class InventoryModule(BaseInventoryPlugin):  # pylint: disable=R0901

--- a/plugins/modules/ipacert.py
+++ b/plugins/modules/ipacert.py
@@ -243,14 +243,9 @@ import base64
 import time
 import ssl
 
-from ansible.module_utils import six
-from ansible.module_utils._text import to_text
 from ansible.module_utils.ansible_freeipa_module import (
-    IPAAnsibleModule, certificate_loader, write_certificate_list,
+    IPAAnsibleModule, certificate_loader, write_certificate_list, to_text,
 )
-
-if six.PY3:
-    unicode = str
 
 # Reasons are defined in RFC 5280 sec. 5.3.1; removeFromCRL is not present in
 # this list; run the module with state=released instead.

--- a/plugins/modules/ipadnsforwardzone.py
+++ b/plugins/modules/ipadnsforwardzone.py
@@ -131,9 +131,8 @@ RETURN = '''
 '''
 
 
-from ansible.module_utils._text import to_text
 from ansible.module_utils.ansible_freeipa_module import \
-    IPAAnsibleModule, compare_args_ipa
+    IPAAnsibleModule, compare_args_ipa, to_text
 
 
 def find_dnsforwardzone(module, name):

--- a/plugins/modules/ipadnsrecord.py
+++ b/plugins/modules/ipadnsrecord.py
@@ -964,9 +964,8 @@ RETURN = """
 """
 
 
-from ansible.module_utils._text import to_text
 from ansible.module_utils.ansible_freeipa_module import \
-    IPAAnsibleModule, is_ipv4_addr, is_ipv6_addr, ipalib_errors
+    IPAAnsibleModule, is_ipv4_addr, is_ipv6_addr, ipalib_errors, to_text
 try:
     import dns.reversename
     import dns.resolver
@@ -975,10 +974,6 @@ except ImportError as _err:
 else:
     MODULE_IMPORT_ERROR = None
 
-from ansible.module_utils import six
-
-if six.PY3:
-    unicode = str
 
 _SUPPORTED_RECORD_TYPES = [
     "A", "AAAA", "A6", "AFSDB", "CERT", "CNAME", "DLV", "DNAME", "DS", "KX",

--- a/plugins/modules/ipadnszone.py
+++ b/plugins/modules/ipadnszone.py
@@ -233,11 +233,6 @@ from ansible.module_utils.ansible_freeipa_module import (
     DNSName,
     netaddr
 )  # noqa: E402
-from ansible.module_utils import six
-
-
-if six.PY3:
-    unicode = str
 
 
 class DNSZoneModule(IPAAnsibleModule):

--- a/plugins/modules/ipagroup.py
+++ b/plugins/modules/ipagroup.py
@@ -327,14 +327,10 @@ EXAMPLES = """
 RETURN = """
 """
 
-from ansible.module_utils._text import to_text
 from ansible.module_utils.ansible_freeipa_module import \
     IPAAnsibleModule, compare_args_ipa, gen_add_del_lists, \
     gen_add_list, gen_intersection_list, api_check_param, \
-    convert_to_sid
-from ansible.module_utils import six
-if six.PY3:
-    unicode = str
+    convert_to_sid, to_text
 # Ensuring (adding) several groups with mixed types external, nonposix
 # and posix require to have a fix in IPA:
 # FreeIPA issue: https://pagure.io/freeipa/issue/9349
@@ -675,11 +671,7 @@ def main():
 
                 check_parameters(ansible_module, state, action)
 
-            elif (
-                isinstance(
-                    group_name, (str, unicode)  # pylint: disable=W0012,E0606
-                )
-            ):
+            elif isinstance(group_name, str):
                 name = group_name
             else:
                 ansible_module.fail_json(msg="Group '%s' is not valid" %

--- a/plugins/modules/ipahost.py
+++ b/plugins/modules/ipahost.py
@@ -427,7 +427,7 @@ EXAMPLES = """
     ip_address: 192.168.0.123
     locality: Lab
     ns_host_location: Lab
-    ns_os_version: CentOS 7
+    ns_os_version: CentOS Stream 10
     ns_hardware_platform: Lenovo T61
     mac_address:
     - "08:00:27:E3:B1:2D"
@@ -511,10 +511,7 @@ from ansible.module_utils.ansible_freeipa_module import \
     IPAAnsibleModule, compare_args_ipa, gen_add_del_lists, \
     encode_certificate, is_ipv4_addr, is_ipv6_addr, ipalib_errors, \
     gen_add_list, gen_intersection_list, normalize_sshpubkey, \
-    convert_input_certificates
-from ansible.module_utils import six
-if six.PY3:
-    unicode = str
+    convert_input_certificates, to_text
 
 
 def find_host(module, name):
@@ -984,9 +981,7 @@ def main():
                     sshpubkey = [str(normalize_sshpubkey(key)) for
                                  key in sshpubkey]
 
-            elif (
-                isinstance(host, (str, unicode))  # pylint: disable=W0012,E0606
-            ):
+            elif isinstance(host, str):
                 name = host
             else:
                 ansible_module.fail_json(msg="Host '%s' is not valid" %
@@ -1105,10 +1100,8 @@ def main():
                                               res_find.get("managedby_host"))
                         principal_add, principal_del = gen_add_del_lists(
                             principal, res_find.get("krbprincipalname"))
-                        # Principals are not returned as utf8 for IPA using
-                        # python2 using host_show, therefore we need to
-                        # convert the principals that we should remove.
-                        principal_del = [unicode(x) for x in principal_del]
+                        # Convert principals to text for consistency
+                        principal_del = [to_text(x) for x in principal_del]
 
                         (allow_create_keytab_user_add,
                          allow_create_keytab_user_del) = \

--- a/plugins/modules/ipaidoverridegroup.py
+++ b/plugins/modules/ipaidoverridegroup.py
@@ -156,10 +156,6 @@ RETURN = """
 
 from ansible.module_utils.ansible_freeipa_module import \
     IPAAnsibleModule, compare_args_ipa, ipalib_errors
-from ansible.module_utils import six
-
-if six.PY3:
-    unicode = str
 
 
 def find_idoverridegroup(module, idview, anchor):

--- a/plugins/modules/ipaidoverrideuser.py
+++ b/plugins/modules/ipaidoverrideuser.py
@@ -317,10 +317,6 @@ from ansible.module_utils.ansible_freeipa_module import \
     IPAAnsibleModule, compare_args_ipa, gen_add_del_lists, gen_add_list, \
     gen_intersection_list, encode_certificate, convert_input_certificates, \
     ipalib_errors
-from ansible.module_utils import six
-
-if six.PY3:
-    unicode = str
 
 
 def find_idoverrideuser(module, idview, anchor):

--- a/plugins/modules/ipaidp.py
+++ b/plugins/modules/ipaidp.py
@@ -186,13 +186,9 @@ RETURN = """
 from ansible.module_utils.ansible_freeipa_module import \
     IPAAnsibleModule, compare_args_ipa, template_str, urlparse, \
     ipalib_errors
-from ansible.module_utils import six
 from copy import deepcopy
 import string
 from itertools import chain
-
-if six.PY3:
-    unicode = str
 
 # Copy from FreeIPA ipaserver/plugins/idp.py
 idp_providers = {

--- a/plugins/modules/ipaidrange.py
+++ b/plugins/modules/ipaidrange.py
@@ -145,10 +145,6 @@ RETURN = """
 from ansible.module_utils.ansible_freeipa_module import \
     IPAAnsibleModule, compare_args_ipa, get_trusted_domain_sid_from_name, \
     ipalib_errors
-from ansible.module_utils import six
-
-if six.PY3:
-    unicode = str
 
 
 def find_idrange(module, name):

--- a/plugins/modules/ipaidview.py
+++ b/plugins/modules/ipaidview.py
@@ -128,10 +128,6 @@ RETURN = """
 from ansible.module_utils.ansible_freeipa_module import \
     IPAAnsibleModule, compare_args_ipa, gen_add_del_lists, gen_add_list, \
     gen_intersection_list, ipalib_errors
-from ansible.module_utils import six
-
-if six.PY3:
-    unicode = str
 
 
 def find_idview(module, name):

--- a/plugins/modules/ipaprivilege.py
+++ b/plugins/modules/ipaprivilege.py
@@ -125,10 +125,6 @@ RETURN = """
 from ansible.module_utils.ansible_freeipa_module import \
     IPAAnsibleModule, compare_args_ipa, gen_add_del_lists, gen_add_list, \
     gen_intersection_list, ipalib_errors
-from ansible.module_utils import six
-
-if six.PY3:
-    unicode = str
 
 
 def find_privilege(module, name):

--- a/plugins/modules/iparole.py
+++ b/plugins/modules/iparole.py
@@ -131,14 +131,9 @@ EXAMPLES = """
 # pylint: disable=wrong-import-position
 # pylint: disable=import-error
 # pylint: disable=no-name-in-module
-from ansible.module_utils._text import to_text
 from ansible.module_utils.ansible_freeipa_module import \
     IPAAnsibleModule, gen_add_del_lists, compare_args_ipa, \
-    gen_intersection_list, ensure_fqdn, ipalib_errors
-from ansible.module_utils import six
-
-if six.PY3:
-    unicode = str
+    gen_intersection_list, ensure_fqdn, ipalib_errors, to_text
 
 
 def find_role(module, name):
@@ -298,7 +293,7 @@ def result_get_value_lowercase(res_find, key, default=None):
     if existing is not None:
         if isinstance(existing, (list, tuple)):
             existing = [to_text(item).lower() for item in existing]
-        if isinstance(existing, (str, unicode)):  # pylint: disable=W0012,E0606
+        if isinstance(existing, str):
             existing = existing.lower()
     else:
         existing = default

--- a/plugins/modules/ipaservice.py
+++ b/plugins/modules/ipaservice.py
@@ -423,9 +423,6 @@ from ansible.module_utils.ansible_freeipa_module import \
     IPAAnsibleModule, compare_args_ipa, encode_certificate, \
     gen_add_del_lists, gen_add_list, gen_intersection_list, ipalib_errors, \
     api_get_realm, to_text, convert_input_certificates
-from ansible.module_utils import six
-if six.PY3:
-    unicode = str
 
 
 def find_service(module, name):
@@ -729,11 +726,7 @@ def main():
 
                 delete_continue = service.get("delete_continue")
 
-            elif (
-                isinstance(
-                    service, (str, unicode)  # pylint: disable=W0012,E0606
-                )
-            ):
+            elif isinstance(service, str):
                 name = service
             else:
                 ansible_module.fail_json(msg="Service '%s' is not valid" %

--- a/plugins/modules/ipaservicedelegationrule.py
+++ b/plugins/modules/ipaservicedelegationrule.py
@@ -131,10 +131,6 @@ RETURN = """
 from ansible.module_utils.ansible_freeipa_module import \
     IPAAnsibleModule, gen_add_del_lists, gen_add_list, gen_intersection_list, \
     servicedelegation_normalize_principals, ipalib_errors
-from ansible.module_utils import six
-
-if six.PY3:
-    unicode = str
 
 
 def find_servicedelegationrule(module, name):

--- a/plugins/modules/ipaservicedelegationtarget.py
+++ b/plugins/modules/ipaservicedelegationtarget.py
@@ -107,10 +107,6 @@ RETURN = """
 from ansible.module_utils.ansible_freeipa_module import \
     IPAAnsibleModule, gen_add_del_lists, gen_add_list, gen_intersection_list, \
     servicedelegation_normalize_principals, ipalib_errors
-from ansible.module_utils import six
-
-if six.PY3:
-    unicode = str
 
 
 def find_servicedelegationtarget(module, name):

--- a/plugins/modules/ipauser.py
+++ b/plugins/modules/ipauser.py
@@ -745,9 +745,6 @@ from ansible.module_utils.ansible_freeipa_module import \
     encode_certificate, load_cert_from_str, DN_x500_text, to_text, \
     ipalib_errors, gen_add_list, gen_intersection_list, \
     convert_input_certificates, date_string
-from ansible.module_utils import six
-if six.PY3:
-    unicode = str
 
 
 def find_user(module, name):
@@ -1384,11 +1381,7 @@ def main():
 
                 email = extend_emails(email, default_email_domain)
 
-            elif (
-                isinstance(
-                    user, (str, unicode)  # pylint: disable=W0012,E0606
-                )
-            ):
+            elif isinstance(user, str):
                 name = user
             else:
                 ansible_module.fail_json(msg="User '%s' is not valid" %

--- a/plugins/modules/ipavault.py
+++ b/plugins/modules/ipavault.py
@@ -329,9 +329,8 @@ vault:
 
 import os
 from base64 import b64decode
-from ansible.module_utils._text import to_text
 from ansible.module_utils.ansible_freeipa_module import IPAAnsibleModule, \
-    gen_add_del_lists, compare_args_ipa, exit_raw_json, ipalib_errors
+    gen_add_del_lists, compare_args_ipa, exit_raw_json, ipalib_errors, to_text
 
 
 def find_vault(module, name, username, service, shared):

--- a/roles/ipabackup/README.md
+++ b/roles/ipabackup/README.md
@@ -32,7 +32,7 @@ FreeIPA versions 4.5 and up are supported by the backup role.
 Supported Distributions
 -----------------------
 
-* RHEL/CentOS 7.6+
+* RHEL 8/9/10
 * CentOS Stream 8+
 * Fedora 40+
 * Ubuntu 16.04 and 18.04

--- a/roles/ipaclient/README.md
+++ b/roles/ipaclient/README.md
@@ -23,7 +23,7 @@ FreeIPA versions 4.5 and up are supported by the client role. There is also limi
 Supported Distributions
 -----------------------
 
-* RHEL/CentOS 7.4+
+* RHEL 8/9/10
 * CentOS Stream 8+
 * Fedora 40+
 * Ubuntu

--- a/roles/ipaclient/library/ipaclient_get_otp.py
+++ b/roles/ipaclient/library/ipaclient_get_otp.py
@@ -78,8 +78,7 @@ import tempfile
 import shutil
 from contextlib import contextmanager
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_text
-from ansible.module_utils import six
+from ansible.module_utils.common.text.converters import to_text
 
 try:
     from ipalib import api
@@ -100,10 +99,6 @@ except ImportError as _err:
     MODULE_IMPORT_ERROR = str(_err)
 else:
     MODULE_IMPORT_ERROR = None
-
-
-if six.PY3:
-    unicode = str
 
 
 def temp_kinit(principal, password, keytab):

--- a/roles/ipaclient/library/ipaclient_test.py
+++ b/roles/ipaclient/library/ipaclient_test.py
@@ -244,11 +244,7 @@ selinux_works:
 
 import os
 import socket
-
-try:
-    from ansible.module_utils.six.moves.configparser import RawConfigParser
-except ImportError:
-    from ConfigParser import RawConfigParser
+from configparser import ConfigParser
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.ansible_ipa_client import (
@@ -300,7 +296,7 @@ def get_ipa_conf():
 
     :returns: dict containing key,value
     """
-    parser = RawConfigParser()
+    parser = ConfigParser()
     parser.read(paths.IPA_DEFAULT_CONF)
     result = {}
     for item in ['basedn', 'realm', 'domain', 'server', 'host', 'xmlrpc_uri']:

--- a/roles/ipareplica/README.md
+++ b/roles/ipareplica/README.md
@@ -26,7 +26,7 @@ FreeIPA versions 4.6 and up are supported by the replica role.
 Supported Distributions
 -----------------------
 
-* RHEL/CentOS 7.6+
+* RHEL 8/9/10
 * CentOS Stream 8+
 * Fedora 40+
 * Ubuntu 16.04 and 18.04

--- a/roles/ipareplica/library/ipareplica_add_to_ipaservers.py
+++ b/roles/ipareplica/library/ipareplica_add_to_ipaservers.py
@@ -71,16 +71,12 @@ RETURN = '''
 import os
 
 from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.common.text.converters import to_text
 from ansible.module_utils.ansible_ipa_replica import (
     check_imports, AnsibleModuleLog, setup_logging, installer, paths,
     gen_env_boostrap_finalize_core, constants, api_bootstrap_finalize,
     gen_remote_api, api
 )
-
-from ansible.module_utils import six
-
-if six.PY3:
-    unicode = str
 
 
 def main():
@@ -139,7 +135,7 @@ def main():
         conn.connect(ccache=installer._ccache)
         remote_api.Command['hostgroup_add_member'](
             u'ipaservers',
-            host=[unicode(api.env.host)],  # pylint: disable=W0012,E0606
+            host=[to_text(api.env.host)],
         )
     finally:
         if conn.isconnected():

--- a/roles/ipareplica/library/ipareplica_prepare.py
+++ b/roles/ipareplica/library/ipareplica_prepare.py
@@ -303,6 +303,7 @@ import traceback
 from shutil import copyfile
 
 from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.common.text.converters import to_text
 from ansible.module_utils.ansible_ipa_replica import (
     check_imports, AnsibleModuleLog, options, installer, DN, paths, sysrestore,
     ansible_module_get_parsed_ip_addresses, Env, ipautil, ipaldap,
@@ -315,10 +316,6 @@ from ansible.module_utils.ansible_ipa_replica import (
     constants, api, redirect_stdout, replica_conn_check, tasks,
     install_ca_cert
 )
-from ansible.module_utils import six
-
-if six.PY3:
-    unicode = str
 
 
 def main():
@@ -722,7 +719,7 @@ def main():
         # Check authorization
         result = remote_api.Command['hostgroup_find'](
             cn=u'ipaservers',
-            host=[unicode(api.env.host)]  # pylint: disable=W0012,E0606
+            host=[to_text(api.env.host)]
         )['result']
         add_to_ipaservers = not result
 

--- a/roles/ipaserver/README.md
+++ b/roles/ipaserver/README.md
@@ -23,7 +23,7 @@ FreeIPA versions 4.5 and up are supported by the server role.
 Supported Distributions
 -----------------------
 
-* RHEL/CentOS 7.6+
+* RHEL 8/9/10
 * CentOS Stream 8+
 * Fedora 40+
 * Ubuntu 16.04 and 18.04

--- a/roles/ipaserver/library/ipaserver_get_connected_server.py
+++ b/roles/ipaserver/library/ipaserver_get_connected_server.py
@@ -66,8 +66,7 @@ import tempfile
 import shutil
 from contextlib import contextmanager
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_text
-from ansible.module_utils import six
+from ansible.module_utils.common.text.converters import to_text
 
 try:
     from ipalib import api
@@ -88,10 +87,6 @@ except ImportError as _err:
     MODULE_IMPORT_ERROR = str(_err)
 else:
     MODULE_IMPORT_ERROR = None
-
-
-if six.PY3:
-    unicode = str
 
 
 def temp_kinit(principal, password):

--- a/roles/ipaserver/module_utils/ansible_ipa_server.py
+++ b/roles/ipaserver/module_utils/ansible_ipa_server.py
@@ -76,7 +76,6 @@ except ImportError:
 
 try:
     from contextlib import contextmanager as contextlib_contextmanager
-    from ansible.module_utils import six
     import base64
 
     from ipapython.version import NUM_VERSION, VERSION
@@ -448,8 +447,7 @@ def encode_certificate(cert):
         encoded = base64.b64encode(cert)
     else:
         encoded = base64.b64encode(cert.public_bytes(Encoding.DER))
-    if not six.PY2:
-        encoded = encoded.decode('ascii')
+    encoded = encoded.decode('ascii')
     return encoded
 
 

--- a/roles/ipasmartcard_client/README.md
+++ b/roles/ipasmartcard_client/README.md
@@ -23,7 +23,7 @@ FreeIPA versions 4.5 and up are supported by this role.
 Supported Distributions
 -----------------------
 
-* RHEL/CentOS 7.6+
+* RHEL 8/9/10
 * CentOS Stream 8+
 * Fedora 40+
 

--- a/roles/ipasmartcard_server/README.md
+++ b/roles/ipasmartcard_server/README.md
@@ -25,7 +25,7 @@ FreeIPA versions 4.5 and up are supported by this role.
 Supported Distributions
 -----------------------
 
-* RHEL/CentOS 7.6+
+* RHEL 8/9/10
 * CentOS Stream 8+
 * Fedora 40+
 

--- a/utils/ansible-freeipa.spec.in
+++ b/utils/ansible-freeipa.spec.in
@@ -82,8 +82,9 @@ versions 4.5 and up, the replica role is currently only working with versions
 
 Supported Distributions
 
-- RHEL/CentOS 7.4+
-- Fedora 26+
+- RHEL 8/9/10
+- CentOS Stream 8+
+- Fedora 40+
 - Ubuntu
 - Debian 10+ (ipaclient only, no server or replica!)
 


### PR DESCRIPTION
This patch removes all dependencies on the 'asible.module_util.six'
module and fixes deprecated imports as defined by the ansible-core
release version 2.20.

This changes render ansible-freeipa collection incompatible with
Python 2.

Changes include:

* Remove six module imports from all modules and roles
  - Removed 'from ansible.module_utils import six' statements
  - Removed 'from ansible.module_utils.six.moves' imports

* Replace and remove Python version checks (six.PY3 and six.PY2)

* Replace unicode usage with to_text or str

* Ensure text conversion routines imports are consistent and are
  imported from Ansible common.text.converters

* Update standard library imports
  - Changed 'six.moves.urllib.parse' to 'urllib.parse'
  - Changed 'six.moves.configparser' to 'ConfigParser'
  - Import 'Mapping' from 'collections.abc'

* Remove Python 2 specific code

Note that this change **only** addresses the deprecation issues
with ansible-core 2.20. For full migration from Python 2 the
minimum supported IPA version should be 4.9, that currently targets
Python 3.6. 

Fixes #1399

## Summary by Sourcery

Remove deprecated ansible.module_utils.six usage and Python 2 compatibility code to comply with ansible-core 2.20 deprecations.

Enhancements:
- Remove all imports and usage of ansible.module_utils.six and eliminate Python 2 specific branches.
- Replace unicode references with str or to_text and consolidate text conversion imports from ansible.module_utils.common.text.converters.
- Update standard library imports to modern modules (urllib.parse, ConfigParser, collections.abc.Mapping).
- Revise certificate tests to use regex matching for "not found" messages instead of hardcoded substrings.