### PR TITLE
Use "#!/usr/bin/env bash" shebang in all shell scripts

### DIFF
--- a/infra/image/build.sh
+++ b/infra/image/build.sh
@@ -1,4 +1,6 @@
-#!/bin/bash -eu
+#!/usr/bin/env bash
+
+set -eu
 
 BASEDIR="$(readlink -f "$(dirname "$0")")"
 TOPDIR="$(readlink -f "${BASEDIR}/../..")"
@@ -119,7 +121,7 @@ then
         deployed=true
     fi
     echo
-    
+
     container_stop "${name}"
 
     $deployed || die "Deployment failed"

--- a/infra/image/start.sh
+++ b/infra/image/start.sh
@@ -1,4 +1,6 @@
-#!/bin/bash -eu
+#!/usr/bin/env bash
+
+set -eu
 
 BASEDIR="$(readlink -f "$(dirname "$0")")"
 TOPDIR="$(readlink -f "${BASEDIR}/../..")"

--- a/tests/group/groups.sh
+++ b/tests/group/groups.sh
@@ -1,4 +1,6 @@
-#!/bin/bash -eu
+#!/usr/bin/env bash
+
+set -eu
 
 NUM=${1-1000}
 FILE="groups.json"

--- a/tests/sanity/sanity.sh
+++ b/tests/sanity/sanity.sh
@@ -1,4 +1,6 @@
-#!/bin/bash -eu
+#!/usr/bin/env bash
+
+set -eu
 
 TOPDIR=$(readlink -f "$(dirname "$0")/../..")
 pushd "${TOPDIR}" >/dev/null || exit 1

--- a/utils/build-collection.sh
+++ b/utils/build-collection.sh
@@ -1,7 +1,9 @@
-#!/bin/bash -eu
+#!/usr/bin/env bash
 #
 # Build Ansible Collection from ansible-freeipa repo
 #
+
+set -eu
 
 prog=$(basename "$0")
 pwd=$(pwd)

--- a/utils/gen_modules_docs.sh
+++ b/utils/gen_modules_docs.sh
@@ -1,4 +1,6 @@
-#!/bin/bash -eu
+#!/usr/bin/env bash
+
+set -eu
 
 for i in roles/ipa*/*/*.py; do
     python utils/gen_module_docs.py "$i"

--- a/utils/lint_check.sh
+++ b/utils/lint_check.sh
@@ -1,4 +1,6 @@
-#!/bin/bash -eu
+#!/usr/bin/env bash
+
+set -eu
 
 INFO="\033[37;1m"
 WARN="\033[33;1m"

--- a/utils/new_module
+++ b/utils/new_module
@@ -1,4 +1,4 @@
-#!/bin/bash -eu
+#!/usr/bin/env bash
 # -*- coding: utf-8 -*-
 
 # Authors:
@@ -20,6 +20,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+set -eu
 
 prog="$(basename "$0")"
 topdir="$(dirname "$0")"

--- a/utils/run-tests.sh
+++ b/utils/run-tests.sh
@@ -1,4 +1,6 @@
-#!/bin/bash -eu
+#!/usr/bin/env bash
+
+set -eu
 
 SCRIPTDIR="$(readlink -f "$(dirname "$0")")"
 TOPDIR="$(readlink -f "${SCRIPTDIR}/..")"
@@ -81,7 +83,7 @@ do
            [ -n "${ANSIBLE_VERSION:-""}" ] && die "Can't use -A with '-a'"
            SKIP_ANSIBLE="YES"
            ;;
-        a) 
+        a)
            [ "${SKIP_ANSIBLE:-"no"}" == "YES" ] && die "Can't use -A with '-a'"
            ANSIBLE_VERSION="${OPTARG}"
            ;;

--- a/utils/setup_test_container.sh
+++ b/utils/setup_test_container.sh
@@ -1,4 +1,6 @@
-#!/bin/bash -eu
+#!/usr/bin/env bash
+
+set -eu
 
 SCRIPTDIR="$(readlink -f "$(dirname "$0")")"
 
@@ -72,7 +74,7 @@ done
 export IPA_HOSTNAME MEMORY IMAGE_TAG scenario
 
 shift $((OPTIND - 1))
-[ $# == 1 ] || die -u "You must provide the name for a single container." 
+[ $# == 1 ] || die -u "You must provide the name for a single container."
 scenario="${1}"
 shift
 


### PR DESCRIPTION
Replace hardcoded "#!/bin/bash" with "#!/usr/bin/env bash" across all shell scripts in infra/, tests/, and utils/ to improve portability on systems where bash is not at /bin/bash (e.g., macOS with Homebrew bash).

## Summary by Sourcery

Enhancements:
- Replace hardcoded /bin/bash shebangs with /usr/bin/env bash in infra, tests, and utils shell scripts to support systems where bash is not installed in /bin.