### PR TITLE
Fix docs: set ipaserver_external_cert_files to a list

### DIFF
--- a/roles/ipaserver/README.md
+++ b/roles/ipaserver/README.md
@@ -153,7 +153,7 @@ Server installation step 2: Copy `<ipaserver hostname>-chain.crt` to the IPA ser
   hosts: ipaserver
   become: true
   vars:
-    ipaserver_external_cert_files: "/root/chain.crt"
+    ipaserver_external_cert_files: ["/root/chain.crt"]
 
   pre_tasks:
   - name: Copy "{{ groups.ipaserver[0] + '-chain.crt' }}" to /root/chain.crt on node

--- a/tests/external-signed-ca-with-manual-copy/install-server-with-external-ca-with-manual-copy.yml
+++ b/tests/external-signed-ca-with-manual-copy/install-server-with-external-ca-with-manual-copy.yml
@@ -33,7 +33,7 @@
   hosts: ipaserver
   become: true
   vars:
-    ipaserver_external_cert_files: "/root/chain.crt"
+    ipaserver_external_cert_files: ["/root/chain.crt"]
     # ipaserver_external_ca_file: "cacert.asc"
 
   pre_tasks:


### PR DESCRIPTION
Fixes issue #874

I'm running into issues following the documentation, so let's first fix the docs.

## Summary by Sourcery

Correct documentation and tests to show ipaserver_external_cert_files as a list rather than a string.

Documentation:
- Update ipaserver role README example to configure ipaserver_external_cert_files as a list value.

Tests:
- Align external CA manual-copy test playbook with the expected list type for ipaserver_external_cert_files.