### PR TITLE
build-containers.yml: Limit Anisble core version to 2.20

### DIFF
--- a/infra/azure/build-containers.yml
+++ b/infra/azure/build-containers.yml
@@ -23,6 +23,7 @@ stages:
     - template: templates/build_container.yml
       parameters:
         distro: ${{ distro }}
+        ansible_core_version: "<2.21"
 
 # Special case for CentOS 8 Stream
 - stage: CentOS_8_Stream


### PR DESCRIPTION
Ansible core needs to stay at 2.20 for now to be able to build the container for ansible-freeipa testing on Fedora Rawhide.

ansible.legacy.setup is not usable with Ansible core 2.21:

ansible/module_utils/_internal/_patches/__init__.py, line 45,
    in get_current_implementation\nAttributeError: module
    'dataclasses' has no attribute '_is_type'

## Summary by Sourcery

Build:
- Pass an ansible_core_version parameter constrained to '<2.21' into the shared container build template.