### PR TITLE
infra/image/shcontainer: New container_save and container_load

### DIFF
--- a/infra/image/shcontainer
+++ b/infra/image/shcontainer
@@ -228,3 +228,22 @@ container_tee() {
     rm "${tmpfile}"
     echo
 }
+
+container_save() {
+    local name=${1}
+
+    archive="${name}.tar"
+    log info "= Saving ${name} to ${archive} ="
+    # podman is not able to overwrite the archive
+    [ -f "${archive}" ] && rm "${archive}"
+    podman save -o "${archive}" "${name}"
+    echo
+}
+
+container_load() {
+    local name=${1}
+
+    image_name=$(podman load -q -i "${name}" | sed -e "s/^Loaded image: //")
+    image=$(podman image list -q "${image_name}")
+    echo "$image"
+}


### PR DESCRIPTION
The new container_save and container_load functions can be used to save and load container images.

container_save
    Save a container image to a local file.
    Example: container_save "${name}"

container_load
    Load a container image from an tar archive.
    Example: local_image=$(container_load "${archive}")

## Summary by Sourcery

Add shell helpers to save and load container images within the infra image tooling.

New Features:
- Introduce container_save to export a container image to a local file.
- Introduce container_load to import a container image from a tar archive into the local container runtime.