### PR TITLE
upstream CI: Fix CheckPR ansible-core version definition

### DIFF
--- a/infra/azure/pr-pipeline.yml
+++ b/infra/azure/pr-pipeline.yml
@@ -12,11 +12,11 @@ parameters:
   - name: "distro_ansible_map"
     type: object
     default:
-    - { distro: "c8s", ansible_version: "2.16" }
+    - { distro: "c8s", ansible_version: "<2.17" }
     # c9s should use 2.14, but this version has an invalid certificate
     # and so is unsuable against ansible-galaxy.
-    - { distro: "c9s", ansible_version: "2.16" }
-    - { distro: "c10s", ansible_version: "2.16" }
+    - { distro: "c9s", ansible_version: "<2.17" }
+    - { distro: "c10s", ansible_version: "<2.17" }
 
 variables:
   distros: "fedora-latest,c10s,c9s,fedora-rawhide"
@@ -62,6 +62,6 @@ stages:
       parameters:
         build_number: $(Build.BuildNumber)
         distro: ${{ config.distro }}
-        ansible_version: -core==${{ config.ansible_version }}
+        ansible_version: -core${{ config.ansible_version }}
         skip_git_test: false
         test_galaxy: false


### PR DESCRIPTION
By using the 'ansible-version' variable as '<2.17' allows 'pip' to install the latest version of the 2.16 series, instead of version 2.16.0 in the case '==2.16'. This ensures we run the tests with the latest supported version for the specific distro.

## Summary by Sourcery

Update PR Azure pipeline to test against the latest compatible ansible-core 2.16.x releases across supported distros.

Bug Fixes:
- Fix ansible-core version specification so CI installs the latest 2.16.x instead of pinning to 2.16.0 for CheckPR jobs.

Enhancements:
- Generalize ansible-core version constraint in the distro-to-version map and corresponding pipeline parameter to use a '<2.17' range.