### PR TITLE
Reworked and renamed script to generate Ansible collections

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,8 +17,8 @@ jobs:
       - name: Run ansible-lint
         run: |
           pip install "ansible-core>=2.16,<2.17" 'ansible-lint==6.22'
-          utils/build-galaxy-release.sh -ki
-          cd .galaxy-build
+          utils/build-collection.sh -ki rpm
+          cd .collection-build
           ansible-lint --profile production --exclude tests/integration/ --exclude tests/unit/ --parseable --nocolor
 
   yamllint:

--- a/infra/azure/templates/run_tests.yml
+++ b/infra/azure/templates/run_tests.yml
@@ -54,7 +54,7 @@ jobs:
 
   - script: |
       git fetch --unshallow
-      utils/build-galaxy-release.sh -i
+      utils/build-collection.sh -i rpm
     retryCountOnTaskFailure: 5
     displayName: Build Galaxy release
     condition: ${{ parameters.test_galaxy }}

--- a/tests/sanity/sanity.sh
+++ b/tests/sanity/sanity.sh
@@ -19,7 +19,7 @@ pip install galaxy_importer
 rm -f "$ANSIBLE_COLLECTION"-*.tar.gz
 rm -f importer_result.json
 
-utils/build-galaxy-release.sh
+utils/build-collection.sh rpm
 
 sed "s/LOCAL_IMAGE_DOCKER = True/LOCAL_IMAGE_DOCKER = ${use_docker}/" < tests/sanity/galaxy-importer.cfg > ${VENV}/galaxy-importer.cfg
 export GALAXY_IMPORTER_CONFIG=${VENV}/galaxy-importer.cfg


### PR DESCRIPTION
The script utils/build-galaxy-release.sh has been renamed to utils/build-collection.sh, the script provides the same options, but requires an extra argument now:

    build-collection.sh [options] rpm|aah|galaxy

The namespace and name are defined according to the argument:

    rpm     freeipa.ansible_freeipa   - General use and RPMs
    galaxy  freeipa.ansible_freeipa   - Ansible Galaxy
    aah     redhat.rhel_idm           - Ansible AutomationHub

The generated file README-COLLECTION.md is set in galaxy.yml as the documentation entry point for the collections generated with aah and galaxy as Ansible AutomationHub and also Ansible Galaxy are not able to render the documentation README files in the collection properly.

The commit also changes the calls of utils/build-galaxy-release.sh to utils/build-collection.sh.

## Summary by Sourcery

Rework the Ansible collection build script to support distinct targets for RPM, Ansible Galaxy, and Automation Hub, and update references across the project.

Enhancements:
- Rename the collection build script to build-collection.sh and change its interface to require a target type (rpm, galaxy, or aah) that determines namespace and collection name.
- Adjust the build process to use a generic build directory, clean VCS and CI artifacts, and set collection metadata (version, namespace, name) via a unified version variable.
- Generate a README-COLLECTION.md file and configure galaxy.yml to use it as the documentation entry point for Galaxy and Automation Hub builds, including additional support information for Automation Hub collections.

CI:
- Update GitHub Actions, Azure Pipelines, and sanity test scripts to call the new build-collection.sh script with the appropriate rpm target.