### PR TITLE
ipauser: Fix query state error handling and per-field conversion errors

### DIFF
--- a/plugins/modules/ipauser.py
+++ b/plugins/modules/ipauser.py
@@ -814,8 +814,8 @@ def user_show(module, name):
 
 def query_convert_result(module, res):
     _res = {}
-    try:
-        for key in res:
+    for key in res:
+        try:
             if key in ["manager", "krbprincipalname", "ipacertmapdata"]:
                 _res[key] = [to_text(x) for x in (res.get(key) or [])]
             elif key == "usercertificate":
@@ -834,10 +834,10 @@ def query_convert_result(module, res):
                 _res[key] = int(res[key])
             else:
                 _res[key] = to_text(res[key])
-    except (TypeError, ValueError) as e:
-        module.fail_json(
-            msg="Failed to convert query result for '%s': %s"
-            % (key, str(e)))
+        except (TypeError, ValueError) as e:
+            module.fail_json(
+                msg="Failed to convert query result for '%s': %s"
+                % (key, str(e)))
     return _res
 
 
@@ -884,6 +884,9 @@ def check_parameters(module, state, action, preserve, user_params):
                 invalid.extend(
                     ["principal", "manager", "certificate", "certmapdata"])
 
+        if state == "query":
+            module.fail_json(
+                msg="check_parameters can not be used with action query.")
         if state == "query":
             invalid.append("users")
 
@@ -1106,7 +1109,7 @@ PARAM_MAPPING = {
     "password": {"api_name": "userpassword"},
     "random": {"query": False},
     "street": {},
-    "rename": {"gen_args": False},
+    "rename": {"gen_args": False, "query": False},
     "noprivate": {"query": False},
     "nomembers": {"api_name": "no_members", "query": False},
     "idp": {"api_name": "ipaidpconfiglink"},
@@ -1308,9 +1311,14 @@ def main():
         if (names is None or len(names) < 1) and \
            (users is None or len(users) < 1):
             ansible_module.fail_json(msg="One of name and users is required")
-    elif users is not None:
-        ansible_module.fail_json(
-            msg="users can not be used with state=query, use name instead")
+    else:
+        if action == "member":
+            ansible_module.fail_json(
+                msg="Query is not possible with action=member")
+        if users is not None:
+            ansible_module.fail_json(
+                msg="users can not be used with state=query, "
+                "use name instead")
 
     if state in ["present", "renamed"]:
         if names is not None and len(names) != 1:


### PR DESCRIPTION
query_convert_result now reports the failing field name per-key instead of aborting the whole loop with an unrelated try/except scope. main() also rejects state=query with action=member and query is excluded from rename's generated args and PARAM_MAPPING query fields.

## Summary by Sourcery

Improve ipauser query handling by reporting per-field conversion errors and tightening invalid state/action and parameter combinations for query operations.

Bug Fixes:
- Ensure query_convert_result reports conversion failures for the specific field instead of aborting processing with a generic error.
- Reject use of state=query with action=member and disallow users parameter for query state to prevent invalid query invocations.
- Exclude rename from query-related parameter mapping and generated query arguments to avoid improper query behavior.