### PR TITLE
[WIP] ipaserver: Add support for key_type_size

### DIFF
--- a/infra/image/build-inventory
+++ b/infra/image/build-inventory
@@ -13,3 +13,4 @@ ipaserver_auto_reverse=true
 ipaserver_setup_kra=true
 ipaserver_setup_firewalld=false
 ipaclient_no_ntp=true
+ipaserver_key_type_size="rsa:2048"

--- a/roles/ipaserver/README.md
+++ b/roles/ipaserver/README.md
@@ -327,6 +327,7 @@ Variable | Description | Required
 `ipaserver_subject_base` | The certificate subject base (default O=<realm-name>). RDNs are in LDAP order (most specific RDN first). (string) | no
 `ipaserver_ca_subject` | The CA certificate subject DN (default CN=Certificate Authority,O=<realm-name>). RDNs are in LDAP order (most specific RDN first). (string) | no
 `ipaserver_ca_signing_algorithm` | Signing algorithm of the IPA CA certificate. (choice: SHA1withRSA, SHA256withRSA, SHA512withRSA) | no
+`ipaserver_key_type_size` | The key type and size for HTTP, LDAP, PKINIT and RA (if CA configured) certificates. Requires FreeIPA version 4.13 or later. (default:"rsa:2048") | no
 
 DNS Variables
 -------------

--- a/roles/ipaserver/library/ipaserver_prepare.py
+++ b/roles/ipaserver/library/ipaserver_prepare.py
@@ -238,8 +238,16 @@ options:
     type: bool
     default: no
     required: no
+  key_type_size:
+    description:
+        The key type and size for HTTP, LDAP, PKINIT and RA (if CA
+        configured) certificates (Requires IPA 4.13+)
+    type: str
+    default: "rsa:2048"
+    required: no
 author:
     - Thomas Woerner (@t-woerner)
+    - Rafael Jeffman (@rjeffman)
 '''
 
 EXAMPLES = '''
@@ -329,6 +337,7 @@ def main():
                                        default=False),
             _hostname_overridden=dict(required=False, type='bool',
                                       default=False),
+            key_type_size=dict(required=False, type="str", default="rsa:2048"),
         ),
         supports_check_mode=False,
     )
@@ -411,6 +420,7 @@ def main():
         '_hostname_overridden')
     sid_generation_always = ansible_module.params.get('sid_generation_always')
     options.kasp_db_file = None
+    options.key_type_size = ansible_module.params.get('key_type_size')
 
     # init ##################################################################
 

--- a/roles/ipaserver/library/ipaserver_prepare.py
+++ b/roles/ipaserver/library/ipaserver_prepare.py
@@ -243,7 +243,7 @@ options:
         The key type and size for HTTP, LDAP, PKINIT and RA (if CA
         configured) certificates (Requires IPA 4.13+)
     type: str
-    default: "rsa:2048"
+    default: None
     required: no
 author:
     - Thomas Woerner (@t-woerner)
@@ -337,7 +337,7 @@ def main():
                                        default=False),
             _hostname_overridden=dict(required=False, type='bool',
                                       default=False),
-            key_type_size=dict(required=False, type="str", default="rsa:2048"),
+            key_type_size=dict(required=False, type="str", default=None),
         ),
         supports_check_mode=False,
     )
@@ -421,6 +421,14 @@ def main():
     sid_generation_always = ansible_module.params.get('sid_generation_always')
     options.kasp_db_file = None
     options.key_type_size = ansible_module.params.get('key_type_size')
+    if hasattr(installutils, "validate_key_type_size"):
+        _err = installutils.validate_key_type_size(options.key_type_size)
+        if _err:
+            ansible_module.fail_json(msg=_err)
+    else:
+        if ansible_module.params.get('key_type_size') is not None:
+            ansible_module.fail_json(
+                msg="IPA version does not support attribute 'key_type_size'")
 
     # init ##################################################################
 
@@ -452,6 +460,8 @@ def main():
             # make sure host name specified by user is used instead of default
             host=options.host_name,
         )
+        if options.key_type_size:
+            cfg['key_type_size'] = options.key_type_size
         if options.setup_ca:
             # we have an IPA-integrated CA
             cfg['ca_host'] = options.host_name
@@ -593,6 +603,7 @@ def main():
         ca_subject=options.ca_subject,
         _ca_subject=options._ca_subject,
         _random_serial_numbers=options._random_serial_numbers,
+        key_type_size=options.key_type_size,
         # dns
         reverse_zones=options.reverse_zones,
         forward_policy=options.forward_policy,

--- a/roles/ipaserver/library/ipaserver_setup_ca.py
+++ b/roles/ipaserver/library/ipaserver_setup_ca.py
@@ -178,6 +178,13 @@ options:
     description: The installer _random_serial_numbers setting
     type: bool
     required: yes
+  key_type_size:
+    description:
+        The key type and size for HTTP, LDAP, PKINIT and RA (if CA
+        configured) certificates (Requires IPA 4.13+)
+    type: str
+    required: no
+    default: None
   reverse_zones:
     description: The reverse DNS zones to use
     type: list
@@ -204,6 +211,7 @@ options:
     required: no
 author:
     - Thomas Woerner (@t-woerner)
+    - Rafael Jeffman (@rjeffman)
 '''
 
 EXAMPLES = '''
@@ -263,6 +271,7 @@ def main():
             _ca_subject=dict(required=False, type='str'),
             ca_signing_algorithm=dict(required=False, type='str'),
             _random_serial_numbers=dict(required=True, type='bool'),
+            key_type_size=dict(required=False, type='str', default=None),
             # dns
             reverse_zones=dict(required=False, type='list', elements='str',
                                default=[]),
@@ -328,6 +337,7 @@ def main():
         'ca_signing_algorithm')
     options._random_serial_numbers = ansible_module.params.get(
         '_random_serial_numbers')
+    options.key_type_size = ansible_module.params.get('key_type_size')
     # dns
     options.reverse_zones = ansible_module.params.get('reverse_zones')
     options.no_reverse = ansible_module.params.get('no_reverse')
@@ -351,7 +361,8 @@ def main():
 
     fstore = sysrestore.FileStore(paths.SYSRESTORE)
 
-    api_Backend_ldap2(options.host_name, options.setup_ca, connect=True)
+    api_Backend_ldap2(options.host_name, options.setup_ca, connect=True,
+                      key_type_size=options.key_type_size)
 
     ds = ds_init_info(ansible_log, fstore,
                       options.domainlevel, options.dirsrv_config_file,

--- a/roles/ipaserver/module_utils/ansible_ipa_server.py
+++ b/roles/ipaserver/module_utils/ansible_ipa_server.py
@@ -376,10 +376,12 @@ options.ignore_last_of_role = False
 
 
 # pylint: disable=invalid-name
-def api_Backend_ldap2(host_name, setup_ca, connect=False):
+def api_Backend_ldap2(host_name, setup_ca, connect=False, key_type_size=None):
     # we are sure we have the configuration file ready.
     cfg = dict(context='installer', confdir=paths.ETC_IPA, in_server=True,
                host=host_name)
+    if key_type_size:
+        cfg['key_type_size'] = key_type_size
     if setup_ca:
         # we have an IPA-integrated CA
         cfg['ca_host'] = host_name

--- a/roles/ipaserver/tasks/install.yml
+++ b/roles/ipaserver/tasks/install.yml
@@ -325,6 +325,7 @@
       ca_signing_algorithm: "{{ ipaserver_ca_signing_algorithm |
                                 default(omit) }}"
       _random_serial_numbers: "{{ result_ipaserver_prepare._random_serial_numbers }}"
+      key_type_size: "{{ result_ipaserver_prepare.key_type_size }}"
       reverse_zones: "{{ result_ipaserver_prepare.reverse_zones }}"
       no_reverse: "{{ ipaserver_no_reverse }}"
       auto_forwarders: "{{ ipaserver_auto_forwarders }}"

--- a/roles/ipaserver/tasks/install.yml
+++ b/roles/ipaserver/tasks/install.yml
@@ -223,6 +223,7 @@
       sid_generation_always: "{{ result_ipaserver_test.sid_generation_always }}"
       random_serial_numbers: "{{ result_ipaserver_test.random_serial_numbers }}"
       _hostname_overridden: "{{ result_ipaserver_test._hostname_overridden }}"
+      key_type_size: "{{ ipaserver_key_type_size | default(omit) }}"
     register: result_ipaserver_prepare
 
   - name: Install - Setup NTP


### PR DESCRIPTION
Since FreeIPA version 4.13.0, the CLI installation supports parameter --key-size-type which allows the selection of the key signing type and length. This will be used to support post-quantum cryptography, as can be seen in FreeIPA PR #8160 [1].

This patch adds the argument 'ipaserver_key_type_size' to ipaserver deployment role, as is must be used on the deployment of the first server. The values for the parameter are defined as '<type>:<bitlength>' and defaults to 'rsa:2048', as does FreeIPA in its current release.

After deployment, the change can be verified using the ipa command 'config-show', and looking at value for 'IPA Service key type:size'.

[1]: https://github.com/freeipa/freeipa/pull/8160

## Summary by Sourcery

Add support for configuring the key type and size used by IPA server certificates during initial server deployment.

New Features:
- Introduce an ipaserver role parameter to specify key type and size for HTTP, LDAP, PKINIT and RA certificates, defaulting to rsa:2048.

Documentation:
- Document the new ipaserver_key_type_size variable and its default in the ipaserver role README.