### PR TITLE
upstream ci: Use version_name for CheckPR labels

### DIFF
--- a/infra/azure/pr-pipeline.yml
+++ b/infra/azure/pr-pipeline.yml
@@ -12,11 +12,11 @@ parameters:
   - name: "distro_ansible_map"
     type: object
     default:
-    - { distro: "c8s", ansible_version: "<2.17" }
+    - { distro: "c8s", ansible_version: "<2.17", version_name: "2.16" }
     # c9s should use 2.14, but this version has an invalid certificate
     # and so is unsuable against ansible-galaxy.
-    - { distro: "c9s", ansible_version: "<2.17" }
-    - { distro: "c10s", ansible_version: "<2.17" }
+    - { distro: "c9s", ansible_version: "<2.17", version_name: "2.16" }
+    - { distro: "c10s", ansible_version: "<2.17", version_name: "2.16" }
 
 variables:
   distros: "fedora-latest,c10s,c9s,fedora-rawhide"
@@ -55,7 +55,7 @@ stages:
 # Test with pinned ansible version for the distro
 
 - ${{ each config in parameters.distro_ansible_map }}:
-  - stage: ${{ config.distro }}_distro_ansible_${{ replace(config.ansible_version, '.', '_') }}
+  - stage: ${{ config.distro }}_distro_ansible_${{ replace(config.version_name, '.', '_') }}
     dependsOn: []
     jobs:
     - template: templates/run_tests.yml


### PR DESCRIPTION
As the ansible_version variable may contain a version specification, we need a version_name to correctly report the job label in Azure.

## Summary by Sourcery

CI:
- Extend distro_ansible_map entries with a version_name field for CentOS stream distros and reference it in stage naming for PR checks.