### PR TITLE
Ansible test sanity fixes

### DIFF
--- a/plugins/modules/ipagroup.py
+++ b/plugins/modules/ipagroup.py
@@ -207,6 +207,10 @@ options:
     required: false
     type: list
     elements: str
+    choices: ["ALL", "BASE", "PKEY_ONLY", "dn", "objectclass", "ipauniqueid",
+      "ipantsecurityidentifier", "name", "description", "gid", "user",
+      "group", "service", "externalmember", "idoverrideuser",
+      "membermanager_user", "membermanager_group"]
   action:
     description: Work on group or member level
     type: str

--- a/plugins/modules/ipapasskeyconfig.py
+++ b/plugins/modules/ipapasskeyconfig.py
@@ -41,7 +41,6 @@ options:
     description: Require user verification for passkey authentication
     required: false
     type: bool
-    default: true
     aliases: ["iparequireuserverification"]
 author:
   - Rafael Guterres Jeffman (@rjeffman)

--- a/plugins/modules/ipasudorule.py
+++ b/plugins/modules/ipasudorule.py
@@ -51,8 +51,7 @@ options:
     suboptions:
       name:
         description: The sudorule name
-        type: list
-        elements: str
+        type: str
         required: true
         aliases: ["cn"]
       description:
@@ -462,7 +461,7 @@ def init_ansible_module():
                       required=False),
             sudorules=dict(
                 type="list",
-                defalut=None,
+                default=None,
                 options=dict(
                     # name of the sudorule
                     name=dict(type="str", required=True, aliases=["cn"]),

--- a/plugins/modules/ipasysaccount.py
+++ b/plugins/modules/ipasysaccount.py
@@ -176,7 +176,7 @@ def main():
             description=dict(required=False, type='str', default=None),
             random=dict(required=False, type='bool', default=None),
             privileged=dict(required=False, type='bool', default=None),
-            password=dict(required=False, type='str',
+            password=dict(required=False, type='str', no_log=True,
                           aliases=["userpassword"], default=None),
 
             # mod

--- a/plugins/modules/ipauser.py
+++ b/plugins/modules/ipauser.py
@@ -613,6 +613,20 @@ options:
     required: false
     type: list
     elements: str
+    choices: ["ALL", "BASE", "PKEY_ONLY", "dn", "objectclass", "ipauniqueid",
+      "ipantsecurityidentifier", "name", "first", "last", "fullname",
+      "displayname", "initials", "homedir", "shell", "email",
+      "principalexpiration", "passwordexpiration", "uid", "gid", "city",
+      "userstate", "postalcode", "phone", "mobile", "pager", "fax",
+      "orgunit", "title", "carlicense", "sshpubkey", "userauthtype",
+      "userclass", "radius", "radiususer", "departmentnumber",
+      "employeenumber", "employeetype", "preferredlanguage", "manager",
+      "principal", "certificate", "certmapdata", "gecos", "password",
+      "street", "idp", "idp_user_id", "smb_logon_script", "smb_profile_path",
+      "smb_home_dir", "smb_home_drive", "krblastpwdchange",
+      "krblastadminunlock", "krbextradata", "krbticketflags",
+      "krbloginfailedcount", "krblastsuccessfulauth", "has_password",
+      "has_keytab", "preserved", "memberof_group", "disabled"]
   action:
     description: Work on user or member level
     type: str

--- a/roles/ipaclient/module_utils/ansible_ipa_client.py
+++ b/roles/ipaclient/module_utils/ansible_ipa_client.py
@@ -23,7 +23,9 @@
 
 from __future__ import (absolute_import, division, print_function)
 
+# pylint: disable=invalid-name
 __metaclass__ = type
+# pylint: enable=invalid-name
 
 __all__ = ["gssapi", "version", "ipadiscovery", "api", "errors", "x509",
            "constants", "sysrestore", "certmonger", "certstore",
@@ -49,7 +51,8 @@ __all__ = ["gssapi", "version", "ipadiscovery", "api", "errors", "x509",
            "sssd_enable_ifp", "configure_selinux_for_client",
            "getargspec", "paths", "options",
            "IPA_PYTHON_VERSION", "NUM_VERSION", "certdb", "get_ca_cert",
-           "ipalib", "logger", "ipautil", "installer"]
+           "ipalib", "logger", "ipautil", "installer",
+           "CLIENT_SUPPORTS_NO_DNSSEC_VALIDATION"]
 
 import sys
 
@@ -76,6 +79,7 @@ except ImportError:
         return ArgSpec(args, varargs, varkw, defaults)
 
 
+ANSIBLE_IPA_CLIENT_MODULE_IMPORT_ERROR = None  # pylint: disable=invalid-name
 try:
     from ipapython.version import NUM_VERSION, VERSION
 
@@ -311,13 +315,17 @@ try:
             configure_selinux_for_client = None
 
         try:
+            # pylint: disable=invalid-name
             CLIENT_SUPPORTS_NO_DNSSEC_VALIDATION = False
+            # pylint: enable=invalid-name
             from ipaclient.install.client import ClientInstallInterface
         except ImportError:
             pass
         else:
             if hasattr(ClientInstallInterface, "no_dnssec_validation"):
+                # pylint: disable=invalid-name
                 CLIENT_SUPPORTS_NO_DNSSEC_VALIDATION = True
+                # pylint: enable=invalid-name
 
         logger = logging.getLogger("ipa-client-install")
         root_logger = logger
@@ -327,13 +335,12 @@ try:
         raise RuntimeError("freeipa version '%s' is too old" % VERSION)
 
 except ImportError as _err:
+    # pylint: disable=invalid-name
     ANSIBLE_IPA_CLIENT_MODULE_IMPORT_ERROR = str(_err)
+    # pylint: enable=invalid-name
 
     for attr in __all__:
         setattr(sys.modules[__name__], attr, None)
-
-else:
-    ANSIBLE_IPA_CLIENT_MODULE_IMPORT_ERROR = None
 
 
 def setup_logging():

--- a/roles/ipareplica/library/ipareplica_prepare.py
+++ b/roles/ipareplica/library/ipareplica_prepare.py
@@ -385,7 +385,7 @@ def main():
             dns_over_tls=dict(required=False, type='bool',
                               default=False),
             dns_over_tls_cert=dict(required=False, type='str'),
-            dns_over_tls_key=dict(required=False, type='str'),
+            dns_over_tls_key=dict(required=False, type='str', no_log=True),
             dns_policy=dict(required=False, type='str',
                             choices=['relaxed', 'enforced'],
                             default='relaxed'),

--- a/roles/ipareplica/library/ipareplica_setup_dns.py
+++ b/roles/ipareplica/library/ipareplica_setup_dns.py
@@ -168,7 +168,7 @@ def main():
                                 default=[]),
             dns_over_tls=dict(required=False, type='bool', default=False),
             dns_over_tls_cert=dict(required=False, type='str'),
-            dns_over_tls_key=dict(required=False, type='str'),
+            dns_over_tls_key=dict(required=False, type='str', no_log=True),
             dns_policy=dict(required=False, type='str',
                             choices=['relaxed', 'enforced'],
                             default='relaxed'),

--- a/roles/ipareplica/library/ipareplica_test.py
+++ b/roles/ipareplica/library/ipareplica_test.py
@@ -281,7 +281,7 @@ def main():
                                 default=[]),
             dns_over_tls=dict(required=False, type='bool', default=False),
             dns_over_tls_cert=dict(required=False, type='str'),
-            dns_over_tls_key=dict(required=False, type='str'),
+            dns_over_tls_key=dict(required=False, type='str', no_log=True),
             dns_policy=dict(required=False, type='str',
                             choices=['relaxed', 'enforced'],
                             default='relaxed'),

--- a/roles/ipareplica/module_utils/ansible_ipa_replica.py
+++ b/roles/ipareplica/module_utils/ansible_ipa_replica.py
@@ -23,7 +23,9 @@
 
 from __future__ import (absolute_import, division, print_function)
 
+# pylint: disable=invalid-name
 __metaclass__ = type
+# pylint: enable=invalid-name
 
 __all__ = ["contextlib", "dnsexception", "dnsresolver", "dnsreversename",
            "parse_version", "IPAChangeConf",
@@ -49,7 +51,8 @@ __all__ = ["contextlib", "dnsexception", "dnsresolver", "dnsreversename",
            "dnsname", "kernel_keyring", "krbinstance", "getargspec",
            "adtrustinstance", "paths", "api", "dsinstance", "ipaldap", "Env",
            "ipautil", "installutils", "IPA_PYTHON_VERSION", "NUM_VERSION",
-           "ReplicaConfig", "create_api", "clean_up_hsm_nicknames"]
+           "ReplicaConfig", "create_api", "clean_up_hsm_nicknames",
+           "CLIENT_SUPPORTS_NO_DNSSEC_VALIDATION"]
 
 import sys
 import logging
@@ -77,6 +80,7 @@ except ImportError:
         return ArgSpec(args, varargs, varkw, defaults)
 
 
+ANSIBLE_IPA_REPLICA_MODULE_IMPORT_ERROR = None  # pylint: disable=invalid-name
 try:
     from contextlib import contextmanager as contextlib_contextmanager
     from ipapython.version import NUM_VERSION, VERSION
@@ -188,25 +192,28 @@ try:
             time_service = "ntpd"  # pylint: disable=invalid-name
 
         try:
+            # pylint: disable=invalid-name
             CLIENT_SUPPORTS_NO_DNSSEC_VALIDATION = False
+            # pylint: enable=invalid-name
             from ipaclient.install.client import ClientInstallInterface
         except ImportError:
             pass
         else:
             if hasattr(ClientInstallInterface, "no_dnssec_validation"):
+                # pylint: disable=invalid-name
                 CLIENT_SUPPORTS_NO_DNSSEC_VALIDATION = True
+                # pylint: enable=invalid-name
     else:
         # IPA version < 4.6
         raise RuntimeError("freeipa version '%s' is too old" % VERSION)
 
 except ImportError as _err:
+    # pylint: disable=invalid-name
     ANSIBLE_IPA_REPLICA_MODULE_IMPORT_ERROR = str(_err)
+    # pylint: enable=invalid-name
 
     for attr in __all__:
         setattr(sys.modules[__name__], attr, None)
-
-else:
-    ANSIBLE_IPA_REPLICA_MODULE_IMPORT_ERROR = None
 
 
 logger = logging.getLogger("ipa-server-install")

--- a/roles/ipaserver/library/ipaserver_prepare.py
+++ b/roles/ipaserver/library/ipaserver_prepare.py
@@ -311,7 +311,7 @@ def main():
             dns_over_tls=dict(required=False, type='bool',
                               default=False),
             dns_over_tls_cert=dict(required=False, type='str'),
-            dns_over_tls_key=dict(required=False, type='str'),
+            dns_over_tls_key=dict(required=False, type='str', no_log=True),
             dns_policy=dict(required=False, type='str',
                             choices=['relaxed', 'enforced'],
                             default='relaxed'),

--- a/roles/ipaserver/library/ipaserver_setup_dns.py
+++ b/roles/ipaserver/library/ipaserver_setup_dns.py
@@ -164,7 +164,7 @@ def main():
                                 default=[]),
             dns_over_tls=dict(required=False, type='bool', default=False),
             dns_over_tls_cert=dict(required=False, type='str'),
-            dns_over_tls_key=dict(required=False, type='str'),
+            dns_over_tls_key=dict(required=False, type='str', no_log=True),
             dns_policy=dict(required=False, type='str',
                             choices=['relaxed', 'enforced'],
                             default='relaxed'),

--- a/roles/ipaserver/library/ipaserver_test.py
+++ b/roles/ipaserver/library/ipaserver_test.py
@@ -427,7 +427,7 @@ def main():
                                 default=[]),
             dns_over_tls=dict(required=False, type='bool', default=False),
             dns_over_tls_cert=dict(required=False, type='str'),
-            dns_over_tls_key=dict(required=False, type='str'),
+            dns_over_tls_key=dict(required=False, type='str', no_log=True),
             dns_policy=dict(required=False, type='str',
                             choices=['relaxed', 'enforced'],
                             default='relaxed'),

--- a/roles/ipaserver/module_utils/ansible_ipa_server.py
+++ b/roles/ipaserver/module_utils/ansible_ipa_server.py
@@ -46,7 +46,8 @@ __all__ = ["IPAChangeConf", "certmonger", "sysrestore", "root_logger",
            "check_available_memory", "getargspec", "get_min_idstart",
            "paths", "api", "ipautil", "adtrust_imported", "NUM_VERSION",
            "time_service", "kra_imported", "dsinstance", "IPA_PYTHON_VERSION",
-           "NUM_VERSION", "SerialNumber", "realm_to_ldapi_uri"]
+           "NUM_VERSION", "SerialNumber", "realm_to_ldapi_uri",
+           "CLIENT_SUPPORTS_NO_DNSSEC_VALIDATION"]
 
 import sys
 import logging
@@ -74,6 +75,7 @@ except ImportError:
         return ArgSpec(args, varargs, varkw, defaults)
 
 
+ANSIBLE_IPA_SERVER_MODULE_IMPORT_ERROR = None  # pylint: disable=invalid-name
 try:
     from contextlib import contextmanager as contextlib_contextmanager
     from ansible.module_utils import six
@@ -217,24 +219,28 @@ try:
             SerialNumber = None
 
         try:
+            # pylint: disable=invalid-name
             CLIENT_SUPPORTS_NO_DNSSEC_VALIDATION = False
+            # pylint: enable=invalid-name
             from ipaclient.install.client import ClientInstallInterface
         except ImportError:
             pass
         else:
             if hasattr(ClientInstallInterface, "no_dnssec_validation"):
+                # pylint: disable=invalid-name
                 CLIENT_SUPPORTS_NO_DNSSEC_VALIDATION = True
+                # pylint: enable=invalid-name
     else:
         # IPA version < 4.5
         raise RuntimeError("freeipa version '%s' is too old" % VERSION)
 
 except ImportError as _err:
+    # pylint: disable=invalid-name
     ANSIBLE_IPA_SERVER_MODULE_IMPORT_ERROR = str(_err)
+    # pylint: enable=invalid-name
 
     for attr in __all__:
         setattr(sys.modules[__name__], attr, None)
-else:
-    ANSIBLE_IPA_SERVER_MODULE_IMPORT_ERROR = None
 
 
 logger = logging.getLogger("ipa-server-install")


### PR DESCRIPTION
Some argument_spec and also DOCUMENTATION issues were fixed.

But also some recurring invalid-name findings like for example for the
__metaclass__ line needed to be "fixed".

## Summary by Sourcery

Align FreeIPA Ansible modules and roles with sanity checks by tightening argument specifications, documentation metadata, and linting compliance across IPA client, server, and replica components.

Bug Fixes:
- Expose CLIENT_SUPPORTS_NO_DNSSEC_VALIDATION and import error flags consistently in IPA client, server, and replica module_utils to avoid missing attributes on import failures.
- Correct ipa sudorule module argument_spec for sudorule name to be a required string rather than a list.
- Fix a typo in the ipasudorule module argument definition by using default instead of defalut.
- Mark password and DNS-over-TLS key parameters as no_log in multiple modules to prevent sensitive values from being logged.
- Remove the default value for ipapasskeyconfig requireuserverification to let server-side defaults apply instead of forcing true.

Enhancements:
- Add explicit choices for ipauser and ipagroup attribute selection options to validate input and improve documentation clarity.
- Add CLIENT_SUPPORTS_NO_DNSSEC_VALIDATION to __all__ in IPA module_utils to make capability detection available to consumers.
- Introduce explicit initialization of ANSIBLE_IPA_*_MODULE_IMPORT_ERROR variables to improve error reporting consistency.
- Annotate legacy names such as __metaclass__ and certain constants with pylint invalid-name disables/enables to satisfy linting without changing runtime behavior.

Documentation:
- Enhance DOCUMENTATION blocks for ipauser, ipagroup, and ipasudorule modules by correcting types and adding valid choice lists for options.