### PR TITLE
Cert tests: Do not fail on new dogtag profile not found error message

### DIFF
--- a/tests/cert/test_cert_host.yml
+++ b/tests/cert/test_cert_host.yml
@@ -194,7 +194,7 @@
       profile: invalid_profile
       state: requested
     register: result
-    failed_when: not (result.failed and "Request failed with status 400" in result.msg)
+    failed_when: not (result.failed and ("Request failed with status 400" in result.msg or "Profile not found" in result.msg))
 
 
   # CLEANUP TEST ITEMS

--- a/tests/cert/test_cert_service.yml
+++ b/tests/cert/test_cert_service.yml
@@ -207,7 +207,7 @@
       profile: invalid_profile
       state: requested
     register: result
-    failed_when: not (result.failed and "Request failed with status 400" in result.msg)
+    failed_when: not (result.failed and ("Request failed with status 400" in result.msg or "Profile not found" in result.msg))
 
   # CLEANUP TEST ITEMS
 

--- a/tests/cert/test_cert_user.yml
+++ b/tests/cert/test_cert_user.yml
@@ -194,7 +194,7 @@
       profile: invalid_profile
       state: requested
     register: result
-    failed_when: not (result.failed and "Request failed with status 400" in result.msg)
+    failed_when: not (result.failed and ("Request failed with status 400" in result.msg or "Profile not found" in result.msg))
 
   # CLEANUP TEST ITEMS
 


### PR DESCRIPTION
The error message for an invalid profile has changes in dogtag. The new message is "Certificate operation cannot be completed: Unable to get enrollment template for <profile name>: Profile not found"

Therefore the test is additionally checking for "Profile not found" now.

## Summary by Sourcery

Tests:
- Extend cert host, service, and user invalid profile tests to also match the new 'Profile not found' Dogtag error message in addition to the existing HTTP 400 text.