### PR TITLE
ipaclient: Increase minimum supported IPA version to 4.6.8#1419

### DIFF
--- a/roles/ipaclient/library/ipaclient_fix_ca.py
+++ b/roles/ipaclient/library/ipaclient_fix_ca.py
@@ -80,8 +80,7 @@ import os
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.ansible_ipa_client import (
     setup_logging, check_imports,
-    SECURE_PATH, paths, sysrestore, options, NUM_VERSION, get_ca_cert,
-    get_ca_certs, errors
+    SECURE_PATH, paths, sysrestore, options, get_ca_certs, errors
 )
 
 
@@ -127,10 +126,7 @@ def main():
         try:
             os.environ['KRB5_CONFIG'] = env['KRB5_CONFIG'] = "/etc/krb5.conf"
             env['KRB5CCNAME'] = os.environ['KRB5CCNAME']
-            if NUM_VERSION < 40100:
-                get_ca_cert(fstore, options, servers[0], basedn)
-            else:
-                get_ca_certs(fstore, options, servers[0], basedn, realm)
+            get_ca_certs(fstore, options, servers[0], basedn, realm)
             changed = True
             os.environ.pop('KRB5_CONFIG', None)
         except errors.FileError as e:

--- a/roles/ipaclient/library/ipaclient_join.py
+++ b/roles/ipaclient/library/ipaclient_join.py
@@ -116,13 +116,13 @@ EXAMPLES = '''
     kinit_attempts: 5
     krb_name: /tmp/tmpkrb5.conf
 
-# Join IPA to get the keytab using ipadiscovery return values
+# Join IPA to get the keytab using discovery return values
 - name: Join IPA
   ipaclient_join:
-    servers: "{{ ipadiscovery.servers }}"
-    realm: "{{ ipadiscovery.realm }}"
-    basedn: "{{ ipadiscovery.basedn }}"
-    hostname: "{{ ipadiscovery.hostname }}"
+    servers: "{{ discovery.servers }}"
+    realm: "{{ discovery.realm }}"
+    basedn: "{{ discovery.basedn }}"
+    hostname: "{{ discovery.hostname }}"
     principal: admin
     password: MySecretPassword
     krb_name: /tmp/tmpkrb5.conf
@@ -142,8 +142,7 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.ansible_ipa_client import (
     setup_logging, check_imports,
     SECURE_PATH, sysrestore, paths, options, realm_to_suffix, kinit_keytab,
-    GSSError, kinit_password, NUM_VERSION, get_ca_cert, get_ca_certs, errors,
-    run
+    GSSError, kinit_password, get_ca_certs, errors, run
 )
 
 
@@ -268,10 +267,7 @@ def main():
         # Get the CA certificate
         try:
             os.environ['KRB5_CONFIG'] = env['KRB5_CONFIG']
-            if NUM_VERSION < 40100:
-                get_ca_cert(fstore, options, servers[0], basedn)
-            else:
-                get_ca_certs(fstore, options, servers[0], basedn, realm)
+            get_ca_certs(fstore, options, servers[0], basedn, realm)
             os.environ.pop('KRB5_CONFIG', None)
         except errors.FileError as e:
             module.fail_json(msg='%s' % e)

--- a/roles/ipaclient/library/ipaclient_setup_ntp.py
+++ b/roles/ipaclient/library/ipaclient_setup_ntp.py
@@ -79,7 +79,7 @@ RETURN = '''
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.ansible_ipa_client import (
     setup_logging, check_imports,
-    options, sysrestore, paths, sync_time, logger, ipadiscovery,
+    options, sysrestore, paths, sync_time, logger, discovery,
     timeconf, getargspec
 )
 
@@ -152,7 +152,7 @@ def main():
             # If that fails, we try to sync directly with IPA server,
             # assuming it runs NTP
             logger.info('Synchronizing time with KDC...')
-            ds = ipadiscovery.IPADiscovery()
+            ds = discovery.IPADiscovery()
             ntp_srv_servers = ds.ipadns_search_srv(cli_domain, '_ntp._udp',
                                                    None, break_on_first=False)
             synced_ntp = False

--- a/roles/ipaclient/library/ipaclient_temp_krb5.py
+++ b/roles/ipaclient/library/ipaclient_temp_krb5.py
@@ -80,14 +80,14 @@ EXAMPLES = '''
     kdc: server1.example.com
     hostname: client1.example.com
 
-# Test IPA with ipadiscovery return values
+# Test IPA with discovery return values
 - name: Join IPA
   ipaclient_test_keytab:
-    servers: "{{ ipadiscovery.servers }}"
-    domain: "{{ ipadiscovery.domain }}"
-    realm: "{{ ipadiscovery.realm }}"
-    kdc: "{{ ipadiscovery.kdc }}"
-    hostname: "{{ ipadiscovery.hostname }}"
+    servers: "{{ discovery.servers }}"
+    domain: "{{ discovery.domain }}"
+    realm: "{{ discovery.realm }}"
+    kdc: "{{ discovery.kdc }}"
+    hostname: "{{ discovery.hostname }}"
 '''
 
 RETURN = '''

--- a/roles/ipaclient/library/ipaclient_test.py
+++ b/roles/ipaclient/library/ipaclient_test.py
@@ -257,7 +257,7 @@ from ansible.module_utils.ansible_ipa_client import (
     logger, x509, normalize_hostname, installer, version, ScriptError,
     CLIENT_INSTALL_ERROR, tasks, check_ldap_conf, timeconf, constants,
     validate_hostname, nssldap_exists, gssapi, remove_file,
-    check_ip_addresses, ipadiscovery, print_port_conf_info,
+    check_ip_addresses, discovery, print_port_conf_info,
     IPA_PYTHON_VERSION, getargspec, services,
     CLIENT_SUPPORTS_NO_DNSSEC_VALIDATION
 )
@@ -603,7 +603,10 @@ def main():
             hostname = options.hostname
             hostname_source = 'Provided as option'
         else:
-            hostname = socket.getfqdn()
+            if hasattr(constants, "FQDN"):
+                hostname = constants.FQDN
+            else:
+                hostname = socket.getfqdn()
             hostname_source = "Machine's FQDN"
         if hostname != hostname.lower():
             raise ScriptError(
@@ -694,7 +697,7 @@ def main():
 
         # Create the discovery instance
         # pylint: disable=invalid-name
-        ds = ipadiscovery.IPADiscovery()
+        ds = discovery.IPADiscovery()
 
         ret = ds.search(
             domain=options.domain,
@@ -719,24 +722,24 @@ def main():
                               ', '.join(options.server),
                               rval=CLIENT_INSTALL_ERROR)
 
-        if ret == ipadiscovery.BAD_HOST_CONFIG:
+        if ret == discovery.BAD_HOST_CONFIG:
             logger.error("Can't get the fully qualified name of this host")
             logger.info("Check that the client is properly configured")
             raise ScriptError(
                 "Can't get the fully qualified name of this host",
                 rval=CLIENT_INSTALL_ERROR)
-        if ret == ipadiscovery.NOT_FQDN:
+        if ret == discovery.NOT_FQDN:
             raise ScriptError(
                 "{0} is not a fully-qualified hostname".format(hostname),
                 rval=CLIENT_INSTALL_ERROR)
-        if ret in (ipadiscovery.NO_LDAP_SERVER, ipadiscovery.NOT_IPA_SERVER) \
+        if ret in (discovery.NO_LDAP_SERVER, discovery.NOT_IPA_SERVER) \
                 or not ds.domain:
-            if ret == ipadiscovery.NO_LDAP_SERVER:
+            if ret == discovery.NO_LDAP_SERVER:
                 if ds.server:
                     logger.debug("%s is not an LDAP server", ds.server)
                 else:
                     logger.debug("No LDAP server found")
-            elif ret == ipadiscovery.NOT_IPA_SERVER:
+            elif ret == discovery.NOT_IPA_SERVER:
                 if ds.server:
                     logger.debug("%s is not an IPA server", ds.server)
                 else:
@@ -775,7 +778,7 @@ def main():
 
         client_domain = hostname[hostname.find(".") + 1:]
 
-        if ret in (ipadiscovery.NO_LDAP_SERVER, ipadiscovery.NOT_IPA_SERVER) \
+        if ret in (discovery.NO_LDAP_SERVER, discovery.NOT_IPA_SERVER) \
                 or not ds.server:
             logger.debug("IPA Server not found")
             if options.server:
@@ -828,14 +831,14 @@ def main():
                 cli_server_source = ds.server_source
                 logger.debug("will use discovered server: %s", cli_server[0])
 
-        if ret == ipadiscovery.NOT_IPA_SERVER:
+        if ret == discovery.NOT_IPA_SERVER:
             logger.error("%s is not an IPA v2 Server.", cli_server[0])
             print_port_conf_info()
             logger.debug("(%s: %s)", cli_server[0], cli_server_source)
             raise ScriptError("%s is not an IPA v2 Server." % cli_server[0],
                               rval=CLIENT_INSTALL_ERROR)
 
-        if ret == ipadiscovery.NO_ACCESS_TO_LDAP:
+        if ret == discovery.NO_ACCESS_TO_LDAP:
             logger.warning("Anonymous access to the LDAP server is disabled.")
             logger.info("Proceeding without strict verification.")
             logger.info(
@@ -843,7 +846,7 @@ def main():
                 "has been explicitly restricted.")
             ret = 0
 
-        if ret == ipadiscovery.NO_TLS_LDAP:
+        if ret == discovery.NO_TLS_LDAP:
             logger.warning(
                 "The LDAP server requires TLS is but we do not have the CA.")
             logger.info("Proceeding without strict verification.")

--- a/roles/ipaclient/library/ipaclient_test_keytab.py
+++ b/roles/ipaclient/library/ipaclient_test_keytab.py
@@ -80,14 +80,14 @@ EXAMPLES = '''
     hostname: client1.example.com
     kinit_attempts: 5
 
-# Test IPA with ipadiscovery return values
+# Test IPA with discovery return values
 - name: Join IPA
   ipaclient_test_keytab:
-    servers: "{{ ipadiscovery.servers }}"
-    domain: "{{ ipadiscovery.domain }}"
-    realm: "{{ ipadiscovery.realm }}"
-    kdc: "{{ ipadiscovery.kdc }}"
-    hostname: "{{ ipadiscovery.hostname }}"
+    servers: "{{ discovery.servers }}"
+    domain: "{{ discovery.domain }}"
+    realm: "{{ discovery.realm }}"
+    kdc: "{{ discovery.kdc }}"
+    hostname: "{{ discovery.hostname }}"
 '''
 
 RETURN = '''

--- a/roles/ipaclient/module_utils/ansible_ipa_client.py
+++ b/roles/ipaclient/module_utils/ansible_ipa_client.py
@@ -25,7 +25,7 @@ from __future__ import (absolute_import, division, print_function)
 
 __metaclass__ = type
 
-__all__ = ["gssapi", "version", "ipadiscovery", "api", "errors", "x509",
+__all__ = ["gssapi", "version", "discovery", "api", "errors", "x509",
            "constants", "sysrestore", "certmonger", "certstore",
            "delete_persistent_client_session_data", "ScriptError",
            "CheckedIPAddress", "validate_domain_name", "normalize_hostname",
@@ -48,10 +48,11 @@ __all__ = ["gssapi", "version", "ipadiscovery", "api", "errors", "x509",
            "configure_firefox", "sync_time", "check_ldap_conf",
            "sssd_enable_ifp", "configure_selinux_for_client",
            "getargspec", "paths", "options",
-           "IPA_PYTHON_VERSION", "NUM_VERSION", "certdb", "get_ca_cert",
+           "IPA_PYTHON_VERSION", "NUM_VERSION", "certdb",
            "ipalib", "logger", "ipautil", "installer"]
 
 import sys
+import logging
 
 # Import getargspec from inspect or provide own getargspec for
 # Python 2 compatibility with Python 3.11+.
@@ -87,244 +88,102 @@ try:
     else:
         IPA_PYTHON_VERSION = NUM_VERSION
 
-    # pylint: disable=invalid-name,useless-object-inheritance
-    class installer_obj(object):
-        def __init__(self):
-            pass
-
-        # pylint: disable=attribute-defined-outside-init
-        def set_logger(self, _logger):
-            self.logger = _logger
-
-        # def __getattribute__(self, attr):
-        #    value = super(installer_obj, self).__getattribute__(attr)
-        #    if not attr.startswith("--") and not attr.endswith("--"):
-        #        logger.debug(
-        #            "  <-- Accessing installer.%s (%s)" % (attr, repr(value)))
-        #    return value
-
-        # def __getattr__(self, attr):
-        #    # logger.info("  --> ADDING missing installer.%s" % attr)
-        #    self.logger.warn("  --> ADDING missing installer.%s" % attr)
-        #    setattr(self, attr, None)
-        #    return getattr(self, attr)
-
-        # def __setattr__(self, attr, value):
-        #    logger.debug("  --> Setting installer.%s to %s" %
-        #                 (attr, repr(value)))
-        #    return super(installer_obj, self).__setattr__(attr, value)
-
-        def knobs(self):
-            for name in self.__dict__:
-                yield self, name
-
-    # Initialize installer settings
-    installer = installer_obj()
-    # Create options
-    options = installer
-    # pylint: disable=attribute-defined-outside-init
-    options.interactive = False
-    options.unattended = not options.interactive
-
-    if NUM_VERSION >= 40400:
-        # IPA version >= 4.4
-
-        # import sys
-        import gssapi
-        import logging
-
-        from ipapython import version
-        try:
-            from ipaclient.install import ipadiscovery
-        except ImportError:
-            from ipaclient import ipadiscovery
-        import ipalib
-        from ipalib import api, errors, x509
-        from ipalib import constants
-        try:
-            from ipalib import sysrestore
-        except ImportError:
-            try:
-                from ipalib.install import sysrestore
-            except ImportError:
-                from ipapython import sysrestore
-        try:
-            from ipalib.install import certmonger
-        except ImportError:
-            from ipapython import certmonger
-        try:
-            from ipalib.install import certstore
-        except ImportError:
-            from ipalib import certstore
-        from ipalib.rpc import delete_persistent_client_session_data
-        from ipapython import certdb, ipautil
-        from ipapython.admintool import ScriptError
-        from ipapython.ipautil import CheckedIPAddress
-        from ipalib.util import validate_domain_name, normalize_hostname, \
-            validate_hostname
-        from ipaplatform import services
-        from ipaplatform.paths import paths
-        from ipaplatform.tasks import tasks
-        try:
-            from cryptography.hazmat.primitives import serialization
-        except ImportError:
-            serialization = None
-        from ipapython.ipautil import CalledProcessError, write_tmp_file, \
-            ipa_generate_password
-        from ipapython.dn import DN
-        try:
-            from ipalib.kinit import kinit_password, kinit_keytab
-        except ImportError:
-            try:
-                from ipalib.install.kinit import kinit_keytab, kinit_password
-            except ImportError:
-                # pre 4.5.0
-                from ipapython.ipautil import kinit_keytab, kinit_password
-        from ipapython.ipa_log_manager import standard_logging_setup
-        from gssapi.exceptions import GSSError
-        try:
-            from ipaclient.install.client import configure_krb5_conf, \
-                get_ca_certs, SECURE_PATH, get_server_connection_interface, \
-                disable_ra, client_dns, \
-                configure_certmonger, update_ssh_keys, \
-                configure_openldap_conf, \
-                hardcode_ldap_server, get_certs_from_ldap, save_state, \
-                create_ipa_nssdb, configure_ssh_config, \
-                configure_sshd_config, \
-                configure_automount, configure_firefox, configure_nisdomain, \
-                CLIENT_INSTALL_ERROR, is_ipa_client_installed, \
-                CLIENT_ALREADY_CONFIGURED, nssldap_exists, remove_file, \
-                check_ip_addresses, print_port_conf_info, configure_ipa_conf, \
-                purge_host_keytab, configure_sssd_conf, configure_ldap_conf, \
-                configure_nslcd_conf
-            get_ca_cert = None
-        except ImportError:
-            # Create temporary copy of ipa-client-install script (as
-            # ipa_client_install.py) to be able to import the script easily
-            # and also to remove the global finally clause in which the
-            # generated ccache file gets removed. The ccache file will be
-            # needed in the next step.
-            # This is done in a temporary directory that gets removed right
-            # after ipa_client_install has been imported.
-            import shutil
-            import tempfile
-            temp_dir = tempfile.mkdtemp(dir="/tmp")
-            sys.path.append(temp_dir)
-            temp_file = "%s/ipa_client_install.py" % temp_dir
-
-            with open("/usr/sbin/ipa-client-install", "r") as f_in:
-                with open(temp_file, "w") as f_out:
-                    for line in f_in:
-                        if line.startswith("finally:"):
-                            break
-                        f_out.write(line)
-            import ipa_client_install
-
-            shutil.rmtree(temp_dir, ignore_errors=True)
-            sys.path.remove(temp_dir)
-
-            # pylint: disable=deprecated-method
-            argspec = getargspec(
-                ipa_client_install.configure_krb5_conf)
-            if argspec.keywords is None:
-                def configure_krb5_conf(
-                        cli_realm, cli_domain, cli_server, cli_kdc, dnsok,
-                        filename, client_domain, client_hostname, force=False,
-                        configure_sssd=True):
-                    options.force = force
-                    options.sssd = configure_sssd
-                    return ipa_client_install.configure_krb5_conf(
-                        cli_realm, cli_domain, cli_server, cli_kdc, dnsok,
-                        options, filename, client_domain, client_hostname)
-            else:
-                configure_krb5_conf = ipa_client_install.configure_krb5_conf
-            if NUM_VERSION < 40100:
-                get_ca_cert = ipa_client_install.get_ca_cert
-                get_ca_certs = None
-            else:
-                get_ca_cert = None
-                get_ca_certs = ipa_client_install.get_ca_certs
-            SECURE_PATH = ("/bin:/sbin:/usr/kerberos/bin:/usr/kerberos/sbin:"
-                           "/usr/bin:/usr/sbin")
-
-            get_server_connection_interface = \
-                ipa_client_install.get_server_connection_interface
-            disable_ra = ipa_client_install.disable_ra
-            client_dns = ipa_client_install.client_dns
-            configure_certmonger = ipa_client_install.configure_certmonger
-            update_ssh_keys = ipa_client_install.update_ssh_keys
-            configure_openldap_conf = \
-                ipa_client_install.configure_openldap_conf
-            hardcode_ldap_server = ipa_client_install.hardcode_ldap_server
-            get_certs_from_ldap = ipa_client_install.get_certs_from_ldap
-            save_state = ipa_client_install.save_state
-
-            create_ipa_nssdb = certdb.create_ipa_nssdb
-
-            argspec = \
-                getargspec(ipa_client_install.configure_nisdomain)
-            if len(argspec.args) == 3:
-                configure_nisdomain = ipa_client_install.configure_nisdomain
-            else:
-                def configure_nisdomain(_options, domain, _statestore=None):
-                    return ipa_client_install.configure_nisdomain(_options,
-                                                                  domain)
-
-            configure_ldap_conf = ipa_client_install.configure_ldap_conf
-            configure_nslcd_conf = ipa_client_install.configure_nslcd_conf
-
-            configure_ssh_config = ipa_client_install.configure_ssh_config
-            configure_sshd_config = ipa_client_install.configure_sshd_config
-            configure_automount = ipa_client_install.configure_automount
-            configure_firefox = ipa_client_install.configure_firefox
-
-        from ipapython.ipautil import realm_to_suffix, run
-
-        try:
-            from ipaclient.install import timeconf
-            time_service = "chronyd"
-        except ImportError:
-            try:
-                from ipaclient.install import ntpconf as timeconf
-            except ImportError:
-                from ipaclient import ntpconf as timeconf
-            time_service = "ntpd"
-
-        try:
-            from ipaclient.install.client import sync_time
-        except ImportError:
-            sync_time = None
-
-        try:
-            from ipaclient.install.client import check_ldap_conf
-        except ImportError:
-            check_ldap_conf = None
-
-        try:
-            from ipaclient.install.client import sssd_enable_ifp
-        except ImportError:
-            sssd_enable_ifp = None
-
-        try:
-            from ipaclient.install.client import configure_selinux_for_client
-        except ImportError:
-            configure_selinux_for_client = None
-
-        try:
-            CLIENT_SUPPORTS_NO_DNSSEC_VALIDATION = False
-            from ipaclient.install.client import ClientInstallInterface
-        except ImportError:
-            pass
-        else:
-            if hasattr(ClientInstallInterface, "no_dnssec_validation"):
-                CLIENT_SUPPORTS_NO_DNSSEC_VALIDATION = True
-
-        logger = logging.getLogger("ipa-client-install")
-        root_logger = logger
-
-    else:
-        # IPA version < 4.4
+    # Minimal IPA version check
+    if NUM_VERSION < 40608:
         raise RuntimeError("freeipa version '%s' is too old" % VERSION)
+
+    import gssapi
+
+    from ipapython import version
+    try:
+        # IPA >= 4.8.0
+        from ipaclient import discovery
+    except ImportError:
+        from ipaclient.install import ipadiscovery as discovery
+    import ipalib
+    from ipalib import api, errors, x509
+    from ipalib import constants
+    try:
+        from ipalib import sysrestore  # IPA >= 4.8.9
+    except ImportError:
+        from ipalib.install import sysrestore  # IPA >= 4.5.0
+    from ipalib.install import certmonger  # IPA >= 4.5.0
+    from ipalib.install import certstore   # IPA >= 4.5.0
+    from ipalib.rpc import delete_persistent_client_session_data
+    from ipapython import certdb, ipautil
+    from ipapython.admintool import ScriptError
+    from ipapython.ipautil import CheckedIPAddress
+    from ipalib.util import validate_domain_name, normalize_hostname, \
+        validate_hostname
+    from ipaplatform import services
+    from ipaplatform.paths import paths
+    from ipaplatform.tasks import tasks
+    try:
+        from cryptography.hazmat.primitives import serialization
+    except ImportError:
+        serialization = None
+    from ipapython.ipautil import CalledProcessError, write_tmp_file, \
+        ipa_generate_password
+    from ipapython.dn import DN
+    try:
+        # IPA >= 4.12.0
+        from ipalib.kinit import kinit_password, kinit_keytab
+    except ImportError:
+        # IPA >= 4.5.0
+        from ipalib.install.kinit import kinit_keytab, kinit_password
+    from ipapython.ipa_log_manager import standard_logging_setup
+    from gssapi.exceptions import GSSError
+    from ipaclient.install.client import configure_krb5_conf, \
+        get_ca_certs, SECURE_PATH, get_server_connection_interface, \
+        disable_ra, client_dns, \
+        configure_certmonger, update_ssh_keys, \
+        configure_openldap_conf, \
+        hardcode_ldap_server, get_certs_from_ldap, save_state, \
+        create_ipa_nssdb, configure_ssh_config, \
+        configure_sshd_config, \
+        configure_automount, configure_firefox, configure_nisdomain, \
+        CLIENT_INSTALL_ERROR, is_ipa_client_installed, \
+        CLIENT_ALREADY_CONFIGURED, nssldap_exists, remove_file, \
+        check_ip_addresses, print_port_conf_info, configure_ipa_conf, \
+        purge_host_keytab, configure_sssd_conf, configure_ldap_conf, \
+        configure_nslcd_conf
+
+    from ipapython.ipautil import realm_to_suffix, run
+
+    try:
+        # IPA >= 4.6.90.pre2
+        from ipaclient.install import timeconf
+        time_service = "chronyd"
+    except ImportError:
+        # IPA >= 4.5.0
+        from ipaclient.install import ntpconf as timeconf
+        time_service = "ntpd"
+
+    try:
+        # IPA >= 4.6.90.pre2
+        from ipaclient.install.client import sync_time
+    except ImportError:
+        sync_time = None
+
+    try:
+        # IPA >= 4.7.0
+        from ipaclient.install.client import check_ldap_conf
+    except ImportError:
+        check_ldap_conf = None
+
+    from ipaclient.install.client import sssd_enable_ifp  # IPA >= 4.6.5
+
+    try:
+        # IPA >= 4.11.0
+        from ipaclient.install.client import configure_selinux_for_client
+    except ImportError:
+        configure_selinux_for_client = None
+
+    from ipaclient.install.client import ClientInstallInterface  # IPA >= 4.5.0
+    CLIENT_SUPPORTS_NO_DNSSEC_VALIDATION = False
+    if hasattr(ClientInstallInterface, "no_dnssec_validation"):
+        # IPA >= 4.13.0
+        CLIENT_SUPPORTS_NO_DNSSEC_VALIDATION = True
 
 except ImportError as _err:
     ANSIBLE_IPA_CLIENT_MODULE_IMPORT_ERROR = str(_err)
@@ -361,3 +220,46 @@ def ansible_module_get_parsed_ip_addresses(ansible_module,
 def check_imports(module):
     if ANSIBLE_IPA_CLIENT_MODULE_IMPORT_ERROR is not None:
         module.fail_json(msg=ANSIBLE_IPA_CLIENT_MODULE_IMPORT_ERROR)
+
+
+# pylint: disable=invalid-name,useless-object-inheritance
+class installer_obj(object):
+    def __init__(self):
+        self.interactive = False
+        self.unattended = not self.interactive
+
+    # pylint: disable=attribute-defined-outside-init
+    def set_logger(self, _logger):
+        self.logger = _logger
+
+    # def __getattribute__(self, attr):
+    #    value = super(installer_obj, self).__getattribute__(attr)
+    #    if not attr.startswith("--") and not attr.endswith("--"):
+    #        logger.debug(
+    #            "  <-- Accessing installer.%s (%s)" % (attr, repr(value)))
+    #    return value
+
+    # def __getattr__(self, attr):
+    #    # logger.info("  --> ADDING missing installer.%s" % attr)
+    #    self.logger.warn("  --> ADDING missing installer.%s" % attr)
+    #    setattr(self, attr, None)
+    #    return getattr(self, attr)
+
+    # def __setattr__(self, attr, value):
+    #    logger.debug("  --> Setting installer.%s to %s" %
+    #                 (attr, repr(value)))
+    #    return super(installer_obj, self).__setattr__(attr, value)
+
+    def knobs(self):
+        for name in self.__dict__:
+            yield self, name
+# pylint: enable=too-few-public-methods, useless-object-inheritance
+
+
+# Initialize installer and options
+installer = installer_obj()
+options = installer
+
+# Initialize logger
+logger = logging.getLogger("ipa-client-install")
+root_logger = logger


### PR DESCRIPTION
This is preparation work for the SIX removal in Ansible that will drop support for RHEL-7 (Python 2) and together with this support for IPA versions prior to 4.8.4.

The goal is to remove code that was needed for IPA versions prior to 4.6.8. Also to mark the code and special cases with the IPA versions that needed these.

## Summary by Sourcery

Raise the minimum supported FreeIPA server version for the ipaclient role and simplify compatibility handling accordingly.

Enhancements:
- Remove legacy code paths and conditionals for FreeIPA versions older than 4.6.8, enforcing a runtime minimum version check.
- Standardize on the modern ipaclient discovery API and update references from ipadiscovery to discovery across modules and documentation strings.
- Simplify CA certificate retrieval and time configuration logic now that only newer FreeIPA interfaces need to be supported.
- Centralize and streamline initialization of the installer options and logging objects in the ipaclient module.