### PR TITLE
Fix table formating in sudorule-readme

### DIFF
--- a/README-sudorule.md
+++ b/README-sudorule.md
@@ -184,7 +184,7 @@ Variable | Description | Required
 `ipaapi_ldap_cache` | Use LDAP cache for IPA connection. The bool setting defaults to yes. (bool) | no
 `name` \| `cn` | The list of sudorule name strings. | no
 `sudorules` | The list of sudorule dicts. Each `sudorule` dict entry can contain sudorule variables.<br>There is one required option in the `sudorule` dict:| no
-&nbsp; | `name` - The sudorule name string of the entry. | yes
+`name` | The sudorule name string of the entry. | yes
 `description` | The sudorule description string. | no
 `usercategory` \| `usercat` | User category the rule applies to. Choices: ["all", ""] | no
 `hostcategory` \| `hostcat` | Host category the rule applies to. Choices: ["all", ""] | no


### PR DESCRIPTION
The row with the `name` attribute was missformated. I changed it to be in line with all the other rows.

## Summary by Sourcery

Documentation:
- Correct the `name` row formatting in README-sudorule.md to match the rest of the variable table.