### PR TITLE
Add --diff support to some IPA modules

### DIFF
--- a/plugins/module_utils/ansible_freeipa_module.py
+++ b/plugins/module_utils/ansible_freeipa_module.py
@@ -582,6 +582,50 @@ def merge_diffs(*diff_pairs):
     return merged_before, merged_after
 
 
+def gen_members_diff(res_find, member_specs):
+    """Compute the merged member-list diff for all categories of one IPA
+    object.
+
+    `res_find` is the dict returned by `find_*()` (or None when the object
+    does not yet exist). `member_specs` is an iterable of
+    `(member_key, add_list, del_list, current_source)` tuples, where:
+
+    * `member_key` (str) is the key under which the change is reported in
+      the diff (e.g. `"user"`, `"hostgroup"`).
+    * `add_list` and `del_list` are the (possibly empty) lists of additions
+      and deletions for this category.
+    * `current_source` describes how to read the current member list from
+      `res_find`:
+
+      * a single str: a key name in `res_find`.
+      * a list/tuple of str: several key names whose values are
+        concatenated (used when the IPA API splits one logical list across
+        multiple attributes, e.g. `memberhost_host` + `externalhost`).
+      * any other iterable: used directly as the current list (useful when
+        the caller pre-built it).
+
+    Returns a single `(before, after)` pair, with all per-category diffs
+    merged.
+    """
+    if res_find is None:
+        res_find = {}
+    pairs = []
+    for member_key, add_list, del_list, source in member_specs:
+        if isinstance(source, str):
+            current = res_find.get(source)
+        elif (
+            isinstance(source, (list, tuple))
+            and all(isinstance(x, str) for x in source)
+        ):
+            current = []
+            for key in source:
+                current.extend(res_find.get(key, []) or [])
+        else:
+            current = source
+        pairs.append(gen_member_diff(member_key, add_list, del_list, current))
+    return merge_diffs(*pairs)
+
+
 def _afm_convert(value):
     if value is not None:
         if isinstance(value, list):

--- a/plugins/module_utils/ansible_freeipa_module.py
+++ b/plugins/module_utils/ansible_freeipa_module.py
@@ -484,6 +484,104 @@ def compare_args_ipa(module, args, ipa, ignore=None):  # noqa
     return True
 
 
+def _compare_key(arg, ipa_arg):
+    """Compare a single key's value using compare_args_ipa logic."""
+    if isinstance(ipa_arg, (list, tuple)):
+        if not isinstance(arg, list):
+            arg = [arg]
+        if len(ipa_arg) != len(arg):
+            return False
+        if ipa_arg and arg and not (
+            isinstance(ipa_arg[0], type(arg[0]))
+            or isinstance(arg[0], type(ipa_arg[0]))
+        ):
+            arg = [to_text(_a) for _a in arg]
+        try:
+            return set(arg) == set(ipa_arg)
+        except TypeError:
+            return arg == ipa_arg
+    return arg == ipa_arg
+
+
+class IPADiffTracker:
+    """Track before/after state for Ansible --diff output."""
+
+    def __init__(self):
+        self._diffs = []
+
+    def build_diff(self):
+        """Return kwargs for exit_json (empty dict if no changes)."""
+        if not self._diffs:
+            return {}
+        return {"diff": self._diffs}
+
+    def add_entry_diff(self, name, before, after):
+        """Record a diff entry for one IPA object."""
+        if before == after:
+            return
+        self._diffs.append({
+            "before_header": name,
+            "after_header": name,
+            "before": before,
+            "after": after,
+        })
+
+
+def gen_args_diff(args, res_find, ignore=None):
+    """Extract only changed keys from args vs res_find for diff output.
+
+    Returns (before_dict, after_dict) containing only keys that differ.
+    Uses the same comparison logic as compare_args_ipa for consistency.
+    Single-element IPA lists are normalized to scalars for readability.
+    """
+    if not args:
+        return {}, {}
+    before = {}
+    after = {}
+    if ignore is None:
+        ignore = []
+    for key in args:
+        if key in ignore:
+            continue
+        arg = args[key]
+        ipa_arg = res_find.get(key, [""])
+        if not _compare_key(arg, ipa_arg):
+            # Normalize for display
+            _ipa = ipa_arg[0] if isinstance(ipa_arg, (list, tuple)) \
+                and len(ipa_arg) == 1 else ipa_arg
+            _arg = arg[0] if isinstance(arg, (list, tuple)) \
+                and len(arg) == 1 else arg
+            before[key] = _ipa
+            after[key] = _arg
+    return before, after
+
+
+def gen_member_diff(member_key, add_list, del_list, current_list):
+    """Compute before/after for one member category.
+
+    Returns (before_dict, after_dict) with member_key as key and sorted
+    lists as values. Returns ({}, {}) if no changes.
+    """
+    if not add_list and not del_list:
+        return {}, {}
+    current = sorted(current_list or [])
+    desired = sorted(
+        [x for x in current if x not in (del_list or [])]
+        + (add_list or [])
+    )
+    return {member_key: current}, {member_key: desired}
+
+
+def merge_diffs(*diff_pairs):
+    """Merge multiple (before, after) tuples into a single pair."""
+    merged_before = {}
+    merged_after = {}
+    for _before, _after in diff_pairs:
+        merged_before.update(_before)
+        merged_after.update(_after)
+    return merged_before, merged_after
+
+
 def _afm_convert(value):
     if value is not None:
         if isinstance(value, list):

--- a/plugins/modules/ipagroup.py
+++ b/plugins/modules/ipagroup.py
@@ -331,7 +331,7 @@ from ansible.module_utils._text import to_text
 from ansible.module_utils.ansible_freeipa_module import \
     IPAAnsibleModule, compare_args_ipa, gen_add_del_lists, \
     gen_add_list, gen_intersection_list, api_check_param, \
-    convert_to_sid, IPADiffTracker, gen_args_diff, gen_member_diff, \
+    convert_to_sid, IPADiffTracker, gen_args_diff, gen_members_diff, \
     merge_diffs
 from ansible.module_utils import six
 if six.PY3:
@@ -965,70 +965,37 @@ def main():
                          }]
                     )
 
-            # Diff tracking
-            _orig = res_find_orig or {}
+            # Diff tracking. The same set of member specs is reused for
+            # state=present (action=group adds attribute changes on top) and
+            # state=absent action=member.
+            member_specs = [
+                ("user", user_add, user_del, "member_user"),
+                ("group", group_add, group_del, "member_group"),
+                ("service", service_add, service_del, "member_service"),
+                ("external", externalmember_add, externalmember_del,
+                 ["member_external", "ipaexternalmember"]),
+                ("idoverrideuser", idoverrides_add, idoverrides_del,
+                 "member_idoverrideuser"),
+                ("membermanager_user",
+                 membermanager_user_add, membermanager_user_del,
+                 "membermanager_user"),
+                ("membermanager_group",
+                 membermanager_group_add, membermanager_group_del,
+                 "membermanager_group"),
+            ]
+            member_before, member_after = gen_members_diff(
+                res_find_orig, member_specs)
+
             if state == "present":
                 if action == "group":
                     before, after = merge_diffs(
                         (attr_before, attr_after),
-                        gen_member_diff(
-                            "user", user_add, user_del,
-                            _orig.get("member_user")),
-                        gen_member_diff(
-                            "group", group_add, group_del,
-                            _orig.get("member_group")),
-                        gen_member_diff(
-                            "service", service_add, service_del,
-                            _orig.get("member_service")),
-                        gen_member_diff(
-                            "external", externalmember_add,
-                            externalmember_del,
-                            list(_orig.get("member_external", []))
-                            + list(_orig.get("ipaexternalmember", []))),
-                        gen_member_diff(
-                            "idoverrideuser", idoverrides_add,
-                            idoverrides_del,
-                            _orig.get("member_idoverrideuser")),
-                        gen_member_diff(
-                            "membermanager_user",
-                            membermanager_user_add, membermanager_user_del,
-                            _orig.get("membermanager_user")),
-                        gen_member_diff(
-                            "membermanager_group",
-                            membermanager_group_add, membermanager_group_del,
-                            _orig.get("membermanager_group")),
+                        (member_before, member_after),
                     )
                     diff_tracker.add_entry_diff(name, before, after)
                 elif action == "member":
-                    before, after = merge_diffs(
-                        gen_member_diff(
-                            "user", user_add, user_del,
-                            _orig.get("member_user")),
-                        gen_member_diff(
-                            "group", group_add, group_del,
-                            _orig.get("member_group")),
-                        gen_member_diff(
-                            "service", service_add, service_del,
-                            _orig.get("member_service")),
-                        gen_member_diff(
-                            "external", externalmember_add,
-                            externalmember_del,
-                            list(_orig.get("member_external", []))
-                            + list(_orig.get("ipaexternalmember", []))),
-                        gen_member_diff(
-                            "idoverrideuser", idoverrides_add,
-                            idoverrides_del,
-                            _orig.get("member_idoverrideuser")),
-                        gen_member_diff(
-                            "membermanager_user",
-                            membermanager_user_add, membermanager_user_del,
-                            _orig.get("membermanager_user")),
-                        gen_member_diff(
-                            "membermanager_group",
-                            membermanager_group_add, membermanager_group_del,
-                            _orig.get("membermanager_group")),
-                    )
-                    diff_tracker.add_entry_diff(name, before, after)
+                    diff_tracker.add_entry_diff(
+                        name, member_before, member_after)
             elif state == "renamed":
                 if rename != name and res_find_orig is not None:
                     diff_tracker.add_entry_diff(
@@ -1040,35 +1007,8 @@ def main():
                             name,
                             {"state": "present"}, {"state": "absent"})
                 elif action == "member":
-                    before, after = merge_diffs(
-                        gen_member_diff(
-                            "user", user_add, user_del,
-                            _orig.get("member_user")),
-                        gen_member_diff(
-                            "group", group_add, group_del,
-                            _orig.get("member_group")),
-                        gen_member_diff(
-                            "service", service_add, service_del,
-                            _orig.get("member_service")),
-                        gen_member_diff(
-                            "external", externalmember_add,
-                            externalmember_del,
-                            list(_orig.get("member_external", []))
-                            + list(_orig.get("ipaexternalmember", []))),
-                        gen_member_diff(
-                            "idoverrideuser", idoverrides_add,
-                            idoverrides_del,
-                            _orig.get("member_idoverrideuser")),
-                        gen_member_diff(
-                            "membermanager_user",
-                            membermanager_user_add, membermanager_user_del,
-                            _orig.get("membermanager_user")),
-                        gen_member_diff(
-                            "membermanager_group",
-                            membermanager_group_add, membermanager_group_del,
-                            _orig.get("membermanager_group")),
-                    )
-                    diff_tracker.add_entry_diff(name, before, after)
+                    diff_tracker.add_entry_diff(
+                        name, member_before, member_after)
 
         # Execute commands
         changed = ansible_module.execute_ipa_commands(

--- a/plugins/modules/ipagroup.py
+++ b/plugins/modules/ipagroup.py
@@ -331,7 +331,8 @@ from ansible.module_utils._text import to_text
 from ansible.module_utils.ansible_freeipa_module import \
     IPAAnsibleModule, compare_args_ipa, gen_add_del_lists, \
     gen_add_list, gen_intersection_list, api_check_param, \
-    convert_to_sid
+    convert_to_sid, IPADiffTracker, gen_args_diff, gen_member_diff, \
+    merge_diffs
 from ansible.module_utils import six
 if six.PY3:
     unicode = str
@@ -597,6 +598,7 @@ def main():
 
     changed = False
     exit_args = {}
+    diff_tracker = IPADiffTracker()
 
     # If nonposix is used, set posix as not nonposix
     if nonposix is not None:
@@ -687,6 +689,7 @@ def main():
 
             # Make sure group exists
             res_find = find_group(ansible_module, name)
+            res_find_orig = res_find
 
             # external members must de handled as SID
             externalmember = convert_to_sid(externalmember)
@@ -721,6 +724,7 @@ def main():
 
                 # Generate args
                 args = gen_args(description, gid, nomembers)
+                attr_before, attr_after = {}, {}
 
                 if action == "group":
                     # Found the group
@@ -742,12 +746,15 @@ def main():
                             if external:
                                 args['external'] = True
                             commands.append([name, "group_mod", args])
+                            attr_before, attr_after = gen_args_diff(
+                                args, res_find)
                     else:
                         if posix is not None and not posix:
                             args['nonposix'] = True
                         if external:
                             args['external'] = True
                         commands.append([name, "group_add", args])
+                        attr_before, attr_after = {}, args
                         # Set res_find dict for next step
                         res_find = {}
 
@@ -958,13 +965,119 @@ def main():
                          }]
                     )
 
+            # Diff tracking
+            _orig = res_find_orig or {}
+            if state == "present":
+                if action == "group":
+                    before, after = merge_diffs(
+                        (attr_before, attr_after),
+                        gen_member_diff(
+                            "user", user_add, user_del,
+                            _orig.get("member_user")),
+                        gen_member_diff(
+                            "group", group_add, group_del,
+                            _orig.get("member_group")),
+                        gen_member_diff(
+                            "service", service_add, service_del,
+                            _orig.get("member_service")),
+                        gen_member_diff(
+                            "external", externalmember_add,
+                            externalmember_del,
+                            list(_orig.get("member_external", []))
+                            + list(_orig.get("ipaexternalmember", []))),
+                        gen_member_diff(
+                            "idoverrideuser", idoverrides_add,
+                            idoverrides_del,
+                            _orig.get("member_idoverrideuser")),
+                        gen_member_diff(
+                            "membermanager_user",
+                            membermanager_user_add, membermanager_user_del,
+                            _orig.get("membermanager_user")),
+                        gen_member_diff(
+                            "membermanager_group",
+                            membermanager_group_add, membermanager_group_del,
+                            _orig.get("membermanager_group")),
+                    )
+                    diff_tracker.add_entry_diff(name, before, after)
+                elif action == "member":
+                    before, after = merge_diffs(
+                        gen_member_diff(
+                            "user", user_add, user_del,
+                            _orig.get("member_user")),
+                        gen_member_diff(
+                            "group", group_add, group_del,
+                            _orig.get("member_group")),
+                        gen_member_diff(
+                            "service", service_add, service_del,
+                            _orig.get("member_service")),
+                        gen_member_diff(
+                            "external", externalmember_add,
+                            externalmember_del,
+                            list(_orig.get("member_external", []))
+                            + list(_orig.get("ipaexternalmember", []))),
+                        gen_member_diff(
+                            "idoverrideuser", idoverrides_add,
+                            idoverrides_del,
+                            _orig.get("member_idoverrideuser")),
+                        gen_member_diff(
+                            "membermanager_user",
+                            membermanager_user_add, membermanager_user_del,
+                            _orig.get("membermanager_user")),
+                        gen_member_diff(
+                            "membermanager_group",
+                            membermanager_group_add, membermanager_group_del,
+                            _orig.get("membermanager_group")),
+                    )
+                    diff_tracker.add_entry_diff(name, before, after)
+            elif state == "renamed":
+                if rename != name and res_find_orig is not None:
+                    diff_tracker.add_entry_diff(
+                        name, {"cn": name}, {"cn": rename})
+            elif state == "absent":
+                if action == "group":
+                    if res_find_orig is not None:
+                        diff_tracker.add_entry_diff(
+                            name,
+                            {"state": "present"}, {"state": "absent"})
+                elif action == "member":
+                    before, after = merge_diffs(
+                        gen_member_diff(
+                            "user", user_add, user_del,
+                            _orig.get("member_user")),
+                        gen_member_diff(
+                            "group", group_add, group_del,
+                            _orig.get("member_group")),
+                        gen_member_diff(
+                            "service", service_add, service_del,
+                            _orig.get("member_service")),
+                        gen_member_diff(
+                            "external", externalmember_add,
+                            externalmember_del,
+                            list(_orig.get("member_external", []))
+                            + list(_orig.get("ipaexternalmember", []))),
+                        gen_member_diff(
+                            "idoverrideuser", idoverrides_add,
+                            idoverrides_del,
+                            _orig.get("member_idoverrideuser")),
+                        gen_member_diff(
+                            "membermanager_user",
+                            membermanager_user_add, membermanager_user_del,
+                            _orig.get("membermanager_user")),
+                        gen_member_diff(
+                            "membermanager_group",
+                            membermanager_group_add, membermanager_group_del,
+                            _orig.get("membermanager_group")),
+                    )
+                    diff_tracker.add_entry_diff(name, before, after)
+
         # Execute commands
         changed = ansible_module.execute_ipa_commands(
             commands, batch=True, keeponly=[], fail_on_member_errors=True)
 
     # Done
 
-    ansible_module.exit_json(changed=changed, **exit_args)
+    _exit_kwargs = dict(exit_args, **diff_tracker.build_diff())
+    ansible_module.exit_json(changed=changed, **_exit_kwargs)
 
 
 if __name__ == "__main__":

--- a/plugins/modules/ipahbacrule.py
+++ b/plugins/modules/ipahbacrule.py
@@ -172,7 +172,7 @@ RETURN = """
 from ansible.module_utils.ansible_freeipa_module import \
     IPAAnsibleModule, compare_args_ipa, gen_add_del_lists, gen_add_list, \
     gen_intersection_list, ensure_fqdn, \
-    IPADiffTracker, gen_args_diff, gen_member_diff, merge_diffs
+    IPADiffTracker, gen_args_diff, gen_members_diff, merge_diffs
 
 
 def find_hbacrule(module, name):
@@ -585,29 +585,27 @@ def main():
                                      "group": group_del,
                                  }])
 
-            # Diff tracking
-            _orig = res_find_orig or {}
+            # Diff tracking. The same set of member specs is reused for
+            # state=present (action=hbacrule adds attribute changes on top)
+            # and state=absent action=member.
+            member_specs = [
+                ("host", host_add, host_del, "memberhost_host"),
+                ("hostgroup", hostgroup_add, hostgroup_del,
+                 "memberhost_hostgroup"),
+                ("hbacsvc", hbacsvc_add, hbacsvc_del,
+                 "memberservice_hbacsvc"),
+                ("hbacsvcgroup", hbacsvcgroup_add, hbacsvcgroup_del,
+                 "memberservice_hbacsvcgroup"),
+                ("user", user_add, user_del, "memberuser_user"),
+                ("group", group_add, group_del, "memberuser_group"),
+            ]
+            member_before, member_after = gen_members_diff(
+                res_find_orig, member_specs)
+
             if state == "present":
                 before, after = merge_diffs(
                     (attr_before, attr_after),
-                    gen_member_diff(
-                        "host", host_add, host_del,
-                        _orig.get("memberhost_host")),
-                    gen_member_diff(
-                        "hostgroup", hostgroup_add, hostgroup_del,
-                        _orig.get("memberhost_hostgroup")),
-                    gen_member_diff(
-                        "hbacsvc", hbacsvc_add, hbacsvc_del,
-                        _orig.get("memberservice_hbacsvc")),
-                    gen_member_diff(
-                        "hbacsvcgroup", hbacsvcgroup_add, hbacsvcgroup_del,
-                        _orig.get("memberservice_hbacsvcgroup")),
-                    gen_member_diff(
-                        "user", user_add, user_del,
-                        _orig.get("memberuser_user")),
-                    gen_member_diff(
-                        "group", group_add, group_del,
-                        _orig.get("memberuser_group")),
+                    (member_before, member_after),
                 )
                 diff_tracker.add_entry_diff(name, before, after)
             elif state == "absent":
@@ -617,28 +615,8 @@ def main():
                             name,
                             {"state": "present"}, {"state": "absent"})
                 elif action == "member":
-                    before, after = merge_diffs(
-                        gen_member_diff(
-                            "host", host_add, host_del,
-                            _orig.get("memberhost_host")),
-                        gen_member_diff(
-                            "hostgroup", hostgroup_add, hostgroup_del,
-                            _orig.get("memberhost_hostgroup")),
-                        gen_member_diff(
-                            "hbacsvc", hbacsvc_add, hbacsvc_del,
-                            _orig.get("memberservice_hbacsvc")),
-                        gen_member_diff(
-                            "hbacsvcgroup", hbacsvcgroup_add,
-                            hbacsvcgroup_del,
-                            _orig.get("memberservice_hbacsvcgroup")),
-                        gen_member_diff(
-                            "user", user_add, user_del,
-                            _orig.get("memberuser_user")),
-                        gen_member_diff(
-                            "group", group_add, group_del,
-                            _orig.get("memberuser_group")),
-                    )
-                    diff_tracker.add_entry_diff(name, before, after)
+                    diff_tracker.add_entry_diff(
+                        name, member_before, member_after)
 
         # Execute commands
 

--- a/plugins/modules/ipahbacrule.py
+++ b/plugins/modules/ipahbacrule.py
@@ -171,7 +171,8 @@ RETURN = """
 
 from ansible.module_utils.ansible_freeipa_module import \
     IPAAnsibleModule, compare_args_ipa, gen_add_del_lists, gen_add_list, \
-    gen_intersection_list, ensure_fqdn
+    gen_intersection_list, ensure_fqdn, \
+    IPADiffTracker, gen_args_diff, gen_member_diff, merge_diffs
 
 
 def find_hbacrule(module, name):
@@ -327,6 +328,7 @@ def main():
 
     changed = False
     exit_args = {}
+    diff_tracker = IPADiffTracker()
 
     # Connect to IPA API
     with ansible_module.ipa_connect():
@@ -344,6 +346,7 @@ def main():
         for name in names:
             # Make sure hbacrule exists
             res_find = find_hbacrule(ansible_module, name)
+            res_find_orig = res_find
 
             host_add, host_del = [], []
             hostgroup_add, hostgroup_del = [], []
@@ -357,6 +360,7 @@ def main():
                 # Generate args
                 args = gen_args(description, usercategory, hostcategory,
                                 servicecategory, nomembers)
+                attr_before, attr_after = {}, {}
 
                 if action == "hbacrule":
                     # Found the hbacrule
@@ -383,8 +387,11 @@ def main():
                         if not compare_args_ipa(ansible_module, args,
                                                 res_find):
                             commands.append([name, "hbacrule_mod", args])
+                            attr_before, attr_after = gen_args_diff(
+                                args, res_find)
                     else:
                         commands.append([name, "hbacrule_add", args])
+                        attr_before, attr_after = {}, args
                         # Set res_find to empty dict for next step
                         res_find = {}
 
@@ -509,6 +516,8 @@ def main():
                 enabled_flag = str(res_find.get("ipaenabledflag", [False])[0])
                 if enabled_flag.upper() != "TRUE":
                     commands.append([name, "hbacrule_enable", {}])
+                    diff_tracker.add_entry_diff(
+                        name, {"enabled": False}, {"enabled": True})
 
             elif state == "disabled":
                 if res_find is None:
@@ -523,6 +532,8 @@ def main():
                 enabled_flag = str(res_find.get("ipaenabledflag", [False])[0])
                 if enabled_flag.upper() != "FALSE":
                     commands.append([name, "hbacrule_disable", {}])
+                    diff_tracker.add_entry_diff(
+                        name, {"enabled": True}, {"enabled": False})
 
             else:
                 ansible_module.fail_json(msg="Unkown state '%s'" % state)
@@ -574,6 +585,61 @@ def main():
                                      "group": group_del,
                                  }])
 
+            # Diff tracking
+            _orig = res_find_orig or {}
+            if state == "present":
+                before, after = merge_diffs(
+                    (attr_before, attr_after),
+                    gen_member_diff(
+                        "host", host_add, host_del,
+                        _orig.get("memberhost_host")),
+                    gen_member_diff(
+                        "hostgroup", hostgroup_add, hostgroup_del,
+                        _orig.get("memberhost_hostgroup")),
+                    gen_member_diff(
+                        "hbacsvc", hbacsvc_add, hbacsvc_del,
+                        _orig.get("memberservice_hbacsvc")),
+                    gen_member_diff(
+                        "hbacsvcgroup", hbacsvcgroup_add, hbacsvcgroup_del,
+                        _orig.get("memberservice_hbacsvcgroup")),
+                    gen_member_diff(
+                        "user", user_add, user_del,
+                        _orig.get("memberuser_user")),
+                    gen_member_diff(
+                        "group", group_add, group_del,
+                        _orig.get("memberuser_group")),
+                )
+                diff_tracker.add_entry_diff(name, before, after)
+            elif state == "absent":
+                if action == "hbacrule":
+                    if res_find_orig is not None:
+                        diff_tracker.add_entry_diff(
+                            name,
+                            {"state": "present"}, {"state": "absent"})
+                elif action == "member":
+                    before, after = merge_diffs(
+                        gen_member_diff(
+                            "host", host_add, host_del,
+                            _orig.get("memberhost_host")),
+                        gen_member_diff(
+                            "hostgroup", hostgroup_add, hostgroup_del,
+                            _orig.get("memberhost_hostgroup")),
+                        gen_member_diff(
+                            "hbacsvc", hbacsvc_add, hbacsvc_del,
+                            _orig.get("memberservice_hbacsvc")),
+                        gen_member_diff(
+                            "hbacsvcgroup", hbacsvcgroup_add,
+                            hbacsvcgroup_del,
+                            _orig.get("memberservice_hbacsvcgroup")),
+                        gen_member_diff(
+                            "user", user_add, user_del,
+                            _orig.get("memberuser_user")),
+                        gen_member_diff(
+                            "group", group_add, group_del,
+                            _orig.get("memberuser_group")),
+                    )
+                    diff_tracker.add_entry_diff(name, before, after)
+
         # Execute commands
 
         changed = ansible_module.execute_ipa_commands(
@@ -581,7 +647,8 @@ def main():
 
     # Done
 
-    ansible_module.exit_json(changed=changed, **exit_args)
+    _exit_kwargs = dict(exit_args, **diff_tracker.build_diff())
+    ansible_module.exit_json(changed=changed, **_exit_kwargs)
 
 
 if __name__ == "__main__":

--- a/plugins/modules/ipahostgroup.py
+++ b/plugins/modules/ipahostgroup.py
@@ -150,7 +150,7 @@ RETURN = """
 from ansible.module_utils.ansible_freeipa_module import \
     IPAAnsibleModule, compare_args_ipa, gen_add_del_lists, gen_add_list, \
     gen_intersection_list, ensure_fqdn, \
-    IPADiffTracker, gen_args_diff, gen_member_diff, merge_diffs
+    IPADiffTracker, gen_args_diff, gen_members_diff, merge_diffs
 
 
 def find_hostgroup(module, name):
@@ -479,46 +479,33 @@ def main():
                         }
                     ])
 
-            # Diff tracking
-            _orig = res_find_orig or {}
+            # Diff tracking. The same set of member specs is reused for
+            # state=present (action=hostgroup adds attribute changes on top)
+            # and state=absent action=member.
+            member_specs = [
+                ("host", host_add, host_del, "member_host"),
+                ("hostgroup", hostgroup_add, hostgroup_del,
+                 "member_hostgroup"),
+                ("membermanager_user",
+                 membermanager_user_add, membermanager_user_del,
+                 "membermanager_user"),
+                ("membermanager_group",
+                 membermanager_group_add, membermanager_group_del,
+                 "membermanager_group"),
+            ]
+            member_before, member_after = gen_members_diff(
+                res_find_orig, member_specs)
+
             if state == "present":
                 if action == "hostgroup":
                     before, after = merge_diffs(
                         (attr_before, attr_after),
-                        gen_member_diff(
-                            "host", host_add, host_del,
-                            _orig.get("member_host")),
-                        gen_member_diff(
-                            "hostgroup", hostgroup_add, hostgroup_del,
-                            _orig.get("member_hostgroup")),
-                        gen_member_diff(
-                            "membermanager_user",
-                            membermanager_user_add, membermanager_user_del,
-                            _orig.get("membermanager_user")),
-                        gen_member_diff(
-                            "membermanager_group",
-                            membermanager_group_add, membermanager_group_del,
-                            _orig.get("membermanager_group")),
+                        (member_before, member_after),
                     )
                     diff_tracker.add_entry_diff(name, before, after)
                 elif action == "member":
-                    before, after = merge_diffs(
-                        gen_member_diff(
-                            "host", host_add, host_del,
-                            _orig.get("member_host")),
-                        gen_member_diff(
-                            "hostgroup", hostgroup_add, hostgroup_del,
-                            _orig.get("member_hostgroup")),
-                        gen_member_diff(
-                            "membermanager_user",
-                            membermanager_user_add, membermanager_user_del,
-                            _orig.get("membermanager_user")),
-                        gen_member_diff(
-                            "membermanager_group",
-                            membermanager_group_add, membermanager_group_del,
-                            _orig.get("membermanager_group")),
-                    )
-                    diff_tracker.add_entry_diff(name, before, after)
+                    diff_tracker.add_entry_diff(
+                        name, member_before, member_after)
             elif state == "renamed":
                 if rename != name and res_find_orig is not None:
                     diff_tracker.add_entry_diff(
@@ -530,23 +517,8 @@ def main():
                             name,
                             {"state": "present"}, {"state": "absent"})
                 elif action == "member":
-                    before, after = merge_diffs(
-                        gen_member_diff(
-                            "host", host_add, host_del,
-                            _orig.get("member_host")),
-                        gen_member_diff(
-                            "hostgroup", hostgroup_add, hostgroup_del,
-                            _orig.get("member_hostgroup")),
-                        gen_member_diff(
-                            "membermanager_user",
-                            membermanager_user_add, membermanager_user_del,
-                            _orig.get("membermanager_user")),
-                        gen_member_diff(
-                            "membermanager_group",
-                            membermanager_group_add, membermanager_group_del,
-                            _orig.get("membermanager_group")),
-                    )
-                    diff_tracker.add_entry_diff(name, before, after)
+                    diff_tracker.add_entry_diff(
+                        name, member_before, member_after)
 
         # Execute commands
 

--- a/plugins/modules/ipahostgroup.py
+++ b/plugins/modules/ipahostgroup.py
@@ -149,7 +149,8 @@ RETURN = """
 
 from ansible.module_utils.ansible_freeipa_module import \
     IPAAnsibleModule, compare_args_ipa, gen_add_del_lists, gen_add_list, \
-    gen_intersection_list, ensure_fqdn
+    gen_intersection_list, ensure_fqdn, \
+    IPADiffTracker, gen_args_diff, gen_member_diff, merge_diffs
 
 
 def find_hostgroup(module, name):
@@ -270,6 +271,7 @@ def main():
 
     changed = False
     exit_args = {}
+    diff_tracker = IPADiffTracker()
 
     # Connect to IPA API
     with ansible_module.ipa_connect():
@@ -308,11 +310,13 @@ def main():
 
             # Make sure hostgroup exists
             res_find = find_hostgroup(ansible_module, name)
+            res_find_orig = res_find
 
             # Create command
             if state == "present":
                 # Generate args
                 args = gen_args(description, nomembers, rename)
+                attr_before, attr_after = {}, {}
 
                 if action == "hostgroup":
                     # Found the hostgroup
@@ -323,8 +327,11 @@ def main():
                         if not compare_args_ipa(ansible_module, args,
                                                 res_find):
                             commands.append([name, "hostgroup_mod", args])
+                            attr_before, attr_after = gen_args_diff(
+                                args, res_find)
                     else:
                         commands.append([name, "hostgroup_add", args])
+                        attr_before, attr_after = {}, args
                         # Set res_find to empty dict for next step
                         res_find = {}
 
@@ -472,6 +479,75 @@ def main():
                         }
                     ])
 
+            # Diff tracking
+            _orig = res_find_orig or {}
+            if state == "present":
+                if action == "hostgroup":
+                    before, after = merge_diffs(
+                        (attr_before, attr_after),
+                        gen_member_diff(
+                            "host", host_add, host_del,
+                            _orig.get("member_host")),
+                        gen_member_diff(
+                            "hostgroup", hostgroup_add, hostgroup_del,
+                            _orig.get("member_hostgroup")),
+                        gen_member_diff(
+                            "membermanager_user",
+                            membermanager_user_add, membermanager_user_del,
+                            _orig.get("membermanager_user")),
+                        gen_member_diff(
+                            "membermanager_group",
+                            membermanager_group_add, membermanager_group_del,
+                            _orig.get("membermanager_group")),
+                    )
+                    diff_tracker.add_entry_diff(name, before, after)
+                elif action == "member":
+                    before, after = merge_diffs(
+                        gen_member_diff(
+                            "host", host_add, host_del,
+                            _orig.get("member_host")),
+                        gen_member_diff(
+                            "hostgroup", hostgroup_add, hostgroup_del,
+                            _orig.get("member_hostgroup")),
+                        gen_member_diff(
+                            "membermanager_user",
+                            membermanager_user_add, membermanager_user_del,
+                            _orig.get("membermanager_user")),
+                        gen_member_diff(
+                            "membermanager_group",
+                            membermanager_group_add, membermanager_group_del,
+                            _orig.get("membermanager_group")),
+                    )
+                    diff_tracker.add_entry_diff(name, before, after)
+            elif state == "renamed":
+                if rename != name and res_find_orig is not None:
+                    diff_tracker.add_entry_diff(
+                        name, {"cn": name}, {"cn": rename})
+            elif state == "absent":
+                if action == "hostgroup":
+                    if res_find_orig is not None:
+                        diff_tracker.add_entry_diff(
+                            name,
+                            {"state": "present"}, {"state": "absent"})
+                elif action == "member":
+                    before, after = merge_diffs(
+                        gen_member_diff(
+                            "host", host_add, host_del,
+                            _orig.get("member_host")),
+                        gen_member_diff(
+                            "hostgroup", hostgroup_add, hostgroup_del,
+                            _orig.get("member_hostgroup")),
+                        gen_member_diff(
+                            "membermanager_user",
+                            membermanager_user_add, membermanager_user_del,
+                            _orig.get("membermanager_user")),
+                        gen_member_diff(
+                            "membermanager_group",
+                            membermanager_group_add, membermanager_group_del,
+                            _orig.get("membermanager_group")),
+                    )
+                    diff_tracker.add_entry_diff(name, before, after)
+
         # Execute commands
 
         changed = ansible_module.execute_ipa_commands(
@@ -479,7 +555,8 @@ def main():
 
     # Done
 
-    ansible_module.exit_json(changed=changed, **exit_args)
+    _exit_kwargs = dict(exit_args, **diff_tracker.build_diff())
+    ansible_module.exit_json(changed=changed, **_exit_kwargs)
 
 
 if __name__ == "__main__":

--- a/plugins/modules/ipapwpolicy.py
+++ b/plugins/modules/ipapwpolicy.py
@@ -153,7 +153,7 @@ RETURN = """
 """
 
 from ansible.module_utils.ansible_freeipa_module import \
-    IPAAnsibleModule, compare_args_ipa
+    IPAAnsibleModule, compare_args_ipa, IPADiffTracker, gen_args_diff
 
 
 def find_pwpolicy(module, name):
@@ -360,6 +360,7 @@ def main():
 
     changed = False
     exit_args = {}
+    diff_tracker = IPADiffTracker()
 
     with ansible_module.ipa_connect():
 
@@ -391,12 +392,17 @@ def main():
                     if not compare_args_ipa(ansible_module, args,
                                             res_find):
                         commands.append([name, "pwpolicy_mod", args])
+                        before, after = gen_args_diff(args, res_find)
+                        diff_tracker.add_entry_diff(name, before, after)
                 else:
                     commands.append([name, "pwpolicy_add", args])
+                    diff_tracker.add_entry_diff(name, {}, args)
 
             elif state == "absent":
                 if res_find is not None:
                     commands.append([name, "pwpolicy_del", {}])
+                    diff_tracker.add_entry_diff(
+                        name, {"state": "present"}, {"state": "absent"})
 
             else:
                 ansible_module.fail_json(msg="Unkown state '%s'" % state)
@@ -407,7 +413,8 @@ def main():
 
     # Done
 
-    ansible_module.exit_json(changed=changed, **exit_args)
+    _exit_kwargs = dict(exit_args, **diff_tracker.build_diff())
+    ansible_module.exit_json(changed=changed, **_exit_kwargs)
 
 
 if __name__ == "__main__":

--- a/plugins/modules/ipasudocmd.py
+++ b/plugins/modules/ipasudocmd.py
@@ -77,7 +77,7 @@ RETURN = """
 """
 
 from ansible.module_utils.ansible_freeipa_module import \
-    IPAAnsibleModule, compare_args_ipa
+    IPAAnsibleModule, compare_args_ipa, IPADiffTracker, gen_args_diff
 
 
 def find_sudocmd(module, name):
@@ -143,6 +143,7 @@ def main():
 
     changed = False
     exit_args = {}
+    diff_tracker = IPADiffTracker()
 
     # Connect to IPA API
     with ansible_module.ipa_connect():
@@ -164,13 +165,18 @@ def main():
                     if not compare_args_ipa(ansible_module, args,
                                             res_find):
                         commands.append([name, "sudocmd_mod", args])
+                        before, after = gen_args_diff(args, res_find)
+                        diff_tracker.add_entry_diff(name, before, after)
                 else:
                     commands.append([name, "sudocmd_add", args])
+                    diff_tracker.add_entry_diff(name, {}, args)
                     # Set res_find to empty dict for next step
                     res_find = {}
             elif state == "absent":
                 if res_find is not None:
                     commands.append([name, "sudocmd_del", {}])
+                    diff_tracker.add_entry_diff(
+                        name, {"state": "present"}, {"state": "absent"})
             else:
                 ansible_module.fail_json(msg="Unkown state '%s'" % state)
 
@@ -178,7 +184,8 @@ def main():
 
     # Done
 
-    ansible_module.exit_json(changed=changed, **exit_args)
+    _exit_kwargs = dict(exit_args, **diff_tracker.build_diff())
+    ansible_module.exit_json(changed=changed, **_exit_kwargs)
 
 
 if __name__ == "__main__":

--- a/plugins/modules/ipasudocmdgroup.py
+++ b/plugins/modules/ipasudocmdgroup.py
@@ -112,7 +112,8 @@ RETURN = """
 
 from ansible.module_utils.ansible_freeipa_module import \
     IPAAnsibleModule, compare_args_ipa, gen_add_del_lists, \
-    gen_add_list, gen_intersection_list, ipalib_errors
+    gen_add_list, gen_intersection_list, ipalib_errors, \
+    IPADiffTracker, gen_args_diff, gen_member_diff, merge_diffs
 
 
 def find_sudocmdgroup(module, name):
@@ -202,6 +203,7 @@ def main():
 
     changed = False
     exit_args = {}
+    diff_tracker = IPADiffTracker()
 
     # Connect to IPA API
     with ansible_module.ipa_connect():
@@ -211,6 +213,7 @@ def main():
         for name in names:
             # Make sure hostgroup exists
             res_find = find_sudocmdgroup(ansible_module, name)
+            res_find_orig = res_find
 
             # Create command
             if state == "present":
@@ -218,6 +221,9 @@ def main():
                 args = gen_args(description, nomembers)
 
                 if action == "sudocmdgroup":
+                    attr_before, attr_after = {}, {}
+                    sudocmd_add, sudocmd_del = [], []
+
                     # Found the hostgroup
                     if res_find is not None:
                         # For all settings is args, check if there are
@@ -226,8 +232,11 @@ def main():
                         if not compare_args_ipa(ansible_module, args,
                                                 res_find):
                             commands.append([name, "sudocmdgroup_mod", args])
+                            attr_before, attr_after = gen_args_diff(
+                                args, res_find)
                     else:
                         commands.append([name, "sudocmdgroup_add", args])
+                        attr_before, attr_after = {}, args
                         # Set res_find to empty dict for next step
                         res_find = {}
 
@@ -255,34 +264,59 @@ def main():
                                                  "sudocmd": sudocmd_del
                                              }
                                              ])
+
+                    # Diff tracking
+                    before, after = merge_diffs(
+                        (attr_before, attr_after),
+                        gen_member_diff(
+                            "sudocmd", sudocmd_add, sudocmd_del,
+                            (res_find_orig or {}).get("member_sudocmd")),
+                    )
+                    diff_tracker.add_entry_diff(name, before, after)
+
                 elif action == "member":
                     if res_find is None:
                         ansible_module.fail_json(
                             msg="No sudocmdgroup '%s'" % name)
 
                     # Ensure members are present
-                    sudocmd = gen_add_list(
+                    sudocmd_add = gen_add_list(
                         sudocmd, res_find.get("member_sudocmd") or [])
-                    if sudocmd:
+                    if sudocmd_add:
                         commands.append([name, "sudocmdgroup_add_member",
-                                         {"sudocmd": sudocmd}
+                                         {"sudocmd": sudocmd_add}
                                          ])
+                    before, after = merge_diffs(
+                        gen_member_diff(
+                            "sudocmd", sudocmd_add, [],
+                            res_find.get("member_sudocmd")),
+                    )
+                    diff_tracker.add_entry_diff(name, before, after)
             elif state == "absent":
                 if action == "sudocmdgroup":
                     if res_find is not None:
                         commands.append([name, "sudocmdgroup_del", {}])
+                        diff_tracker.add_entry_diff(
+                            name,
+                            {"state": "present"}, {"state": "absent"})
 
                 elif action == "member":
                     if res_find is None:
                         ansible_module.fail_json(
                             msg="No sudocmdgroup '%s'" % name)
 
-                    sudocmd = gen_intersection_list(
+                    sudocmd_del = gen_intersection_list(
                         sudocmd, res_find.get("member_sudocmd") or [])
-                    if sudocmd:
+                    if sudocmd_del:
                         commands.append([name, "sudocmdgroup_remove_member",
-                                         {"sudocmd": sudocmd}
+                                         {"sudocmd": sudocmd_del}
                                          ])
+                    before, after = merge_diffs(
+                        gen_member_diff(
+                            "sudocmd", [], sudocmd_del,
+                            res_find.get("member_sudocmd")),
+                    )
+                    diff_tracker.add_entry_diff(name, before, after)
             else:
                 ansible_module.fail_json(msg="Unkown state '%s'" % state)
 
@@ -291,7 +325,8 @@ def main():
 
     # Done
 
-    ansible_module.exit_json(changed=changed, **exit_args)
+    _exit_kwargs = dict(exit_args, **diff_tracker.build_diff())
+    ansible_module.exit_json(changed=changed, **_exit_kwargs)
 
 
 if __name__ == "__main__":

--- a/plugins/modules/ipasudocmdgroup.py
+++ b/plugins/modules/ipasudocmdgroup.py
@@ -113,7 +113,7 @@ RETURN = """
 from ansible.module_utils.ansible_freeipa_module import \
     IPAAnsibleModule, compare_args_ipa, gen_add_del_lists, \
     gen_add_list, gen_intersection_list, ipalib_errors, \
-    IPADiffTracker, gen_args_diff, gen_member_diff, merge_diffs
+    IPADiffTracker, gen_args_diff, gen_members_diff, merge_diffs
 
 
 def find_sudocmdgroup(module, name):
@@ -215,15 +215,15 @@ def main():
             res_find = find_sudocmdgroup(ansible_module, name)
             res_find_orig = res_find
 
+            attr_before, attr_after = {}, {}
+            sudocmd_add, sudocmd_del = [], []
+
             # Create command
             if state == "present":
                 # Generate args
                 args = gen_args(description, nomembers)
 
                 if action == "sudocmdgroup":
-                    attr_before, attr_after = {}, {}
-                    sudocmd_add, sudocmd_del = [], []
-
                     # Found the hostgroup
                     if res_find is not None:
                         # For all settings is args, check if there are
@@ -265,15 +265,6 @@ def main():
                                              }
                                              ])
 
-                    # Diff tracking
-                    before, after = merge_diffs(
-                        (attr_before, attr_after),
-                        gen_member_diff(
-                            "sudocmd", sudocmd_add, sudocmd_del,
-                            (res_find_orig or {}).get("member_sudocmd")),
-                    )
-                    diff_tracker.add_entry_diff(name, before, after)
-
                 elif action == "member":
                     if res_find is None:
                         ansible_module.fail_json(
@@ -286,19 +277,10 @@ def main():
                         commands.append([name, "sudocmdgroup_add_member",
                                          {"sudocmd": sudocmd_add}
                                          ])
-                    before, after = merge_diffs(
-                        gen_member_diff(
-                            "sudocmd", sudocmd_add, [],
-                            res_find.get("member_sudocmd")),
-                    )
-                    diff_tracker.add_entry_diff(name, before, after)
             elif state == "absent":
                 if action == "sudocmdgroup":
                     if res_find is not None:
                         commands.append([name, "sudocmdgroup_del", {}])
-                        diff_tracker.add_entry_diff(
-                            name,
-                            {"state": "present"}, {"state": "absent"})
 
                 elif action == "member":
                     if res_find is None:
@@ -311,14 +293,38 @@ def main():
                         commands.append([name, "sudocmdgroup_remove_member",
                                          {"sudocmd": sudocmd_del}
                                          ])
-                    before, after = merge_diffs(
-                        gen_member_diff(
-                            "sudocmd", [], sudocmd_del,
-                            res_find.get("member_sudocmd")),
-                    )
-                    diff_tracker.add_entry_diff(name, before, after)
             else:
                 ansible_module.fail_json(msg="Unkown state '%s'" % state)
+
+            # Diff tracking. The same set of member specs is reused across
+            # state=present action=sudocmdgroup (with attribute changes
+            # layered on top), state=present action=member, and state=absent
+            # action=member.
+            member_specs = [
+                ("sudocmd", sudocmd_add, sudocmd_del, "member_sudocmd"),
+            ]
+            member_before, member_after = gen_members_diff(
+                res_find_orig, member_specs)
+
+            if state == "present":
+                if action == "sudocmdgroup":
+                    before, after = merge_diffs(
+                        (attr_before, attr_after),
+                        (member_before, member_after),
+                    )
+                    diff_tracker.add_entry_diff(name, before, after)
+                elif action == "member":
+                    diff_tracker.add_entry_diff(
+                        name, member_before, member_after)
+            elif state == "absent":
+                if action == "sudocmdgroup":
+                    if res_find_orig is not None:
+                        diff_tracker.add_entry_diff(
+                            name,
+                            {"state": "present"}, {"state": "absent"})
+                elif action == "member":
+                    diff_tracker.add_entry_diff(
+                        name, member_before, member_after)
 
         changed = ansible_module.execute_ipa_commands(
             commands, fail_on_member_errors=True)

--- a/plugins/modules/ipasudorule.py
+++ b/plugins/modules/ipasudorule.py
@@ -371,7 +371,7 @@ from ansible.module_utils.ansible_freeipa_module import \
     IPAAnsibleModule, compare_args_ipa, gen_add_del_lists, gen_add_list, \
     gen_intersection_list, api_get_domain, ensure_fqdn, netaddr, to_text, \
     ipalib_errors, convert_param_value_to_lowercase, EntryFactory, \
-    IPADiffTracker, gen_args_diff, gen_member_diff, merge_diffs
+    IPADiffTracker, gen_args_diff, gen_members_diff, merge_diffs
 
 
 def find_sudorule(module, name):
@@ -1102,57 +1102,44 @@ def main():
                         {"ipasudoopt": option}
                     ])
 
-            # Diff tracking
-            _orig = res_find_orig or {}
+            # Diff tracking. The same set of member specs is reused for
+            # state=present (with attribute changes layered on top) and
+            # state=absent action=member.
+            member_specs = [
+                ("host", host_add, host_del,
+                 ["memberhost_host", "externalhost"]),
+                ("hostgroup", hostgroup_add, hostgroup_del,
+                 "memberhost_hostgroup"),
+                ("hostmask", hostmask_add, hostmask_del, "hostmask"),
+                ("user", user_add, user_del,
+                 ["memberuser_user", "externaluser"]),
+                ("group", group_add, group_del, "memberuser_group"),
+                ("allow_sudocmd", allow_cmd_add, allow_cmd_del,
+                 "memberallowcmd_sudocmd"),
+                ("allow_sudocmdgroup",
+                 allow_cmdgroup_add, allow_cmdgroup_del,
+                 "memberallowcmd_sudocmdgroup"),
+                ("deny_sudocmd", deny_cmd_add, deny_cmd_del,
+                 "memberdenycmd_sudocmd"),
+                ("deny_sudocmdgroup",
+                 deny_cmdgroup_add, deny_cmdgroup_del,
+                 "memberdenycmd_sudocmdgroup"),
+                ("sudooption", sudooption_add, sudooption_del, "ipasudoopt"),
+                ("runasuser", runasuser_add, runasuser_del,
+                 ["ipasudorunas_user", "ipasudorunasextuser"]),
+                ("runasuser_group",
+                 runasuser_group_add, runasuser_group_del,
+                 "ipasudorunas_group"),
+                ("runasgroup", runasgroup_add, runasgroup_del,
+                 ["ipasudorunasgroup_group", "ipasudorunasextgroup"]),
+            ]
+            member_before, member_after = gen_members_diff(
+                res_find_orig, member_specs)
+
             if state == "present":
                 before, after = merge_diffs(
                     (attr_before, attr_after),
-                    gen_member_diff(
-                        "host", host_add, host_del,
-                        list(_orig.get("memberhost_host", []))
-                        + list(_orig.get("externalhost", []))),
-                    gen_member_diff(
-                        "hostgroup", hostgroup_add, hostgroup_del,
-                        _orig.get("memberhost_hostgroup")),
-                    gen_member_diff(
-                        "hostmask", hostmask_add, hostmask_del,
-                        _orig.get("hostmask")),
-                    gen_member_diff(
-                        "user", user_add, user_del,
-                        list(_orig.get("memberuser_user", []))
-                        + list(_orig.get("externaluser", []))),
-                    gen_member_diff(
-                        "group", group_add, group_del,
-                        _orig.get("memberuser_group")),
-                    gen_member_diff(
-                        "allow_sudocmd", allow_cmd_add, allow_cmd_del,
-                        _orig.get("memberallowcmd_sudocmd")),
-                    gen_member_diff(
-                        "allow_sudocmdgroup",
-                        allow_cmdgroup_add, allow_cmdgroup_del,
-                        _orig.get("memberallowcmd_sudocmdgroup")),
-                    gen_member_diff(
-                        "deny_sudocmd", deny_cmd_add, deny_cmd_del,
-                        _orig.get("memberdenycmd_sudocmd")),
-                    gen_member_diff(
-                        "deny_sudocmdgroup",
-                        deny_cmdgroup_add, deny_cmdgroup_del,
-                        _orig.get("memberdenycmd_sudocmdgroup")),
-                    gen_member_diff(
-                        "sudooption", sudooption_add, sudooption_del,
-                        _orig.get("ipasudoopt")),
-                    gen_member_diff(
-                        "runasuser", runasuser_add, runasuser_del,
-                        list(_orig.get("ipasudorunas_user", []))
-                        + list(_orig.get("ipasudorunasextuser", []))),
-                    gen_member_diff(
-                        "runasuser_group",
-                        runasuser_group_add, runasuser_group_del,
-                        _orig.get("ipasudorunas_group")),
-                    gen_member_diff(
-                        "runasgroup", runasgroup_add, runasgroup_del,
-                        list(_orig.get("ipasudorunasgroup_group", []))
-                        + list(_orig.get("ipasudorunasextgroup", []))),
+                    (member_before, member_after),
                 )
                 diff_tracker.add_entry_diff(entry.name, before, after)
             elif state == "absent":
@@ -1162,55 +1149,8 @@ def main():
                             entry.name,
                             {"state": "present"}, {"state": "absent"})
                 elif action == "member":
-                    before, after = merge_diffs(
-                        gen_member_diff(
-                            "host", host_add, host_del,
-                            list(_orig.get("memberhost_host", []))
-                            + list(_orig.get("externalhost", []))),
-                        gen_member_diff(
-                            "hostgroup", hostgroup_add, hostgroup_del,
-                            _orig.get("memberhost_hostgroup")),
-                        gen_member_diff(
-                            "hostmask", hostmask_add, hostmask_del,
-                            _orig.get("hostmask")),
-                        gen_member_diff(
-                            "user", user_add, user_del,
-                            list(_orig.get("memberuser_user", []))
-                            + list(_orig.get("externaluser", []))),
-                        gen_member_diff(
-                            "group", group_add, group_del,
-                            _orig.get("memberuser_group")),
-                        gen_member_diff(
-                            "allow_sudocmd", allow_cmd_add, allow_cmd_del,
-                            _orig.get("memberallowcmd_sudocmd")),
-                        gen_member_diff(
-                            "allow_sudocmdgroup",
-                            allow_cmdgroup_add, allow_cmdgroup_del,
-                            _orig.get("memberallowcmd_sudocmdgroup")),
-                        gen_member_diff(
-                            "deny_sudocmd", deny_cmd_add, deny_cmd_del,
-                            _orig.get("memberdenycmd_sudocmd")),
-                        gen_member_diff(
-                            "deny_sudocmdgroup",
-                            deny_cmdgroup_add, deny_cmdgroup_del,
-                            _orig.get("memberdenycmd_sudocmdgroup")),
-                        gen_member_diff(
-                            "sudooption", sudooption_add, sudooption_del,
-                            _orig.get("ipasudoopt")),
-                        gen_member_diff(
-                            "runasuser", runasuser_add, runasuser_del,
-                            list(_orig.get("ipasudorunas_user", []))
-                            + list(_orig.get("ipasudorunasextuser", []))),
-                        gen_member_diff(
-                            "runasuser_group",
-                            runasuser_group_add, runasuser_group_del,
-                            _orig.get("ipasudorunas_group")),
-                        gen_member_diff(
-                            "runasgroup", runasgroup_add, runasgroup_del,
-                            list(_orig.get("ipasudorunasgroup_group", []))
-                            + list(_orig.get("ipasudorunasextgroup", []))),
-                    )
-                    diff_tracker.add_entry_diff(entry.name, before, after)
+                    diff_tracker.add_entry_diff(
+                        entry.name, member_before, member_after)
 
         # Execute commands
 

--- a/plugins/modules/ipasudorule.py
+++ b/plugins/modules/ipasudorule.py
@@ -370,7 +370,8 @@ RETURN = """
 from ansible.module_utils.ansible_freeipa_module import \
     IPAAnsibleModule, compare_args_ipa, gen_add_del_lists, gen_add_list, \
     gen_intersection_list, api_get_domain, ensure_fqdn, netaddr, to_text, \
-    ipalib_errors, convert_param_value_to_lowercase, EntryFactory
+    ipalib_errors, convert_param_value_to_lowercase, EntryFactory, \
+    IPADiffTracker, gen_args_diff, gen_member_diff, merge_diffs
 
 
 def find_sudorule(module, name):
@@ -586,6 +587,7 @@ def main():
     # Init
     changed = False
     exit_args = {}
+    diff_tracker = IPADiffTracker()
 
     # Factory parameters
     params = {
@@ -646,6 +648,7 @@ def main():
 
             # Try to retrieve sudorule
             res_find = find_sudorule(ansible_module, entry.name)
+            res_find_orig = res_find
 
             # Fail if sudorule must exist but is not found
             if (
@@ -658,6 +661,7 @@ def main():
             if state == "present":
                 # Generate args
                 args = gen_args(entry)
+                attr_before, attr_after = {}, {}
                 if action == "sudorule":
                     # Found the sudorule
                     if res_find is not None:
@@ -703,8 +707,11 @@ def main():
                         if not compare_args_ipa(ansible_module, args,
                                                 res_find):
                             commands.append([entry.name, "sudorule_mod", args])
+                            attr_before, attr_after = gen_args_diff(
+                                args, res_find)
                     else:
                         commands.append([entry.name, "sudorule_add", args])
+                        attr_before, attr_after = {}, args
                         # Set res_find to empty dict for next step
                         res_find = {}
 
@@ -970,6 +977,9 @@ def main():
                 enabled_flag = str(res_find.get("ipaenabledflag", [False])[0])
                 if enabled_flag.upper() != "TRUE":
                     commands.append([entry.name, "sudorule_enable", {}])
+                    diff_tracker.add_entry_diff(
+                        entry.name,
+                        {"enabled": False}, {"enabled": True})
 
             elif state == "disabled":
                 # sudorule_disable is not failing on an disabled sudorule
@@ -982,6 +992,9 @@ def main():
                 enabled_flag = str(res_find.get("ipaenabledflag", [False])[0])
                 if enabled_flag.upper() != "FALSE":
                     commands.append([entry.name, "sudorule_disable", {}])
+                    diff_tracker.add_entry_diff(
+                        entry.name,
+                        {"enabled": True}, {"enabled": False})
 
             else:
                 ansible_module.fail_json(msg="Unkown state '%s'" % state)
@@ -1089,6 +1102,116 @@ def main():
                         {"ipasudoopt": option}
                     ])
 
+            # Diff tracking
+            _orig = res_find_orig or {}
+            if state == "present":
+                before, after = merge_diffs(
+                    (attr_before, attr_after),
+                    gen_member_diff(
+                        "host", host_add, host_del,
+                        list(_orig.get("memberhost_host", []))
+                        + list(_orig.get("externalhost", []))),
+                    gen_member_diff(
+                        "hostgroup", hostgroup_add, hostgroup_del,
+                        _orig.get("memberhost_hostgroup")),
+                    gen_member_diff(
+                        "hostmask", hostmask_add, hostmask_del,
+                        _orig.get("hostmask")),
+                    gen_member_diff(
+                        "user", user_add, user_del,
+                        list(_orig.get("memberuser_user", []))
+                        + list(_orig.get("externaluser", []))),
+                    gen_member_diff(
+                        "group", group_add, group_del,
+                        _orig.get("memberuser_group")),
+                    gen_member_diff(
+                        "allow_sudocmd", allow_cmd_add, allow_cmd_del,
+                        _orig.get("memberallowcmd_sudocmd")),
+                    gen_member_diff(
+                        "allow_sudocmdgroup",
+                        allow_cmdgroup_add, allow_cmdgroup_del,
+                        _orig.get("memberallowcmd_sudocmdgroup")),
+                    gen_member_diff(
+                        "deny_sudocmd", deny_cmd_add, deny_cmd_del,
+                        _orig.get("memberdenycmd_sudocmd")),
+                    gen_member_diff(
+                        "deny_sudocmdgroup",
+                        deny_cmdgroup_add, deny_cmdgroup_del,
+                        _orig.get("memberdenycmd_sudocmdgroup")),
+                    gen_member_diff(
+                        "sudooption", sudooption_add, sudooption_del,
+                        _orig.get("ipasudoopt")),
+                    gen_member_diff(
+                        "runasuser", runasuser_add, runasuser_del,
+                        list(_orig.get("ipasudorunas_user", []))
+                        + list(_orig.get("ipasudorunasextuser", []))),
+                    gen_member_diff(
+                        "runasuser_group",
+                        runasuser_group_add, runasuser_group_del,
+                        _orig.get("ipasudorunas_group")),
+                    gen_member_diff(
+                        "runasgroup", runasgroup_add, runasgroup_del,
+                        list(_orig.get("ipasudorunasgroup_group", []))
+                        + list(_orig.get("ipasudorunasextgroup", []))),
+                )
+                diff_tracker.add_entry_diff(entry.name, before, after)
+            elif state == "absent":
+                if action == "sudorule":
+                    if res_find_orig is not None:
+                        diff_tracker.add_entry_diff(
+                            entry.name,
+                            {"state": "present"}, {"state": "absent"})
+                elif action == "member":
+                    before, after = merge_diffs(
+                        gen_member_diff(
+                            "host", host_add, host_del,
+                            list(_orig.get("memberhost_host", []))
+                            + list(_orig.get("externalhost", []))),
+                        gen_member_diff(
+                            "hostgroup", hostgroup_add, hostgroup_del,
+                            _orig.get("memberhost_hostgroup")),
+                        gen_member_diff(
+                            "hostmask", hostmask_add, hostmask_del,
+                            _orig.get("hostmask")),
+                        gen_member_diff(
+                            "user", user_add, user_del,
+                            list(_orig.get("memberuser_user", []))
+                            + list(_orig.get("externaluser", []))),
+                        gen_member_diff(
+                            "group", group_add, group_del,
+                            _orig.get("memberuser_group")),
+                        gen_member_diff(
+                            "allow_sudocmd", allow_cmd_add, allow_cmd_del,
+                            _orig.get("memberallowcmd_sudocmd")),
+                        gen_member_diff(
+                            "allow_sudocmdgroup",
+                            allow_cmdgroup_add, allow_cmdgroup_del,
+                            _orig.get("memberallowcmd_sudocmdgroup")),
+                        gen_member_diff(
+                            "deny_sudocmd", deny_cmd_add, deny_cmd_del,
+                            _orig.get("memberdenycmd_sudocmd")),
+                        gen_member_diff(
+                            "deny_sudocmdgroup",
+                            deny_cmdgroup_add, deny_cmdgroup_del,
+                            _orig.get("memberdenycmd_sudocmdgroup")),
+                        gen_member_diff(
+                            "sudooption", sudooption_add, sudooption_del,
+                            _orig.get("ipasudoopt")),
+                        gen_member_diff(
+                            "runasuser", runasuser_add, runasuser_del,
+                            list(_orig.get("ipasudorunas_user", []))
+                            + list(_orig.get("ipasudorunasextuser", []))),
+                        gen_member_diff(
+                            "runasuser_group",
+                            runasuser_group_add, runasuser_group_del,
+                            _orig.get("ipasudorunas_group")),
+                        gen_member_diff(
+                            "runasgroup", runasgroup_add, runasgroup_del,
+                            list(_orig.get("ipasudorunasgroup_group", []))
+                            + list(_orig.get("ipasudorunasextgroup", []))),
+                    )
+                    diff_tracker.add_entry_diff(entry.name, before, after)
+
         # Execute commands
 
         changed = ansible_module.execute_ipa_commands(
@@ -1096,7 +1219,8 @@ def main():
 
     # Done
 
-    ansible_module.exit_json(changed=changed, **exit_args)
+    _exit_kwargs = dict(exit_args, **diff_tracker.build_diff())
+    ansible_module.exit_json(changed=changed, **_exit_kwargs)
 
 
 if __name__ == "__main__":

--- a/plugins/modules/ipauser.py
+++ b/plugins/modules/ipauser.py
@@ -745,7 +745,7 @@ from ansible.module_utils.ansible_freeipa_module import \
     encode_certificate, load_cert_from_str, DN_x500_text, to_text, \
     ipalib_errors, gen_add_list, gen_intersection_list, \
     convert_input_certificates, date_string, \
-    IPADiffTracker, gen_args_diff, gen_member_diff, merge_diffs
+    IPADiffTracker, gen_args_diff, gen_members_diff, merge_diffs
 from ansible.module_utils import six
 if six.PY3:
     unicode = str
@@ -1457,6 +1457,15 @@ def main():
             res_find = find_user(ansible_module, name)
             res_find_orig = res_find
 
+            # Initialise diff inputs so the post-state-branch diff block can
+            # treat state=present action=user, state=present action=member
+            # and state=absent action=member symmetrically: each branch only
+            # fills the lists it actually changes; the others stay at [].
+            attr_before, attr_after = {}, {}
+            manager_add, manager_del = [], []
+            principal_add, principal_del = [], []
+            certificate_add, certificate_del = [], []
+
             # Create command
             if state == "present":
                 # Generate args
@@ -1472,7 +1481,6 @@ def main():
                     smb_home_dir, smb_home_drive, idp, idp_user_id, noprivate,
                     nomembers,
                 )
-                attr_before, attr_after = {}, {}
 
                 if action == "user":
                     # Found the user
@@ -1647,21 +1655,6 @@ def main():
                             commands.append([name, "user_remove_certmapdata",
                                              gen_certmapdata_args(_data)])
 
-                    # Diff tracking
-                    before, after = merge_diffs(
-                        (attr_before, attr_after),
-                        gen_member_diff(
-                            "manager", manager_add, manager_del,
-                            (res_find_orig or {}).get("manager")),
-                        gen_member_diff(
-                            "principal", principal_add, principal_del,
-                            (res_find_orig or {}).get("krbprincipalname")),
-                        gen_member_diff(
-                            "certificate", certificate_add, certificate_del,
-                            (res_find_orig or {}).get("usercertificate")),
-                    )
-                    diff_tracker.add_entry_diff(name, before, after)
-
                 elif action == "member":
                     if res_find is None:
                         ansible_module.fail_json(
@@ -1721,20 +1714,6 @@ def main():
                         for _data in certmapdata_add:
                             commands.append([name, "user_add_certmapdata",
                                              gen_certmapdata_args(_data)])
-
-                    # Diff tracking
-                    before, after = merge_diffs(
-                        gen_member_diff(
-                            "manager", manager_add, [],
-                            (res_find or {}).get("manager")),
-                        gen_member_diff(
-                            "principal", principal_add, [],
-                            (res_find or {}).get("krbprincipalname")),
-                        gen_member_diff(
-                            "certificate", certificate_add, [],
-                            (res_find or {}).get("usercertificate")),
-                    )
-                    diff_tracker.add_entry_diff(name, before, after)
 
             elif state == "absent":
                 if action == "user":
@@ -1810,20 +1789,6 @@ def main():
                             commands.append([name, "user_remove_certmapdata",
                                              gen_certmapdata_args(_data)])
 
-                    # Diff tracking
-                    before, after = merge_diffs(
-                        gen_member_diff(
-                            "manager", [], manager_del or [],
-                            (res_find or {}).get("manager")),
-                        gen_member_diff(
-                            "principal", [], principal_del or [],
-                            (res_find or {}).get("krbprincipalname")),
-                        gen_member_diff(
-                            "certificate", [], certificate_del or [],
-                            (res_find or {}).get("usercertificate")),
-                    )
-                    diff_tracker.add_entry_diff(name, before, after)
-
             elif state == "undeleted":
                 if res_find is not None:
                     if res_find.get("preserved", False):
@@ -1865,6 +1830,38 @@ def main():
                             name, {"uid": name}, {"uid": rename})
             else:
                 ansible_module.fail_json(msg="Unkown state '%s'" % state)
+
+            # Diff tracking for the present/absent member operations.
+            # The same set of member specs is reused for state=present
+            # action=user (with attribute changes layered on top),
+            # state=present action=member (only add lists are populated by
+            # the branch above), and state=absent action=member (only del
+            # lists are populated). Branches that do not touch members
+            # leave the lists at their initial [] values, so this call is
+            # a no-op for them.
+            member_specs = [
+                ("manager", manager_add, manager_del, "manager"),
+                ("principal", principal_add, principal_del,
+                 "krbprincipalname"),
+                ("certificate", certificate_add, certificate_del,
+                 "usercertificate"),
+            ]
+            member_before, member_after = gen_members_diff(
+                res_find_orig, member_specs)
+
+            if state == "present":
+                if action == "user":
+                    before, after = merge_diffs(
+                        (attr_before, attr_after),
+                        (member_before, member_after),
+                    )
+                    diff_tracker.add_entry_diff(name, before, after)
+                elif action == "member":
+                    diff_tracker.add_entry_diff(
+                        name, member_before, member_after)
+            elif state == "absent" and action == "member":
+                diff_tracker.add_entry_diff(
+                    name, member_before, member_after)
 
         del user_set
 

--- a/plugins/modules/ipauser.py
+++ b/plugins/modules/ipauser.py
@@ -744,7 +744,8 @@ from ansible.module_utils.ansible_freeipa_module import \
     IPAAnsibleModule, compare_args_ipa, gen_add_del_lists, convert_date, \
     encode_certificate, load_cert_from_str, DN_x500_text, to_text, \
     ipalib_errors, gen_add_list, gen_intersection_list, \
-    convert_input_certificates, date_string
+    convert_input_certificates, date_string, \
+    IPADiffTracker, gen_args_diff, gen_member_diff, merge_diffs
 from ansible.module_utils import six
 if six.PY3:
     unicode = str
@@ -1268,6 +1269,7 @@ def main():
 
     changed = False
     exit_args = {}
+    diff_tracker = IPADiffTracker()
 
     # Connect to IPA API
     with ansible_module.ipa_connect():
@@ -1453,6 +1455,7 @@ def main():
 
             # Make sure user exists
             res_find = find_user(ansible_module, name)
+            res_find_orig = res_find
 
             # Create command
             if state == "present":
@@ -1469,6 +1472,7 @@ def main():
                     smb_home_dir, smb_home_drive, idp, idp_user_id, noprivate,
                     nomembers,
                 )
+                attr_before, attr_after = {}, {}
 
                 if action == "user":
                     # Found the user
@@ -1498,6 +1502,14 @@ def main():
                                 ansible_module, args, res_find,
                                 ignore=["no_members"]):
                             commands.append([name, "user_mod", args])
+                            attr_before, attr_after = gen_args_diff(
+                                args, res_find,
+                                ignore=["no_members"])
+                            # Mask password in diff
+                            if "userpassword" in attr_before:
+                                attr_before["userpassword"] = "********"
+                            if "userpassword" in attr_after:
+                                attr_after["userpassword"] = "********"
 
                     else:
                         # Make sure we have a first and last name
@@ -1521,6 +1533,10 @@ def main():
                         for key in smb_attrs.keys():
                             del args[key]
                         commands.append([name, "user_add", args])
+                        _diff_args = dict(args)
+                        if "userpassword" in _diff_args:
+                            _diff_args["userpassword"] = "********"
+                        attr_before, attr_after = {}, _diff_args
                         if smb_attrs:
                             commands.append([name, "user_mod", smb_attrs])
                     # Handle members: principal, manager, certificate and
@@ -1631,6 +1647,21 @@ def main():
                             commands.append([name, "user_remove_certmapdata",
                                              gen_certmapdata_args(_data)])
 
+                    # Diff tracking
+                    before, after = merge_diffs(
+                        (attr_before, attr_after),
+                        gen_member_diff(
+                            "manager", manager_add, manager_del,
+                            (res_find_orig or {}).get("manager")),
+                        gen_member_diff(
+                            "principal", principal_add, principal_del,
+                            (res_find_orig or {}).get("krbprincipalname")),
+                        gen_member_diff(
+                            "certificate", certificate_add, certificate_del,
+                            (res_find_orig or {}).get("usercertificate")),
+                    )
+                    diff_tracker.add_entry_diff(name, before, after)
+
                 elif action == "member":
                     if res_find is None:
                         ansible_module.fail_json(
@@ -1691,6 +1722,20 @@ def main():
                             commands.append([name, "user_add_certmapdata",
                                              gen_certmapdata_args(_data)])
 
+                    # Diff tracking
+                    before, after = merge_diffs(
+                        gen_member_diff(
+                            "manager", manager_add, [],
+                            (res_find or {}).get("manager")),
+                        gen_member_diff(
+                            "principal", principal_add, [],
+                            (res_find or {}).get("krbprincipalname")),
+                        gen_member_diff(
+                            "certificate", certificate_add, [],
+                            (res_find or {}).get("usercertificate")),
+                    )
+                    diff_tracker.add_entry_diff(name, before, after)
+
             elif state == "absent":
                 if action == "user":
                     if res_find is not None:
@@ -1702,6 +1747,9 @@ def main():
                             or not args.get("preserve", False)
                         ):
                             commands.append([name, "user_del", args])
+                            diff_tracker.add_entry_diff(
+                                name,
+                                {"state": "present"}, {"state": "absent"})
                 elif action == "member":
                     if res_find is None:
                         ansible_module.fail_json(
@@ -1761,6 +1809,21 @@ def main():
                         for _data in certmapdata_del:
                             commands.append([name, "user_remove_certmapdata",
                                              gen_certmapdata_args(_data)])
+
+                    # Diff tracking
+                    before, after = merge_diffs(
+                        gen_member_diff(
+                            "manager", [], manager_del or [],
+                            (res_find or {}).get("manager")),
+                        gen_member_diff(
+                            "principal", [], principal_del or [],
+                            (res_find or {}).get("krbprincipalname")),
+                        gen_member_diff(
+                            "certificate", [], certificate_del or [],
+                            (res_find or {}).get("usercertificate")),
+                    )
+                    diff_tracker.add_entry_diff(name, before, after)
+
             elif state == "undeleted":
                 if res_find is not None:
                     if res_find.get("preserved", False):
@@ -1772,6 +1835,8 @@ def main():
                 if res_find is not None:
                     if res_find["nsaccountlock"]:
                         commands.append([name, "user_enable", {}])
+                        diff_tracker.add_entry_diff(
+                            name, {"enabled": False}, {"enabled": True})
                 else:
                     raise ValueError("No user '%s'" % name)
 
@@ -1779,6 +1844,8 @@ def main():
                 if res_find is not None:
                     if not res_find["nsaccountlock"]:
                         commands.append([name, "user_disable", {}])
+                        diff_tracker.add_entry_diff(
+                            name, {"enabled": True}, {"enabled": False})
                 else:
                     raise ValueError("No user '%s'" % name)
 
@@ -1794,6 +1861,8 @@ def main():
                 else:
                     if rename != name:
                         commands.append([name, 'user_mod', {"rename": rename}])
+                        diff_tracker.add_entry_diff(
+                            name, {"uid": name}, {"uid": rename})
             else:
                 ansible_module.fail_json(msg="Unkown state '%s'" % state)
 
@@ -1806,7 +1875,8 @@ def main():
             exit_args=exit_args, single_user=users is None)
 
     # Done
-    ansible_module.exit_json(changed=changed, user=exit_args)
+    _exit_kwargs = diff_tracker.build_diff()
+    ansible_module.exit_json(changed=changed, user=exit_args, **_exit_kwargs)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR adds `--diff` support to the following 8 modules:

* `ipagroup`
* `ipahbacrule`
* `ipahostgroup`
* `ipapwpolicy`
* `ipasudocmd`
* `ipasudocmdgroup`
* `ipasudorule`
* `ipauser`

(since these are the ones that we are using for our [LFOps Ansible Collection](https://github.com/Linuxfabrik/lfops) right now).

This partly fixes https://github.com/freeipa/ansible-freeipa/issues/483.

## Summary by Sourcery

Add structured diff reporting for IPA modules to support Ansible --diff output when managing IPA objects and their memberships.

New Features:
- Expose before/after state in Ansible --diff output for ipagroup, ipahbacrule, ipahostgroup, ipapwpolicy, ipasudocmd, ipasudocmdgroup, ipasudorule, and ipauser modules, including creation, deletion, attribute updates, membership changes, and enable/disable operations.

Enhancements:
- Introduce a shared IPADiffTracker utility and helper functions to compute and merge attribute and membership diffs consistently across IPA modules, masking sensitive values like user passwords in diff output.