### PR TITLE
Fix Ansible warnings in Firewall zone testing tasks

### DIFF
--- a/roles/ipabackup/tasks/restore.yml
+++ b/roles/ipabackup/tasks/restore.yml
@@ -91,20 +91,21 @@
       enabled: yes
       state: started
 
-  - name: Firewalld - Verify runtime zone "{{ ipabackup_firewalld_zone }}"
-    ansible.builtin.shell: >
-      firewall-cmd
-      --info-zone="{{ ipabackup_firewalld_zone }}"
-      >/dev/null
+  - name: Firewalld - Verify zones
     when: ipabackup_firewalld_zone is defined
+    block:
+    - name: Firewalld - Verify runtime zone from ipabackup_firewalld_zone
+      ansible.builtin.shell: >
+        firewall-cmd
+        --info-zone="{{ ipabackup_firewalld_zone }}"
+        >/dev/null
 
-  - name: Firewalld - Verify permanent zone "{{ ipabackup_firewalld_zone }}"
-    ansible.builtin.shell: >
-      firewall-cmd
-      --permanent
-      --info-zone="{{ ipabackup_firewalld_zone }}"
-      >/dev/null
-    when: ipabackup_firewalld_zone is defined
+    - name: Firewalld - Verify permanent zone from ipabackup_firewalld_zone
+      ansible.builtin.shell: >
+        firewall-cmd
+        --permanent
+        --info-zone="{{ ipabackup_firewalld_zone }}"
+        >/dev/null
 
 ### RESTORE
 

--- a/roles/ipareplica/tasks/install.yml
+++ b/roles/ipareplica/tasks/install.yml
@@ -47,20 +47,21 @@
       enabled: yes
       state: started
 
-  - name: Firewalld - Verify runtime zone "{{ ipareplica_firewalld_zone }}"
-    ansible.builtin.shell: >
-      firewall-cmd
-      --info-zone="{{ ipareplica_firewalld_zone }}"
-      >/dev/null
+  - name: Firewalld - Verify zones
     when: ipareplica_firewalld_zone is defined
+    block:
+    - name: Firewalld - Verify runtime zone from ipareplica_firewalld_zone
+      ansible.builtin.shell: >
+        firewall-cmd
+        --info-zone="{{ ipareplica_firewalld_zone }}"
+        >/dev/null
 
-  - name: Firewalld - Verify permanent zone "{{ ipareplica_firewalld_zone }}"
-    ansible.builtin.shell: >
-      firewall-cmd
-      --permanent
-      --info-zone="{{ ipareplica_firewalld_zone }}"
-      >/dev/null
-    when: ipareplica_firewalld_zone is defined
+    - name: Firewalld - Verify permanent zone from ipareplica_firewalld_zone
+      ansible.builtin.shell: >
+        firewall-cmd
+        --permanent
+        --info-zone="{{ ipareplica_firewalld_zone }}"
+        >/dev/null
 
 - name: Install - Set ipareplica_servers
   ansible.builtin.set_fact:

--- a/roles/ipaserver/tasks/install.yml
+++ b/roles/ipaserver/tasks/install.yml
@@ -47,20 +47,21 @@
       enabled: yes
       state: started
 
-  - name: Firewalld - Verify runtime zone "{{ ipaserver_firewalld_zone }}"
-    ansible.builtin.shell: >
-      firewall-cmd
-      --info-zone="{{ ipaserver_firewalld_zone }}"
-      >/dev/null
+  - name: Firewalld - verify zones
     when: ipaserver_firewalld_zone is defined
+    block:
+    - name: Firewalld - Verify runtime zone from ipaserver_firewalld_zone
+      ansible.builtin.shell: >
+        firewall-cmd
+        --info-zone="{{ ipaserver_firewalld_zone }}"
+        >/dev/null
 
-  - name: Firewalld - Verify permanent zone "{{ ipaserver_firewalld_zone }}"
-    ansible.builtin.shell: >
-      firewall-cmd
-      --permanent
-      --info-zone="{{ ipaserver_firewalld_zone }}"
-      >/dev/null
-    when: ipaserver_firewalld_zone is defined
+    - name: Firewalld - Verify permanent zone from ipaserver_firewalld_zone
+      ansible.builtin.shell: >
+        firewall-cmd
+        --permanent
+        --info-zone="{{ ipaserver_firewalld_zone }}"
+        >/dev/null
 
 - name: Copy external certs
   ansible.builtin.include_tasks: "{{ role_path }}/tasks/copy_external_cert.yml"


### PR DESCRIPTION
The firewalld zone verification tasks in ipaserver, ipareplica, and ipabackup roles were triggering Ansible warnings due to variable ipareplica_firewalld_zone not being defined when evaluating the task name.

This fix remove the Jinja template from the task names and wrap the tasks in a single block so the variable verification is done only once.

## Summary by Sourcery

Bug Fixes:
- Prevent Ansible warnings by removing Jinja templating from task names and ensuring firewalld zone checks only run when the corresponding zone variable is defined.